### PR TITLE
BlockHeaderStore: return error when chainTip fails

### DIFF
--- a/headerfs/store.go
+++ b/headerfs/store.go
@@ -441,12 +441,12 @@ func (h *BlockHeaderStore) CheckConnectivity() error {
 func (h *BlockHeaderStore) ChainTip() (*wire.BlockHeader, uint32, error) {
 	_, tipHeight, err := h.chainTip()
 	if err != nil {
-		return nil, 0, nil
+		return nil, 0, err
 	}
 
 	latestHeader, err := h.readHeader(int64(tipHeight))
 	if err != nil {
-		return nil, 0, nil
+		return nil, 0, err
 	}
 
 	return latestHeader, tipHeight, nil
@@ -646,12 +646,12 @@ func (f *FilterHeaderStore) WriteHeaders(hdrs ...FilterHeader) error {
 func (f *FilterHeaderStore) ChainTip() (*chainhash.Hash, uint32, error) {
 	_, tipHeight, err := f.chainTip()
 	if err != nil {
-		return nil, 0, nil
+		return nil, 0, err
 	}
 
 	latestHeader, err := f.readHeader(int64(tipHeight))
 	if err != nil {
-		return nil, 0, nil
+		return nil, 0, err
 	}
 
 	return latestHeader, tipHeight, nil


### PR DESCRIPTION
Earlier `nil` was always returned, even on error, which could lead to `nil` pointer dereferencing here: https://github.com/lightninglabs/neutrino/blob/master/blockmanager.go#L293 