### PR TITLE
rescan: return error when `GetUTXO` outpoint not created since start block

### DIFF
--- a/rescan.go
+++ b/rescan.go
@@ -993,7 +993,10 @@ func (s *ChainService) GetUtxo(options ...RescanOption) (*SpendReport, error) {
 		// Otherwise, iterate backwards until we've gone too far.
 		curStamp.Height--
 		if curStamp.Height < ro.startBlock.Height {
-			return nil, nil
+			return nil, fmt.Errorf("Transaction %s not found "+
+				"since start block %d (%s)",
+				ro.watchOutPoints[0].Hash, curStamp.Height+1,
+				curStamp.Hash)
 		}
 
 		// Fetch the previous header so we can continue our walk


### PR DESCRIPTION
This PR should fix the panic seen in https://github.com/lightninglabs/lightning-app/issues/87 by returning an error when a transaction which creates the requested output isn't created since the `StartBlock` argument to `GetUTXO`.