### PR TITLE
Correct types for headerfs

### DIFF
--- a/headerfs/file.go
+++ b/headerfs/file.go
@@ -19,7 +19,7 @@ func (h *headerStore) appendRaw(header []byte) error {
 // readRaw reads a raw header from disk from a particular seek distance. The
 // amount of bytes read past the seek distance is determined by the specified
 // header type.
-func (h *headerStore) readRaw(seekDist int64) ([]byte, error) {
+func (h *headerStore) readRaw(seekDist uint64) ([]byte, error) {
 	var headerSize uint32
 
 	// Based on the defined header type, we'll determine the number of
@@ -39,7 +39,7 @@ func (h *headerStore) readRaw(seekDist int64) ([]byte, error) {
 	// for that number of bytes, and read directly from the file into the
 	// buffer.
 	rawHeader := make([]byte, headerSize)
-	if _, err := h.file.ReadAt(rawHeader, seekDist); err != nil {
+	if _, err := h.file.ReadAt(rawHeader, int64(seekDist)); err != nil {
 		return nil, err
 	}
 
@@ -48,10 +48,10 @@ func (h *headerStore) readRaw(seekDist int64) ([]byte, error) {
 
 // readHeader reads a full block header from the flat-file. The header read is
 // determined by the hight value.
-func (h *BlockHeaderStore) readHeader(height int64) (*wire.BlockHeader, error) {
+func (h *BlockHeaderStore) readHeader(height uint32) (*wire.BlockHeader, error) {
 	// Each header is 80 bytes, so using this information, we'll seek a
 	// distance to cover that height based on the size of block headers.
-	seekDistance := height * 80
+	seekDistance := uint64(height) * 80
 
 	// With the distance calculated, we'll raw a raw header start from that
 	// offset.
@@ -72,8 +72,8 @@ func (h *BlockHeaderStore) readHeader(height int64) (*wire.BlockHeader, error) {
 
 // readHeader reads a single filter header at the specified height from the
 // flat files on disk.
-func (f *FilterHeaderStore) readHeader(height int64) (*chainhash.Hash, error) {
-	seekDistance := height * 32
+func (f *FilterHeaderStore) readHeader(height uint32) (*chainhash.Hash, error) {
+	seekDistance := uint64(height) * 32
 
 	rawHeader, err := f.readRaw(seekDistance)
 	if err != nil {

--- a/headerfs/store.go
+++ b/headerfs/store.go
@@ -141,7 +141,7 @@ func NewBlockHeaderStore(filePath string, db walletdb.DB,
 
 	// First, we'll compute the size of the current file so we can
 	// calculate the latest header written to disk.
-	fileHeight := uint32(fileInfo.Size() / 80) - 1
+	fileHeight := uint32(fileInfo.Size()/80) - 1
 
 	// Using the file's current height, fetch the latest on-disk header.
 	latestFileHeader, err := bhs.readHeader(fileHeight)
@@ -574,7 +574,7 @@ func NewFilterHeaderStore(filePath string, db walletdb.DB,
 
 	// First, we'll compute the size of the current file so we can
 	// calculate the latest header written to disk.
-	fileHeight := uint32(fileInfo.Size() / 32) - 1
+	fileHeight := uint32(fileInfo.Size()/32) - 1
 
 	// Using the file's current height, fetch the latest on-disk header.
 	latestFileHeader, err := fhs.readHeader(fileHeight)

--- a/sync_test.go
+++ b/sync_test.go
@@ -1140,10 +1140,10 @@ func testRandomBlocks(t *testing.T, svc *neutrino.ChainService,
 				return
 			}
 			// Check that block height matches what we have.
-			if int32(height) != haveBlock.Height() {
+			if height != uint32(haveBlock.Height()) {
 				errChan <- fmt.Errorf("Block height from "+
 					"network doesn't match expected "+
-					"height. Want: %s, network: %s",
+					"height. Want: %v, network: %v",
 					height, haveBlock.Height())
 				return
 			}


### PR DESCRIPTION
Correct types for headerfs:
seek distances should be unsigned integer 64
heights (header or filter) should be unsigned integer 32

The changes eliminate conversions.