### PR TITLE
Reorg and notification fixes

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -54,13 +54,6 @@ type newPeerMsg struct {
 	peer *serverPeer
 }
 
-// blockMsg packages a bitcoin block message and the peer it came from together
-// so the block handler has access to that information.
-type blockMsg struct {
-	block *btcutil.Block
-	peer  *serverPeer
-}
-
 // invMsg packages a bitcoin inv message and the peer it came from together
 // so the block handler has access to that information.
 type invMsg struct {

--- a/blocksubscriptions.go
+++ b/blocksubscriptions.go
@@ -1,0 +1,175 @@
+// NOTE: THIS API IS UNSTABLE AND WILL BE MOVED TO ITS OWN PACKAGE OR REFACTORED
+// OUT.
+
+package neutrino
+
+import "github.com/roasbeef/btcd/wire"
+
+// messageType describes the type of blockMessage.
+type messageType int
+
+const (
+	connectBasic messageType = iota
+	connectExt
+	disconnect
+)
+
+// blockMessage is a notification from the block manager to a block
+// subscription's goroutine to be forwarded on via the appropriate channel.
+type blockMessage struct {
+	header  *wire.BlockHeader
+	msgType messageType
+}
+
+// blockSubscription allows a client to subscribe to and unsubscribe from block
+// connect and disconnect notifications.
+// TODO(aakselrod): Move this to its own package so that the subscriber can't
+// access internals, in particular the notifyBlock and intQuit members.
+type blockSubscription struct {
+	onConnectBasic chan<- wire.BlockHeader
+	onConnectExt   chan<- wire.BlockHeader
+	onDisconnect   chan<- wire.BlockHeader
+	quit           <-chan struct{}
+
+	notifyBlock chan *blockMessage
+	intQuit     chan struct{}
+}
+
+// sendSubscribedMsg sends all block subscribers a message if they request this
+// type.
+// TODO(aakselrod): Refactor so we're able to handle more message types in new
+// package.
+func (s *ChainService) sendSubscribedMsg(bm *blockMessage) {
+	var subChan chan<- wire.BlockHeader
+	s.mtxSubscribers.RLock()
+	for sub := range s.blockSubscribers {
+		switch bm.msgType {
+		case connectBasic:
+			subChan = sub.onConnectBasic
+		case connectExt:
+			subChan = sub.onConnectExt
+		case disconnect:
+			subChan = sub.onDisconnect
+		default:
+			// TODO: Return a useful error when factored out into
+			// its own package.
+			panic("invalid message type")
+		}
+		if subChan != nil {
+			select {
+			case sub.notifyBlock <- bm:
+			case <-sub.quit:
+			case <-sub.intQuit:
+			}
+		}
+	}
+	s.mtxSubscribers.RUnlock()
+}
+
+// subscribeBlockMsg handles adding block subscriptions to the ChainService.
+// TODO(aakselrod): move this to its own package and refactor so that we're
+// not modifying an object held by the caller.
+func (s *ChainService) subscribeBlockMsg(subscription *blockSubscription) {
+	subscription.notifyBlock = make(chan *blockMessage)
+	subscription.intQuit = make(chan struct{})
+	s.mtxSubscribers.Lock()
+	defer s.mtxSubscribers.Unlock()
+	s.blockSubscribers[subscription] = struct{}{}
+	go subscription.subscriptionHandler()
+}
+
+// unsubscribeBlockMsgs handles removing block subscriptions from the
+// ChainService.
+// TODO(aakselrod): move this to its own package and refactor so that we're
+// not depending on the caller to not modify the argument between subscribe and
+// unsubscribe.
+func (s *ChainService) unsubscribeBlockMsgs(subscription *blockSubscription) {
+	s.mtxSubscribers.Lock()
+	delete(s.blockSubscribers, subscription)
+	s.mtxSubscribers.Unlock()
+	close(subscription.intQuit)
+
+	// Drain the inbound notification channel
+cleanup:
+	for {
+		select {
+		case <-subscription.notifyBlock:
+		default:
+			break cleanup
+		}
+	}
+}
+
+// subscriptionHandler must be run as a goroutine and queues notification
+// messages from the chain service to the subscriber.
+func (s *blockSubscription) subscriptionHandler() {
+	// Start with a small queue; it will grow if needed.
+	ntfns := make([]*blockMessage, 0, 5)
+	var next *blockMessage
+
+	// Try to send on the specified channel. If a new message arrives while
+	// we try to send, queue it and continue with the loop. If a quit signal
+	// is sent, let the loop know.
+	selectChan := func(notify chan<- wire.BlockHeader) bool {
+		if notify == nil {
+			select {
+			case <-s.quit:
+				return false
+			case <-s.intQuit:
+				return false
+			default:
+				return true
+			}
+		}
+		select {
+		case notify <- *next.header:
+			next = nil
+			return true
+		case queueMsg := <-s.notifyBlock:
+			ntfns = append(ntfns, queueMsg)
+			return true
+		case <-s.quit:
+			return false
+		case <-s.intQuit:
+			return false
+		}
+	}
+
+	// Loop until we get a signal on s.quit or s.intQuit.
+	for {
+		if next != nil {
+			// If selectChan returns false, we were signalled on
+			// s.quit or s.intQuit.
+			switch next.msgType {
+			case connectBasic:
+				if !selectChan(s.onConnectBasic) {
+					return
+				}
+			case connectExt:
+				if !selectChan(s.onConnectExt) {
+					return
+				}
+			case disconnect:
+				if !selectChan(s.onDisconnect) {
+					return
+				}
+			}
+		} else {
+			// Next notification is nil, so see if we can get a
+			// notification from the queue. If not, we wait for a
+			// notification on s.notifyBlock or quit if signalled.
+			if len(ntfns) > 0 {
+				next = ntfns[0]
+				ntfns = ntfns[1:]
+			} else {
+				select {
+				case next = <-s.notifyBlock:
+				case <-s.quit:
+					return
+				case <-s.intQuit:
+					return
+				}
+			}
+		}
+	}
+}

--- a/neutrino.go
+++ b/neutrino.go
@@ -132,7 +132,6 @@ type serverPeer struct {
 	server         *ChainService
 	persistent     bool
 	continueHash   *chainhash.Hash
-	relayMtx       sync.Mutex
 	requestQueue   []*wire.InvVect
 	knownAddresses map[string]struct{}
 	banScore       connmgr.DynamicBanScore

--- a/rescan.go
+++ b/rescan.go
@@ -301,11 +301,13 @@ rescanLoop:
 				// Only deal with the next block from what we
 				// know about. Otherwise, it's in the future.
 				if header.PrevBlock != curStamp.Hash {
+					log.Debugf("Rescan got out of order block %s with prevblock %s", header.BlockHash(), header.PrevBlock)
 					continue rescanLoop
 				}
 				curHeader = header
 				curStamp.Hash = header.BlockHash()
 				curStamp.Height++
+				log.Tracef("Rescan got block %d (%s)", curStamp.Height, curStamp.Hash)
 
 			case header := <-blockDisconnected:
 				// Only deal with it if it's the current block

--- a/rescan.go
+++ b/rescan.go
@@ -274,7 +274,7 @@ rescanLoop:
 			select {
 
 			case <-ro.quit:
-				s.unsubscribeBlockMsgs(subscription)
+				s.unsubscribeBlockMsgs(&subscription)
 				return nil
 
 			// An update mesage has just come across, if it points
@@ -351,7 +351,7 @@ rescanLoop:
 					curStamp.Height, curStamp.Hash)
 				current = true
 				// Subscribe to block notifications.
-				s.subscribeBlockMsg(subscription)
+				s.subscribeBlockMsg(&subscription)
 				continue rescanLoop
 			}
 			curHeader = *header

--- a/rescan.go
+++ b/rescan.go
@@ -329,11 +329,8 @@ rescanLoop:
 							curStamp.Height,
 							curHeader.Timestamp)
 					}
