### PR TITLE
Windows rollback fix

### DIFF
--- a/headerfs/file.go
+++ b/headerfs/file.go
@@ -46,39 +46,6 @@ func (h *headerStore) readRaw(seekDist int64) ([]byte, error) {
 	return rawHeader, nil
 }
 
-// singleTruncate truncates a single header from the end of the header file.
-// This can be used in the case of a re-org to remove the last header from the
-// end of the main chain.
-//
-// TODO(roasbeef): define this and the two methods above on a headerFile
-// struct?
-func (h *headerStore) singleTruncate() error {
-	// In order to truncate the file, we'll need to grab the absolute size
-	// of the file as it stands currently.
-	fileInfo, err := h.file.Stat()
-	if err != nil {
-		return err
-	}
-	fileSize := fileInfo.Size()
-
-	// Next, we'll determine the number of bytes we need to truncate from
-	// the end of the file.
-	var truncateLength int64
-	switch h.indexType {
-	case Block:
-		truncateLength = 80
-	case RegularFilter:
-		fallthrough
-	case ExtendedFilter:
-		truncateLength = 32
-	}
-
-	// Finally, we'll use both of these values to calculate the new size of
-	// the file and truncate it accordingly.
-	newSize := fileSize - truncateLength
-	return h.file.Truncate(newSize)
-}
-
 // readHeader reads a full block header from the flat-file. The header read is
 // determined by the hight value.
 func (h *BlockHeaderStore) readHeader(height int64) (*wire.BlockHeader, error) {

--- a/headerfs/store.go
+++ b/headerfs/store.go
@@ -92,11 +92,11 @@ type BlockHeaderStore struct {
 	*headerStore
 }
 
-// New creates a new instance of the BlockHeaderStore based on a target file
-// path, an open database instance, and finally a set of parameters for the
-// target chain. These parameters are required as if this is the initial start
-// up of the BlockHeaderStore, then the initial genesis header will need to be
-// inserted.
+// NewBlockHeaderStore creates a new instance of the BlockHeaderStore based on
+// a target file path, an open database instance, and finally a set of
+// parameters for the target chain. These parameters are required as if this is
+// the initial start up of the BlockHeaderStore, then the initial genesis
+// header will need to be inserted.
 func NewBlockHeaderStore(filePath string, db walletdb.DB,
 	netParams *chaincfg.Params) (*BlockHeaderStore, error) {
 
@@ -388,7 +388,7 @@ func (h *BlockHeaderStore) CheckConnectivity() error {
 		// index entries are also accurate. To do this, we start from a
 		// height of one before our current tip.
 		var newHeader *wire.BlockHeader
-		for height := int64(tipHeight) - 1; height > 0; height-- {
+		for height := tipHeight - 1; height > 0; height-- {
 			// First, read the block header for this block height,
 			// and also compute the block hash for it.
 			newHeader, err = h.readHeader(height)
@@ -411,7 +411,7 @@ func (h *BlockHeaderStore) CheckConnectivity() error {
 			// With the index entry retrieved, we'll now assert
 			// that the height matches up with our current height
 			// in this backwards walk.
-			if int64(indexHeight) != height {
+			if indexHeight != height {
 				return fmt.Errorf("index height isn't monotonically " +
 					"increasing")
 			}

--- a/headerfs/store.go
+++ b/headerfs/store.go
@@ -65,7 +65,7 @@ func newHeaderStore(db walletdb.DB, filePath string,
 	// We'll open the file, creating it if necessary and ensuring that all
 	// writes are actually appends to the end of the file.
 	fileFlags := os.O_RDWR | os.O_APPEND | os.O_CREATE
-	headerFile, err := os.OpenFile(flatFileName, fileFlags, 0755)
+	headerFile, err := os.OpenFile(flatFileName, fileFlags, 0644)
 	if err != nil {
 		return nil, err
 	}

--- a/headerfs/truncate.go
+++ b/headerfs/truncate.go
@@ -1,0 +1,36 @@
+// +build !windows
+
+package headerfs
+
+// singleTruncate truncates a single header from the end of the header file.
+// This can be used in the case of a re-org to remove the last header from the
+// end of the main chain.
+//
+// TODO(roasbeef): define this and the two methods above on a headerFile
+// struct?
+func (h *headerStore) singleTruncate() error {
+	// In order to truncate the file, we'll need to grab the absolute size
+	// of the file as it stands currently.
+	fileInfo, err := h.file.Stat()
+	if err != nil {
+		return err
+	}
+	fileSize := fileInfo.Size()
+
+	// Next, we'll determine the number of bytes we need to truncate from
+	// the end of the file.
+	var truncateLength int64
+	switch h.indexType {
+	case Block:
+		truncateLength = 80
+	case RegularFilter:
+		fallthrough
+	case ExtendedFilter:
+		truncateLength = 32
+	}
+
+	// Finally, we'll use both of these values to calculate the new size of
+	// the file and truncate it accordingly.
+	newSize := fileSize - truncateLength
+	return h.file.Truncate(newSize)
+}

--- a/headerfs/truncate_windows.go
+++ b/headerfs/truncate_windows.go
@@ -1,0 +1,53 @@
+// +build windows
+
+package headerfs
+
+import "os"
+
+// singleTruncate truncates a single header from the end of the header file.
+// This can be used in the case of a re-org to remove the last header from the
+// end of the main chain.
+//
+// TODO(roasbeef): define this and the two methods above on a headerFile
+// struct?
+func (h *headerStore) singleTruncate() error {
+	// In order to truncate the file, we'll need to grab the absolute size
+	// of the file as it stands currently.
+	fileInfo, err := h.file.Stat()
+	if err != nil {
+		return err
+	}
+	fileSize := fileInfo.Size()
+
+	// Next, we'll determine the number of bytes we need to truncate from
+	// the end of the file.
+	var truncateLength int64
+	switch h.indexType {
+	case Block:
+		truncateLength = 80
+	case RegularFilter:
+		fallthrough
+	case ExtendedFilter:
+		truncateLength = 32
+	}
+
+	// Finally, we'll use both of these values to calculate the new size of
+	// the file.
+	newSize := fileSize - truncateLength
+
+	// On Windows, a file can't be truncated while open, even if using a
+	// file handle to truncate it. This means we have to close, truncate,
+	// and reopen it.
+	fileName := h.file.Name()
+	if err = h.file.Close(); err != nil {
+		return err
+	}
+
+	if err = os.Truncate(fileName, newSize); err != nil {
+		return err
+	}
+
+	fileFlags := os.O_RDWR | os.O_APPEND | os.O_CREATE
+	h.file, err = os.OpenFile(fileName, fileFlags, 0644)
+	return err
+}


### PR DESCRIPTION
This PR fixes #21 on Windows. In addition, it fixes some linter errors in `store.go` and ensures that the header store flat files are created/opened without execute permissions.