### PR TITLE
Refactor locking in `headerfs`, fix rescan race condition during reorg

### DIFF
--- a/headerfs/index.go
+++ b/headerfs/index.go
@@ -53,7 +53,7 @@ const (
 	// headers.
 	Block HeaderType = iota
 
-	// RegularFiler is a header type that represents the basic filter
+	// RegularFilter is a header type that represents the basic filter
 	// header type for the filter header chain.
 	RegularFilter
 
@@ -80,11 +80,9 @@ func newHeaderIndex(db walletdb.DB, indexType HeaderType) (*headerIndex, error) 
 	// necessary for functioning of the index. If these buckets has already
 	// been created, then we can exit early.
 	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
-		if _, err := tx.CreateTopLevelBucket(indexBucket); err != nil {
-			return err
-		}
+		_, err := tx.CreateTopLevelBucket(indexBucket)
+		return err
 
-		return nil
 	})
 	if err != nil && err != walletdb.ErrBucketExists {
 		return nil, err


### PR DESCRIPTION
This PR refactors locking in `headerfs` by making the `RWMutex` private and using it in all access methods to prevent certain race conditions and deadlocks. It also fixes a couple of small linter complaints in `headerfs/index.go`.

The PR also fixes a rescan race condition that happens when a rescan is notified of a new block but that block is reorged out while the rescan is attempting to fetch the filters for the block in order to match it.

This PR should address #25 and #26, as well as additional test failures/flakes.