### PR TITLE
rescan: handle err in GetUtxo to prevent shutdown panic

### DIFF
--- a/rescan.go
+++ b/rescan.go
@@ -892,12 +892,13 @@ func (s *ChainService) GetUtxo(options ...RescanOption) (*SpendReport, error) {
 
 	// Track our position in the chain.
 	curHeader, curHeight, err := s.BlockHeaders.ChainTip()
+	if err != nil {
+		return nil, err
+	}
+
 	curStamp := &waddrmgr.BlockStamp{
 		Hash:   curHeader.BlockHash(),
 		Height: int32(curHeight),
-	}
-	if err != nil {
-		return nil, err
 	}
 
 	// Find our earliest possible block.


### PR DESCRIPTION
Fix a panic I noticed during a shutdown of neutrino. The fix was to move handle the error from `ChainTip` in `GetUtxo` immediately before accessing any of the returned header's methods. 