### PR TITLE
Resolved: TODO(roasbeef): similar interface for headerfs?

### DIFF
--- a/filterdb/db.go
+++ b/filterdb/db.go
@@ -48,7 +48,6 @@ var (
 // storing and retiring filters according to their corresponding block hash and
 // also their filter type.
 //
-// TODO(roasbeef): similar interface for headerfs?
 type FilterDatabase interface {
 	// PutFilter stores a filter with the given hash and type to persistent
 	// storage.

--- a/headerfs/blockheaderdb.go
+++ b/headerfs/blockheaderdb.go
@@ -7,6 +7,8 @@ import (
 	"github.com/roasbeef/btcwallet/waddrmgr"
 )
 
+// Interface to persistent block header store
+// An implementation of BlockHeaderDB is a fully fledged database for Bitcoin block headers.
 type BlockHeaderDB interface {
 	// WriteHeaders writes a set of headers to disk and updates the index in a
 	// single atomic transaction.
@@ -49,13 +51,14 @@ type BlockHeaderDB interface {
 	RollbackLastBlock() (*waddrmgr.BlockStamp, error)
 }
 
-// BlockHeaderStore is an implementation of a fully fledged database for
-// Bitcoin block headers. The BlockHeaderStore combines a flat file to store
+
+// BlockHeaderStore implements the BlockHeaderDB interface
+// Create an instance with: NewBlockHeaderStore
+//
+// The BlockHeaderStore combines a flat file to store
 // the block headers with a database instance for managing the index into the
 // set of flat files.
 //
-// BlockHeaderStore implements the BlockHeaderDB interface
-// Create an instance with: NewBlockHeaderStore
 type BlockHeaderStore struct {
 	*headerStore
 }

--- a/headerfs/blockheaderdb.go
+++ b/headerfs/blockheaderdb.go
@@ -7,7 +7,7 @@ import (
 	"github.com/roasbeef/btcwallet/waddrmgr"
 )
 
-// Interface to persistent block header store
+// BlockHeaderDB is the interface to the persistent block header store
 // An implementation of BlockHeaderDB is a fully fledged database for Bitcoin block headers.
 type BlockHeaderDB interface {
 	// WriteHeaders writes a set of headers to disk and updates the index in a
@@ -50,7 +50,6 @@ type BlockHeaderDB interface {
 	// information about the new header tip after truncation is returned.
 	RollbackLastBlock() (*waddrmgr.BlockStamp, error)
 }
-
 
 // BlockHeaderStore implements the BlockHeaderDB interface
 // Create an instance with: NewBlockHeaderStore

--- a/headerfs/blockheaderdb.go
+++ b/headerfs/blockheaderdb.go
@@ -1,0 +1,70 @@
+package headerfs
+
+import (
+	"github.com/roasbeef/btcd/blockchain"
+	"github.com/roasbeef/btcd/chaincfg/chainhash"
+	"github.com/roasbeef/btcd/wire"
+	"github.com/roasbeef/btcwallet/waddrmgr"
+)
+
+type BlockHeaderDB interface {
+	// WriteHeaders writes a set of headers to disk and updates the index in a
+	// single atomic transaction.
+	WriteHeaders(hdrs ...BlockHeader) error
+
+	// LatestBlockLocator returns the latest block locator object based on the tip
+	// of the current main chain from the PoV of the database and flat files.
+	LatestBlockLocator() (blockchain.BlockLocator, error)
+
+	// BlockLocatorFromHash computes a block locator given a particular hash. The
+	// standard Bitcoin algorithm to compute block locators are employed.
+	BlockLocatorFromHash(hash *chainhash.Hash) (blockchain.BlockLocator, error)
+
+	// CheckConnectivity cycles through all of the block headers on disk, from last
+	// to first, and makes sure they all connect to each other. Additionally, at
+	// each block header, we also ensure that the index entry for that height and
+	// hash also match up properly.
+	CheckConnectivity() error
+
+	// ChainTip returns the best known block header and height for the
+	// BlockHeaderStore.
+	ChainTip() (*wire.BlockHeader, uint32, error)
+
+	// FetchHeader attempts to retrieve a block header determined by the passed
+	// block height.
+	FetchHeader(hash *chainhash.Hash) (*wire.BlockHeader, uint32, error)
+
+	// FetchHeaderByHeight attempts to retrieve a target block header based on a
+	// block height.
+	FetchHeaderByHeight(height uint32) (*wire.BlockHeader, error)
+
+	// HeightFromHash returns the height of a particualr block header given its
+	// hash.
+	HeightFromHash(hash *chainhash.Hash) (uint32, error)
+
+	// RollbackLastBlock rollsback both the index, and on-disk header file by a
+	// _single_ header. This method is meant to be used in the case of re-org which
+	// disconnects the latest block header from the end of the main chain. The
+	// information about the new header tip after truncation is returned.
+	RollbackLastBlock() (*waddrmgr.BlockStamp, error)
+}
+
+// BlockHeaderStore is an implementation of a fully fledged database for
+// Bitcoin block headers. The BlockHeaderStore combines a flat file to store
+// the block headers with a database instance for managing the index into the
+// set of flat files.
+//
+// BlockHeaderStore implements the BlockHeaderDB interface
+// Create an instance with: NewBlockHeaderStore
+type BlockHeaderStore struct {
+	*headerStore
+}
+
+// BlockHeader is a Bitcoin block header that also has its height included.
+type BlockHeader struct {
+	*wire.BlockHeader
+
+	// Height is the height of this block header within the current main
+	// chain.
+	Height uint32
+}

--- a/headerfs/filterheaderdb.go
+++ b/headerfs/filterheaderdb.go
@@ -1,0 +1,57 @@
+package headerfs
+
+import (
+	"github.com/roasbeef/btcd/chaincfg/chainhash"
+	"github.com/roasbeef/btcwallet/waddrmgr"
+)
+
+type FilterHeaderDB interface {
+	// FetchHeader returns the filter header that corresponds to the passed block
+	// height.
+	FetchHeader(hash *chainhash.Hash) (*chainhash.Hash, error)
+
+	// FetchHeaderByHeight returns the filter header for a particular block height.
+	FetchHeaderByHeight(height uint32) (*chainhash.Hash, error)
+
+	// WriteHeaders writes a batch of filter headers to persistent storage. The
+	// headers themselves are appended to the flat file, and then the index updated
+	// to reflect the new entires.
+	WriteHeaders(hdrs ...FilterHeader) error
+
+	// ChainTip returns the latest filter header and height known to the
+	// FilterHeaderStore.
+	ChainTip() (*chainhash.Hash, uint32, error)
+
+	// RollbackLastBlock rollsback both the index, and on-disk header file by a
+	// _single_ filter header. This method is meant to be used in the case of
+	// re-org which disconnects the latest filter header from the end of the main
+	// chain. The information about the latest header tip after truncation is
+	// returnd.
+	RollbackLastBlock(newTip *chainhash.Hash) (*waddrmgr.BlockStamp, error)
+}
+
+// FilterHeaderStore is an implementation of a fully fledged database for any
+// variant of filter headers.  The FilterHeaderStore combines a flat file to
+// store the block headers with a database instance for managing the index into
+// the set of flat files.
+//
+// FilterHeaderStore implements the FilterHeaderDB interface
+// Create an instance with: NewFilterHeaderStore
+type FilterHeaderStore struct {
+	*headerStore
+}
+
+// FilterHeader represents a filter header (basic or extended). The filter
+// header itself is coupled with the block height and hash of the filter's
+// block.
+type FilterHeader struct {
+	// HeaderHash is the hash of the block header that this filter header
+	// corresponds to.
+	HeaderHash chainhash.Hash
+
+	// FilterHash is the filter header itself.
+	FilterHash chainhash.Hash
+
+	// Height is the block height of the filter header in the main chain.
+	Height uint32
+}

--- a/headerfs/filterheaderdb.go
+++ b/headerfs/filterheaderdb.go
@@ -5,6 +5,8 @@ import (
 	"github.com/roasbeef/btcwallet/waddrmgr"
 )
 
+// interface to persistent filter header store
+// An implementation of FilterHeaderDB is a fully fledged database for any variant of filter headers.
 type FilterHeaderDB interface {
 	// FetchHeader returns the filter header that corresponds to the passed block
 	// height.
@@ -30,13 +32,11 @@ type FilterHeaderDB interface {
 	RollbackLastBlock(newTip *chainhash.Hash) (*waddrmgr.BlockStamp, error)
 }
 
-// FilterHeaderStore is an implementation of a fully fledged database for any
-// variant of filter headers.  The FilterHeaderStore combines a flat file to
-// store the block headers with a database instance for managing the index into
-// the set of flat files.
-//
 // FilterHeaderStore implements the FilterHeaderDB interface
 // Create an instance with: NewFilterHeaderStore
+//
+// The FilterHeaderStore combines a flat file to store the block headers with a
+// database instance for managing the index into the set of flat files.
 type FilterHeaderStore struct {
 	*headerStore
 }

--- a/headerfs/filterheaderdb.go
+++ b/headerfs/filterheaderdb.go
@@ -5,7 +5,7 @@ import (
 	"github.com/roasbeef/btcwallet/waddrmgr"
 )
 
-// interface to persistent filter header store
+// FilterHeaderDB is the interface to the persistent filter header store
 // An implementation of FilterHeaderDB is a fully fledged database for any variant of filter headers.
 type FilterHeaderDB interface {
 	// FetchHeader returns the filter header that corresponds to the passed block

--- a/headerfs/index.go
+++ b/headerfs/index.go
@@ -258,7 +258,7 @@ func (h *headerIndex) chainTip() (*chainhash.Hash, uint32, error) {
 	return tipHash, tipHeight, nil
 }
 
-// truncateIndex truncates the index for a particluar header type by a single
+// truncateIndex truncates the index for a particular header type by a single
 // header entry. The passed newTip pointer should point to the hash of the new
 // chain tip. Optionally, if the entry is to be deleted as well, then the
 // delete flag should be set to true.

--- a/headerfs/store.go
+++ b/headerfs/store.go
@@ -85,14 +85,6 @@ func newHeaderStore(db walletdb.DB, filePath string,
 	}, nil
 }
 
-// BlockHeaderStore is an implementation of a fully fledged database for
-// Bitcoin block headers. The BlockHeaderStore combines a flat file to store
-// the block headers with a database instance for managing the index into the
-// set of flat files.
-type BlockHeaderStore struct {
-	*headerStore
-}
-
 // NewBlockHeaderStore creates a new instance of the BlockHeaderStore based on
 // a target file path, an open database instance, and finally a set of
 // parameters for the target chain. These parameters are required as if this is
@@ -253,15 +245,6 @@ func (h *BlockHeaderStore) RollbackLastBlock() (*waddrmgr.BlockStamp, error) {
 		Height: int32(chainTipHeight) - 1,
 		Hash:   prevHeaderHash,
 	}, nil
-}
-
-// BlockHeader is a Bitcoin block header that also has its height included.
-type BlockHeader struct {
-	*wire.BlockHeader
-
-	// Height is the height of this block header within the current main
-	// chain.
-	Height uint32
 }
 
 // toIndexEntry converts the BlockHeader into a matching headerEntry. This
@@ -485,14 +468,6 @@ func (h *BlockHeaderStore) ChainTip() (*wire.BlockHeader, uint32, error) {
 	return latestHeader, tipHeight, nil
 }
 
-// FilterHeaderStore is an implementation of a fully fledged database for any
-// variant of filter headers.  The FilterHeaderStore combines a flat file to
-// store the block headers with a database instance for managing the index into
-// the set of flat files.
-type FilterHeaderStore struct {
-	*headerStore
-}
-
 // NewFilterHeaderStore returns a new instance of the FilterHeaderStore based
 // on a target file path, filter type, and target net parameters. These
 // parameters are required as if this is the initial start up of the
@@ -625,21 +600,6 @@ func (f *FilterHeaderStore) FetchHeaderByHeight(height uint32) (*chainhash.Hash,
 	defer f.mtx.RUnlock()
 
 	return f.readHeader(int64(height))
-}
-
-// FilterHeader represents a filter header (basic or extended). The filter
-// header itself is coupled with the block height and hash of the filter's
-// block.
-type FilterHeader struct {
-	// HeaderHash is the hash of the block header that this filter header
-	// corresponds to.
-	HeaderHash chainhash.Hash
-
-	// FilterHash is the filter header itself.
-	FilterHash chainhash.Hash
-
-	// Height is the block height of the filter header in the main chain.
-	Height uint32
 }
 
 // toIndexEntry converts the filter header into a index entry to be stored

--- a/neutrino.go
+++ b/neutrino.go
@@ -589,9 +589,9 @@ type ChainService struct {
 	shutdown      int32
 
 	FilterDB         filterdb.FilterDatabase
-	BlockHeaders     *headerfs.BlockHeaderStore
-	RegFilterHeaders *headerfs.FilterHeaderStore
-	ExtFilterHeaders *headerfs.FilterHeaderStore
+	BlockHeaders     headerfs.BlockHeaderDB
+	RegFilterHeaders headerfs.FilterHeaderDB
+	ExtFilterHeaders headerfs.FilterHeaderDB
 
 	chainParams       chaincfg.Params
 	addrManager       *addrmgr.AddrManager

--- a/sync_test.go
+++ b/sync_test.go
@@ -50,7 +50,7 @@ var (
 	// messages.
 	numQueryThreads = 20
 	queryOptions    = []neutrino.QueryOption{
-	//neutrino.NumRetries(5),
+		//neutrino.NumRetries(5),
 	}
 
 	// The logged sequence of events we want to see. The value of i


### PR DESCRIPTION
introduced BlockHeaderDB and FilterHeaderDB interfaces that expose the previously exported functions.