### PR TITLE
Add support for rescan start time

### DIFF
--- a/rescan.go
+++ b/rescan.go
@@ -714,7 +714,7 @@ func (r *Rescan) WaitForShutdown() {
 // Start kicks off the rescan goroutine, which will begin to scan the chain
 // according to the specified rescan options.
 func (r *Rescan) Start() <-chan error {
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 
 	r.wg.Add(1)
 	go func() {


### PR DESCRIPTION
In order to support key birthdays, rescans will now support a start time. If the start block is earlier than the start time, filters will not be downloaded and checked before the start time. `OnBlockConnected` and empty `OnFilteredBlockConnected` notifications are still sent prior to the start time, as are the block disconnected notifications.

In addition, the rescan's error channel is now buffered to prevent the rescan goroutine from being unable to exit, previously caused by the error channel not being read.