### PR TITLE
multi: comply with updated BIP157+158 specifications

### DIFF
--- a/filterdb/db.go
+++ b/filterdb/db.go
@@ -100,7 +100,7 @@ func New(db walletdb.DB, params chaincfg.Params) (*FilterStore, error) {
 		// With the bucket created, we'll now construct the initial
 		// basic genesis filter and store it within the database.
 		basicFilter, err := builder.BuildBasicFilter(genesisBlock)
-		if err != nil && err != gcs.ErrNoData {
+		if err != nil {
 			return err
 		}
 		err = putFilter(regFilters, genesisHash, basicFilter)
@@ -117,7 +117,7 @@ func New(db walletdb.DB, params chaincfg.Params) (*FilterStore, error) {
 		}
 
 		extFilter, err := builder.BuildExtFilter(genesisBlock)
-		if err != nil && err != gcs.ErrNoData {
+		if err != nil {
 			return err
 		}
 		return putFilter(extFilters, genesisHash, extFilter)
@@ -141,7 +141,12 @@ func putFilter(bucket walletdb.ReadWriteBucket, hash *chainhash.Hash,
 		return bucket.Put(hash[:], nil)
 	}
 
-	return bucket.Put(hash[:], filter.NBytes())
+	bytes, err := filter.NBytes()
+	if err != nil {
+		return err
+	}
+
+	return bucket.Put(hash[:], bytes)
 }
 
 // PutFilter stores a filter with the given hash and type to persistent
@@ -166,7 +171,12 @@ func (f *FilterStore) PutFilter(hash *chainhash.Hash,
 			return targetBucket.Put(hash[:], nil)
 		}
 
-		return targetBucket.Put(hash[:], filter.NBytes())
+		bytes, err := filter.NBytes()
+		if err != nil {
+			return err
+		}
+
+		return targetBucket.Put(hash[:], bytes)
 	})
 }
 

--- a/headerfs/store.go
+++ b/headerfs/store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/roasbeef/btcd/chaincfg"
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
 	"github.com/roasbeef/btcd/wire"
-	"github.com/roasbeef/btcutil/gcs"
 	"github.com/roasbeef/btcutil/gcs/builder"
 	"github.com/roasbeef/btcwallet/waddrmgr"
 	"github.com/roasbeef/btcwallet/walletdb"
@@ -530,27 +529,33 @@ func NewFilterHeaderStore(filePath string, db walletdb.DB,
 			basicFilter, err := builder.BuildBasicFilter(
 				netParams.GenesisBlock,
 			)
-			if err != nil && err != gcs.ErrNoData {
+			if err != nil {
 				return nil, err
 			}
 
-			genesisFilterHash = builder.MakeHeaderForFilter(
+			genesisFilterHash, err = builder.MakeHeaderForFilter(
 				basicFilter,
 				netParams.GenesisBlock.Header.PrevBlock,
 			)
+			if err != nil {
+				return nil, err
+			}
 
 		case ExtendedFilter:
 			extFilter, err := builder.BuildExtFilter(
 				netParams.GenesisBlock,
 			)
-			if err != nil && err != gcs.ErrNoData {
+			if err != nil {
 				return nil, err
 			}
 
-			genesisFilterHash = builder.MakeHeaderForFilter(
+			genesisFilterHash, err = builder.MakeHeaderForFilter(
 				extFilter,
 				netParams.GenesisBlock.Header.PrevBlock,
 			)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		genesisHeader := FilterHeader{

--- a/neutrino.go
+++ b/neutrino.go
@@ -222,20 +222,11 @@ func (sp *ServerPeer) addBanScore(persistent, transient uint32, reason string) {
 
 // pushGetCFHeadersMsg sends a getcfheaders message for the provided block
 // locator and stop hash to the connected peer.
-func (sp *ServerPeer) pushGetCFHeadersMsg(locator blockchain.BlockLocator,
+func (sp *ServerPeer) pushGetCFHeadersMsg(startHeight uint32,
 	stopHash *chainhash.Hash, filterType wire.FilterType) error {
 
-	msg := wire.NewMsgGetCFHeaders()
-	msg.HashStop = *stopHash
-	for _, hash := range locator {
-		err := msg.AddBlockLocatorHash(hash)
-		if err != nil {
-			return err
-		}
-	}
-
-	msg.FilterType = filterType
-	sp.QueueMessage(msg, nil)
+	sp.QueueMessage(wire.NewMsgGetCFHeaders(filterType, startHeight,
+		stopHash), nil)
 	return nil
 }
 
@@ -440,7 +431,7 @@ func (sp *ServerPeer) OnReject(_ *peer.Peer, msg *wire.MsgReject) {
 // is used to notify the server about a list of committed filter headers.
 func (sp *ServerPeer) OnCFHeaders(p *peer.Peer, msg *wire.MsgCFHeaders) {
 	log.Tracef("Got cfheaders message with %d items from %s",
-		len(msg.HeaderHashes), p.Addr())
+		len(msg.FilterHashes), p.Addr())
 	sp.server.blockManager.QueueCFHeaders(msg, sp)
 }
 


### PR DESCRIPTION
This commit updates `neutrino` to comply wtih the new BIP157 and BIP158 specifications for filter, header, and wire message formats. It does not yet take full advantage of all of the optimizations made possible by the new format, such as parallelizing cfheader download, requesting multiple cfilters at once, etc.