-					header, _, err := s.BlockHeaders.FetchHeader(
-						&header.PrevBlock)
-					if err != nil {
-						return err
-					}
+					header := s.getReorgTip(
+						header.PrevBlock)
 					curHeader = *header
 					curStamp.Hash = header.BlockHash()
 					curStamp.Height--
@@ -971,4 +968,15 @@ func (s *ChainService) GetUtxo(options ...RescanOption) (*SpendReport, error) {
 		}
 		curStamp.Hash = header.BlockHash()
 	}
+}
+
+// getReorgTip gets a block header from the chain service's cache. This is only
+// required until the block subscription API is factored out into its own
+// package.
+//
+// TODO(aakselrod): Get rid of this as described above.
+func (s *ChainService) getReorgTip(hash chainhash.Hash) *wire.BlockHeader {
+	s.mtxReorgHeader.RLock()
+	defer s.mtxReorgHeader.RUnlock()
+	return s.reorgedBlockHeaders[hash]
 }

--- a/sync_test.go
+++ b/sync_test.go
@@ -523,6 +523,11 @@ func TestSetup(t *testing.T) {
 	// it with a quit channel at the end and make sure we got the expected
 	// results.
 	quitRescan := make(chan struct{})
+	defer func() {
+		if quitRescan != nil {
+			close(quitRescan)
+		}
+	}()
 	startBlock = waddrmgr.BlockStamp{Height: 795}
 	rescan, errChan := startRescan(t, svc, addr1, &startBlock, quitRescan)
 	if err != nil {
@@ -774,6 +779,7 @@ func TestSetup(t *testing.T) {
 
 	close(quitRescan)
 	err = <-errChan
+	quitRescan = nil
 	if err != nil {
 		t.Fatalf("Rescan ended with error: %s", err)
 	}


### PR DESCRIPTION
This pull request makes `go test -v .` work in the presence of updated `btcd` and reduces flake incidence in `lnd`'s `chainntfns` interface tests for `neutrino`. It does so via the following:

* Makes block notifications fully asynchronous
* Compensates for instances caused by the above where a rescan tries to read a block header after it's been reorganized out (improved handling of this will be added when the block subscription mechanism is factored out into its own package and message types abstracted out so they can be used in a single notification channel)
* Improves test robustness and error reporting
* Ensures `inv` messages are sent on connect if a peer reports that it has a longer chain than the chain service knows about