### PR TITLE
Fix panic caused by rapid small reorgs

### DIFF
--- a/headerfs/store.go
+++ b/headerfs/store.go
@@ -439,6 +439,15 @@ func (h *BlockHeaderStore) CheckConnectivity() error {
 // ChainTip returns the best known block header and height for the
 // BlockHeaderStore.
 func (h *BlockHeaderStore) ChainTip() (*wire.BlockHeader, uint32, error) {
+	// Ensure index and flat file read are part of same tx.
+	tx, err := h.db.BeginReadTx()
+	if err != nil {
+		return nil, 0, err
+	}
+	defer tx.Rollback()
+	h.RLock()
+	defer h.RUnlock()
+
 	_, tipHeight, err := h.chainTip()
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
This PR adds a test that triggers rapid, small reorgs which cause a panic in `neutrino` and sometimes also in `rpctest`.

The PR then adds a commit which ensures cfheaders are only rolled back if they're caught up to the height of the block being rolled back. This fixes a race condition which happens when a `headers` message with a reorg is processed before all of the `cfheaders` messages for currently-known blocks, triggering a panic on EOF from one of the filter header stores.

The PR also adds a commit which ensures that the block header store's `ChainTip` method is atomic, which prevents a race condition causing a panic on EOF from the block header store which is triggered when the database block index is written but the header file is not.

The `rpctest` issue will be resolved in a separate PR to `btcd`.