### PR TITLE
query: race condition and performance fixes

### DIFF
--- a/query.go
+++ b/query.go
@@ -437,8 +437,8 @@ func (s *ChainService) GetCFilter(blockHash chainhash.Hash, extended bool,
 				// know about it and we declare it sane. We can
 				// kill the query and pass the response back to
 				// the caller.
-				close(quit)
 				filter = gotFilter
+				close(quit)
 			default:
 			}
 		},
@@ -543,8 +543,8 @@ func (s *ChainService) GetBlockFromNetwork(blockHash chainhash.Hash,
 				// know about it and we declare it sane. We can
 				// kill the query and pass the response back to
 				// the caller.
-				close(quit)
 				foundBlock = block
+				close(quit)
 			default:
 			}
 		},

--- a/query.go
+++ b/query.go
@@ -410,7 +410,8 @@ func (s *ChainService) GetCFilter(blockHash chainhash.Hash, extended bool,
 
 				// If the response doesn't match our request.
 				// Ignore this message.
-				if blockHash != response.BlockHash {
+				if blockHash != response.BlockHash ||
+					extended != response.Extended {
 					return
 				}
 


### PR DESCRIPTION
This PR prevents further processing in the CFilter callback when the `extended` flag doesn't match between the `getcfilter` command and the `cfilter` response, possibly due to another process requesting a cfilter of a different type for the same block.

In addition, the PR ensures that a valid filter or block received in a message notification callback is assigned to the original caller's result variable before the quit channel is closed. This should prevent `queryPeers()` from exiting before the variable is assigned and erroneously returning/trying to write a nil filter or block that actually matched.