### PR TITLE
Fix stall detection-caused sync and query issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.8.3
-  - 1.9
+  - "1.9.4"
+  - "1.10"
 sudo: false
 install:
   - GLIDE_TAG=v0.12.3

--- a/blocklogger.go
+++ b/blocklogger.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog"
 )
 
 // blockProgressLogger provides periodic logging for other services in order

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -10,12 +10,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/lightninglabs/neutrino/headerfs"
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/neutrino/headerfs"
 )
 
 const (

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -44,6 +44,12 @@ var (
 	// messages from peers. It defaults to 3 seconds but can be increased
 	// for higher security and decreased for faster synchronization.
 	WaitForMoreCFHeaders = 3 * time.Second
+
+	// CFHMinPeers specifies the minimum number of peers to which we
+	// require to be connected before broadcasting a getcfheaders request.
+	// This is mostly for testing, but can be useful when being actively
+	// attacked by peers sending false information.
+	CFHMinPeers = 1
 )
 
 // zeroHash is the zero value hash (all zeros).  It is defined as a convenience.
@@ -1205,6 +1211,23 @@ func (b *blockManager) sendGetcfheaders(startHeight uint32, endBlock *chainhash.
 		filterType: filterType,
 		stopHash:   *endBlock,
 	}
+
+	// Ensure we have peers.
+	// TODO(aakselrod): This is hacky, but is going away soon, when the
+	// cfheaders download is parallelized and refactored to use the query
+	// API.
+	var peers []*ServerPeer
+	var timeWithoutPeers time.Duration
+	for len(peers) < CFHMinPeers &&
+		timeWithoutPeers < QueryPeerConnectTimeout {
+		peers = b.server.Peers()
+		if len(peers) == 0 {
+			time.Sleep(QueryTimeBetweenPeerEnums)
+			timeWithoutPeers += QueryTimeBetweenPeerEnums
+		}
+	}
+
+	// Broadcast the message.
 	b.server.ForAllPeers(func(sp *ServerPeer) {
 		// Should probably use better isolation for this but we're in
 		// the same package. One of the things to clean up when we do

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -50,6 +50,11 @@ var (
 	// This is mostly for testing, but can be useful when being actively
 	// attacked by peers sending false information.
 	CFHMinPeers = 1
+
+	// CFHTimeBetweenPeerEnums specifies how long to wait between attempts
+	// to enumerate the peers to which the underlying chain service is
+	// connected.
+	CFHTimeBetweenPeerEnums = time.Millisecond * 200
 )
 
 // zeroHash is the zero value hash (all zeros).  It is defined as a convenience.
@@ -1222,8 +1227,8 @@ func (b *blockManager) sendGetcfheaders(startHeight uint32, endBlock *chainhash.
 		timeWithoutPeers < QueryPeerConnectTimeout {
 		peers = b.server.Peers()
 		if len(peers) == 0 {
-			time.Sleep(QueryTimeBetweenPeerEnums)
-			timeWithoutPeers += QueryTimeBetweenPeerEnums
+			time.Sleep(CFHTimeBetweenPeerEnums)
+			timeWithoutPeers += CFHTimeBetweenPeerEnums
 		}
 	}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,46 @@
-hash: 739feabd5245524873f9810a94258ee1934bfcf419c5045b89cb931af77003e8
-updated: 2018-04-05T18:59:35.906808045-07:00
+hash: 45b0ddaf6e4a92c2155472442ececdfe72079a70896871f8ec8324129613360c
+updated: 2018-05-23T19:45:10.732106605-07:00
 imports:
 - name: github.com/aead/siphash
   version: e404fcfc888570cadd1610538e2dbc89f66af814
+- name: github.com/btcsuite/btcd
+  version: d52471044ab259b656083399c4304ce6672308fd
+  subpackages:
+  - addrmgr
+  - blockchain
+  - btcec
+  - btcjson
+  - chaincfg
+  - chaincfg/chainhash
+  - connmgr
+  - database
+  - integration/rpctest
+  - peer
+  - rpcclient
+  - txscript
+  - wire
 - name: github.com/btcsuite/btclog
   version: 84c8d2346e9fc8c7b947e243b9c24e6df9fd206a
+- name: github.com/btcsuite/btcutil
+  version: 45edb4b6e59ef7890c7f4be92da61d5ebfa50b65
+  subpackages:
+  - base58
+  - bech32
+  - gcs
+  - gcs/builder
+  - hdkeychain
+- name: github.com/btcsuite/btcwallet
+  version: 56fac5572c745acd6e627942d90cef38763556d8
+  subpackages:
+  - internal/helpers
+  - internal/zero
+  - snacl
+  - waddrmgr
+  - wallet/internal/txsizes
+  - wallet/txauthor
+  - wallet/txrules
+  - walletdb
+  - walletdb/bdb
 - name: github.com/btcsuite/go-socks
   version: 4720035b7bfd2a9bb130b1c184f8bbe41b6f0d0f
   subpackages:
@@ -26,63 +62,27 @@ imports:
 - name: github.com/coreos/bbolt
   version: 4f5275f4ebbf6fe7cb772de987fa96ee674460a7
 - name: github.com/davecgh/go-spew
-  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/golang/protobuf
-  version: ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
+  version: 3a3da3a4e26776cc22a79ef46d5d58477532dede
   subpackages:
   - proto
 - name: github.com/jessevdk/go-flags
   version: 1679536dcc895411a9f5848d9a0250be7856448c
 - name: github.com/kkdai/bstream
-  version: f391b8402d23024e7c0f624b31267a89998fca95
-- name: github.com/btcsuite/btcd
-  version: 609264819073f69e69716f17e2978ba18288eafe
-  subpackages:
-  - addrmgr
-  - blockchain
-  - btcec
-  - btcjson
-  - chaincfg
-  - chaincfg/chainhash
-  - connmgr
-  - database
-  - integration/rpctest
-  - peer
-  - rpcclient
-  - txscript
-  - wire
-- name: github.com/btcsuite/btcutil
-  version: dfb640c57141f1c2113b92b4b16d2a89c30dd258
-  subpackages:
-  - base58
-  - bech32
-  - gcs
-  - gcs/builder
-  - hdkeychain
-- name: github.com/btcsuite/btcwallet
-  version: 45445d1b09670109410174cb01fab0b133e3a904
-  subpackages:
-  - internal/helpers
-  - internal/zero
-  - snacl
-  - waddrmgr
-  - wallet/internal/txsizes
-  - wallet/txauthor
-  - wallet/txrules
-  - walletdb
-  - walletdb/bdb
+  version: f71540b9dfdcfe64dbf2818e9b66423c6aafcacd
 - name: golang.org/x/crypto
-  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
+  version: 75e913eb8a8e3d31a97b216de09de106a7b07681
   subpackages:
   - ripemd160
 - name: golang.org/x/net
-  version: 66aacef3dd8a676686c7ae3716979581e8b03c47
+  version: 9ef9f5bb98a1fdc41f8cf6c250a4404b4085e389
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: ab9e364efd8b52800ff7ee48a9ffba4e0ed78dfb
+  version: 77b0e4315053a57ed2962443614bdb28db152054
   subpackages:
   - unix
 - name: google.golang.org/grpc

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,11 @@
-hash: 45b0ddaf6e4a92c2155472442ececdfe72079a70896871f8ec8324129613360c
-updated: 2018-05-23T19:45:10.732106605-07:00
+hash: 2d5df08614cebead2f5a0b3cf51806fbbd2e998de1dfd2b74df9e0143e4c8c36
+updated: 2018-05-23T20:15:04.144997639-07:00
 imports:
 - name: github.com/aead/siphash
   version: e404fcfc888570cadd1610538e2dbc89f66af814
 - name: github.com/btcsuite/btcd
-  version: d52471044ab259b656083399c4304ce6672308fd
+  version: 3f1ccb8b866dd611031d55caa31e04c62a91cbca
+  repo: git@github.com:Roasbeef/btcd.git
   subpackages:
   - addrmgr
   - blockchain

--- a/glide.lock
+++ b/glide.lock
@@ -1,11 +1,10 @@
-hash: 2d5df08614cebead2f5a0b3cf51806fbbd2e998de1dfd2b74df9e0143e4c8c36
-updated: 2018-05-23T20:15:04.144997639-07:00
+hash: 5909bf265ccd8693901c3071eafb53bd1f8530a69a466d89c482419b30ca0922
+updated: 2018-05-23T21:13:59.726103942-07:00
 imports:
 - name: github.com/aead/siphash
   version: e404fcfc888570cadd1610538e2dbc89f66af814
 - name: github.com/btcsuite/btcd
-  version: 3f1ccb8b866dd611031d55caa31e04c62a91cbca
-  repo: git@github.com:Roasbeef/btcd.git
+  version: bc0944904505aab55e089371a892be2f87883161
   subpackages:
   - addrmgr
   - blockchain
@@ -23,7 +22,7 @@ imports:
 - name: github.com/btcsuite/btclog
   version: 84c8d2346e9fc8c7b947e243b9c24e6df9fd206a
 - name: github.com/btcsuite/btcutil
-  version: 45edb4b6e59ef7890c7f4be92da61d5ebfa50b65
+  version: d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4
   subpackages:
   - base58
   - bech32
@@ -31,7 +30,7 @@ imports:
   - gcs/builder
   - hdkeychain
 - name: github.com/btcsuite/btcwallet
-  version: 56fac5572c745acd6e627942d90cef38763556d8
+  version: 74a7124666b49cd7e67da87c61169f4fb83fbd73
   subpackages:
   - internal/helpers
   - internal/zero

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,8 @@ import:
 - package: github.com/coreos/bbolt
   version: 4f5275f4ebbf6fe7cb772de987fa96ee674460a7
 - package: github.com/btcsuite/btcd
-  version: d52471044ab259b656083399c4304ce6672308fd
+  version: 3f1ccb8b866dd611031d55caa31e04c62a91cbca
+  repo: git@github.com:Roasbeef/btcd.git
   subpackages:
   - blockchain
   - btcec

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,8 +3,7 @@ import:
 - package: github.com/coreos/bbolt
   version: 4f5275f4ebbf6fe7cb772de987fa96ee674460a7
 - package: github.com/btcsuite/btcd
-  version: 3f1ccb8b866dd611031d55caa31e04c62a91cbca
-  repo: git@github.com:Roasbeef/btcd.git
+  version: bc0944904505aab55e089371a892be2f87883161
   subpackages:
   - blockchain
   - btcec
@@ -15,14 +14,14 @@ import:
   - wire
 - package: github.com/btcsuite/btclog
 - package: github.com/btcsuite/btcutil
-  version: 45edb4b6e59ef7890c7f4be92da61d5ebfa50b65
+  version: d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4
   subpackages:
   - base58
   - gcs
   - gcs/builder
   - hdkeychain
 - package: github.com/btcsuite/btcwallet
-  version: 56fac5572c745acd6e627942d90cef38763556d8
+  version: 74a7124666b49cd7e67da87c61169f4fb83fbd73
   subpackages:
   - waddrmgr
   - wallet/txauthor

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/coreos/bbolt
   version: 4f5275f4ebbf6fe7cb772de987fa96ee674460a7
 - package: github.com/btcsuite/btcd
-  version: 609264819073f69e69716f17e2978ba18288eafe
+  version: d52471044ab259b656083399c4304ce6672308fd
   subpackages:
   - blockchain
   - btcec
@@ -14,14 +14,14 @@ import:
   - wire
 - package: github.com/btcsuite/btclog
 - package: github.com/btcsuite/btcutil
-  version: dfb640c57141f1c2113b92b4b16d2a89c30dd258
+  version: 45edb4b6e59ef7890c7f4be92da61d5ebfa50b65
   subpackages:
   - base58
   - gcs
   - gcs/builder
   - hdkeychain
 - package: github.com/btcsuite/btcwallet
-  version: 45445d1b09670109410174cb01fab0b133e3a904
+  version: 56fac5572c745acd6e627942d90cef38763556d8
   subpackages:
   - waddrmgr
   - wallet/txauthor

--- a/headerfs/store_test.go
+++ b/headerfs/store_test.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/davecgh/go-spew/spew"
 )
 
 func createTestBlockHeaderStore() (func(), walletdb.DB, string, *BlockHeaderStore, error) {

--- a/log.go
+++ b/log.go
@@ -1,11 +1,11 @@
 package neutrino
 
 import (
-	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/btcd/addrmgr"
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/peer"
 	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btclog"
 )
 
 // log is a logger that is initialized with no output filters.  This

--- a/neutrino.go
+++ b/neutrino.go
@@ -126,7 +126,7 @@ type spMsg struct {
 	msg wire.Message
 }
 
-// spMsgSubscription sends all messages from a peer ove a channel, allowing
+// spMsgSubscription sends all messages from a peer over a channel, allowing
 // pluggable filtering of the messages.
 type spMsgSubscription struct {
 	msgChan  chan<- spMsg

--- a/neutrino.go
+++ b/neutrino.go
@@ -120,6 +120,19 @@ type cfhRequest struct {
 	stopHash   chainhash.Hash
 }
 
+// spMsg represents a message over the wire from a specific peer.
+type spMsg struct {
+	sp  *ServerPeer
+	msg wire.Message
+}
+
+// spMsgSubscription sends all messages from a peer ove a channel, allowing
+// pluggable filtering of the messages.
+type spMsgSubscription struct {
+	msgChan  chan<- spMsg
+	quitChan <-chan struct{}
+}
+
 // ServerPeer extends the peer to maintain state shared by the server and the
 // blockmanager.
 type ServerPeer struct {
@@ -498,9 +511,7 @@ func (sp *ServerPeer) OnRead(_ *peer.Peer, bytesRead int, msg wire.Message,
 	sp.mtxSubscribers.RLock()
 	defer sp.mtxSubscribers.RUnlock()
 	for subscription := range sp.recvSubscribers {
-		subscription.wg.Add(1)
 		go func(subscription spMsgSubscription) {
-			defer subscription.wg.Done()
 			select {
 			case <-subscription.quitChan:
 			case subscription.msgChan <- spMsg{

--- a/neutrino.go
+++ b/neutrino.go
@@ -12,8 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/lightninglabs/neutrino/filterdb"
-	"github.com/lightninglabs/neutrino/headerfs"
 	"github.com/btcsuite/btcd/addrmgr"
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -24,6 +22,8 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/lightninglabs/neutrino/filterdb"
+	"github.com/lightninglabs/neutrino/headerfs"
 )
 
 // These are exported variables so they can be changed by users.

--- a/query.go
+++ b/query.go
@@ -30,12 +30,6 @@ var (
 	// underlying chain service to connect to a peer before giving up
 	// on a query in case we don't have any peers.
 	QueryPeerConnectTimeout = time.Second * 30
-
-	// QueryTimeBetweenPeerEnums specifies how long to wait between attempts
-	// to enumerate the peers to which the underlying chain service is
-	// connected. This value is only set globally, not as a query
-	// option.
-	QueryTimeBetweenPeerEnums = time.Millisecond * 200
 )
 
 // queries are a set of options that can be modified per-query, unlike global

--- a/query.go
+++ b/query.go
@@ -4,8 +4,6 @@ package neutrino
 
 import (
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
@@ -27,6 +25,17 @@ var (
 	// response. This allows to make up for missed messages in some
 	// instances.
 	QueryNumRetries = 2
+
+	// QueryPeerConnectTimeout specifies how long to wait for the
+	// underlying chain service to connect to a peer before giving up
+	// on a query in case we don't have any peers.
+	QueryPeerConnectTimeout = time.Second * 30
+
+	// QueryTimeBetweenPeerEnums specifies how long to wait between attempts
+	// to enumerate the peers to which the underlying chain service is
+	// connected. This value is only set globally, not as a query
+	// option.
+	QueryTimeBetweenPeerEnums = time.Millisecond * 200
 )
 
 // queries are a set of options that can be modified per-query, unlike global
@@ -42,6 +51,11 @@ type queryOptions struct {
 	// the query.
 	numRetries uint8
 
+	// peerConnectTimeout lets the query know how long to wait for the
+	// underlying chain service to connect to a peer before giving up
+	// on a query in case we don't have any peers.
+	peerConnectTimeout time.Duration
+
 	// doneChan lets the query signal the caller when it's done, in case
 	// it's run in a goroutine.
 	doneChan chan<- struct{}
@@ -56,8 +70,9 @@ type QueryOption func(*queryOptions)
 // defaultQueryOptions returns a queryOptions set to package-level defaults.
 func defaultQueryOptions() *queryOptions {
 	return &queryOptions{
-		timeout:    QueryTimeout,
-		numRetries: uint8(QueryNumRetries),
+		timeout:            QueryTimeout,
+		numRetries:         uint8(QueryNumRetries),
+		peerConnectTimeout: QueryPeerConnectTimeout,
 	}
 }
 
@@ -77,6 +92,15 @@ func NumRetries(numRetries uint8) QueryOption {
 	}
 }
 
+// PeerConnectTimeout is a query option that lets the query know how long to
+// wait for the underlying chain service to connect to a peer before giving up
+// on a query in case we don't have any peers.
+func PeerConnectTimeout(timeout time.Duration) QueryOption {
+	return func(qo *queryOptions) {
+		qo.peerConnectTimeout = timeout
+	}
+}
+
 // DoneChan allows the caller to pass a channel that will get closed when the
 // query is finished.
 func DoneChan(doneChan chan<- struct{}) QueryOption {
@@ -85,15 +109,34 @@ func DoneChan(doneChan chan<- struct{}) QueryOption {
 	}
 }
 
-type spMsg struct {
-	sp  *ServerPeer
-	msg wire.Message
-}
+// checkPeer alows the caller to query a single peer. Should be called in its
+// own goroutine. Exits when quit channel is closed or a message on it is
+// received.
+func checkPeer(sp *ServerPeer, subscription spMsgSubscription,
+	queryMsg wire.Message, quit <-chan struct{}) {
 
-type spMsgSubscription struct {
-	msgChan  chan<- spMsg
-	quitChan <-chan struct{}
-	wg       *sync.WaitGroup
+	// Don't do anything if the peer isn't connected.
+	if sp == nil || !sp.Connected() {
+		return
+	}
+
+	// Subscribe to the peer's received messages.
+	sp.subscribeRecvMsg(subscription)
+	defer sp.unsubscribeRecvMsgs(subscription)
+
+	// Send the query to the peer. Exit if we quit before reading the sent
+	// channel.
+	sentChan := make(chan struct{}, 1)
+	sp.QueueMessageWithEncoding(queryMsg, sentChan, wire.WitnessEncoding)
+	select {
+	case <-sentChan:
+	case <-quit:
+	}
+
+	// Wait for a quit signal.
+	select {
+	case <-quit:
+	}
 }
 
 // queryPeers is a helper function that sends a query to one or more peers and
@@ -120,190 +163,44 @@ func (s *ChainService) queryPeers(
 		option(qo)
 	}
 
-	// This is done in a single-threaded query because the peerState is
-	// held in a single thread. This is the only part of the query
-	// framework that requires access to peerState, so it's done once per
-	// query.
-	peers := s.Peers()
-	syncPeer := s.blockManager.SyncPeer()
+	// We get an initial view of our peers, to be updated each time a peer
+	// query times out.
+	curPeer := s.blockManager.SyncPeer()
+	peerTries := make(map[string]uint8)
 
-	// This will be shared state between the per-peer goroutines. The
-	// startQuery channel will be used as a sort of totem to allow the
-	// goroutines launched by each peer to query serially, passing the
-	// totem if there's an error or a timeout occurs.
+	// This will be state used by the peer query goroutine.
 	quit := make(chan struct{})
-	allQuit := make(chan struct{})
-	startQuery := make(chan struct{})
-
-	var (
-		wg            sync.WaitGroup
-		syncPeerTries uint32
-	)
+	subQuit := make(chan struct{})
+	peerQuit := make(chan struct{})
 
 	// Increase this number to be able to handle more queries at once as
 	// each channel gets results for all queries, otherwise messages can
 	// get mixed and there's a vicious cycle of retries causing a bigger
 	// message flood, more of which get missed.
-	var subwg sync.WaitGroup
 	msgChan := make(chan spMsg)
 	subscription := spMsgSubscription{
 		msgChan:  msgChan,
-		quitChan: allQuit,
-		wg:       &subwg,
+		quitChan: subQuit,
 	}
-
-	// Start a goroutine for each peer that potentially queries that peer.
-	for _, sp := range peers {
-		wg.Add(1)
-		go func(sp *ServerPeer) {
-			defer wg.Done()
-			defer sp.unsubscribeRecvMsgs(subscription)
-
-			numRetries := qo.numRetries
-
-			// Should we do this when the goroutine gets a message
-			// via startQuery rather than at the launch of the
-			// goroutine?
-			if !sp.Connected() {
-				return
-			}
-
-			timeout := make(<-chan time.Time)
-		queryLoop:
-			for {
-				select {
-
-				case <-timeout:
-					// After timeout, we try to notify
-					// another of our peer goroutines to do
-					// a query until we get a signal to
-					// quit.
-					select {
-					case startQuery <- struct{}{}:
-					case <-quit:
-						return
-					case <-allQuit:
-						return
-					}
-
-					// At this point, we've sent
-					// startQuery.  We return if we've run
-					// through this section of code
-					// numRetries times.
-					if numRetries--; numRetries == 0 {
-						return
-					}
-
-				// After we're told to quit, we return.
-				case <-quit:
-					return
-
-				// After we're told to quit, we return.
-				case <-allQuit:
-					return
-
-				case <-startQuery:
-					// We're the lucky peer whose turn it
-					// is to try to answer the current
-					// query.
-					//
-					// If the sync peer hasn't tried yet
-					// and we aren't the sync peer, don't
-					// do anything but forward the message
-					// down the startQuery channel until
-					// the sync peer gets a shot.
-					//
-					// TODO: Add support for querying *all*
-					// peers simultaneously to avoid
-					// timeout delays.
-					if sp == syncPeer {
-						atomic.StoreUint32(
-							&syncPeerTries, 1)
-					}
-					if atomic.LoadUint32(&syncPeerTries) == 0 {
-						select {
-						case startQuery <- struct{}{}:
-						case <-quit:
-							return
-						case <-allQuit:
-							return
-						}
-						continue queryLoop
-					}
-
-					sp.subscribeRecvMsg(subscription)
-
-					// Don't want the peer hanging on send
-					// to the channel if we quit before
-					// reading the channel.
-					sentChan := make(chan struct{}, 1)
-					sp.QueueMessageWithEncoding(queryMsg,
-						sentChan, wire.WitnessEncoding)
-					select {
-					case <-sentChan:
-					case <-quit:
-						return
-					case <-allQuit:
-						return
-					}
-					timeout = time.After(qo.timeout)
-				default:
-				}
-			}
-		}(sp)
-	}
-
-	// Kick off the query by sending the query totem into the startQuery
-	// channel.
-	startQuery <- struct{}{}
-
-	// This goroutine will wait until all of the peer-query goroutines have
-	// terminated, and then initiate a query shutdown.
-	go func() {
-		wg.Wait()
-
-		// If we timed out on each goroutine and didn't quit or time
-		// out on the main goroutine, make sure our main goroutine
-		// knows to quit.
-		select {
-		case <-allQuit:
-		default:
-			close(allQuit)
-		}
-
-		// Close the done channel, if any.
-		if qo.doneChan != nil {
-			close(qo.doneChan)
-		}
-
-		// Wait until all goroutines started by subscriptions have
-		// exited after we closed allQuit before letting the message
-		// channel get garbage collected.
-		subwg.Wait()
-	}()
 
 	// Loop for any messages sent to us via our subscription channel and
 	// check them for whether they satisfy the query. Break the loop if
 	// it's time to quit.
-	timeout := time.After(time.Duration(len(peers)+1) *
-		qo.timeout * time.Duration(qo.numRetries))
+	peerTimeout := time.Tick(qo.timeout)
+	timeout := time.After(qo.peerConnectTimeout)
+	if curPeer != nil {
+		peerTries[curPeer.Addr()]++
+		go checkPeer(curPeer, subscription, queryMsg, peerQuit)
+	}
 checkResponses:
 	for {
 		select {
 		case <-timeout:
-			// When we time out, close the allQuit channel if it
-			// hasn't already been closed.
-			select {
-			case <-allQuit:
-			default:
-				close(allQuit)
-			}
+			// When we time out, we're done.
 			break checkResponses
 
 		case <-quit:
-			break checkResponses
-
-		case <-allQuit:
+			// Same when we get a quit signal.
 			break checkResponses
 
 		// A message has arrived over the subscription channel, so we
@@ -314,7 +211,35 @@ checkResponses:
 			// stuck. This is a caveat for callers that should be
 			// fixed before exposing this function for public use.
 			checkResponse(sm.sp, sm.msg, quit)
+
+		// The current peer we're querying has failed to answer the
+		// query. Time to select a new peer and query it.
+		case <-peerTimeout:
+			select {
+			case peerQuit <- struct{}{}:
+			default:
+			}
+
+			curPeer = nil
+			for _, curPeer = range s.Peers() {
+				if curPeer != nil && curPeer.Connected() &&
+					peerTries[curPeer.Addr()] <
+						qo.numRetries {
+					// Found a peer we can query.
+					peerTries[curPeer.Addr()]++
+					go checkPeer(curPeer, subscription,
+						queryMsg, peerQuit)
+					break
+				}
+			}
 		}
+	}
+
+	// Close the subordinate quit channels and the done channel, if any.
+	close(subQuit)
+	close(peerQuit)
+	if qo.doneChan != nil {
+		close(qo.doneChan)
 	}
 }
 

--- a/query.go
+++ b/query.go
@@ -8,13 +8,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/lightninglabs/neutrino/filterdb"
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/gcs"
 	"github.com/btcsuite/btcutil/gcs/builder"
+	"github.com/lightninglabs/neutrino/filterdb"
 )
 
 var (

--- a/rescan.go
+++ b/rescan.go
@@ -9,7 +9,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/lightninglabs/neutrino/headerfs"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
@@ -18,6 +17,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/gcs/builder"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/neutrino/headerfs"
 )
 
 // rescanOptions holds the set of functional parameters for Rescan.

--- a/sync_test.go
+++ b/sync_test.go
@@ -4,6 +4,7 @@ package neutrino_test
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -370,6 +371,7 @@ func TestSetup(t *testing.T) {
 	neutrino.MaxPeers = 3
 	neutrino.BanDuration = 5 * time.Second
 	neutrino.WaitForMoreCFHeaders = time.Second
+	neutrino.QueryPeerConnectTimeout = 10 * time.Second
 	svc, err := neutrino.NewChainService(config)
 	if err != nil {
 		t.Fatalf("Error creating ChainService: %s", err)
@@ -651,7 +653,9 @@ func TestSetup(t *testing.T) {
 		t.Fatalf("Couldn't sign transaction: %s", err)
 	}
 	banPeer(svc, h2)
-	err = svc.SendTransaction(authTx1.Tx, queryOptions...)
+	err = svc.SendTransaction(authTx1.Tx,
+		append(queryOptions,
+			neutrino.PeerConnectTimeout(3*time.Second))...)
 	if err != nil && !strings.Contains(err.Error(), "already have") {
 		t.Fatalf("Unable to send transaction to network: %s", err)
 	}
@@ -689,7 +693,9 @@ func TestSetup(t *testing.T) {
 		t.Fatalf("Couldn't sign transaction: %s", err)
 	}
 	banPeer(svc, h2)
-	err = svc.SendTransaction(authTx2.Tx, queryOptions...)
+	err = svc.SendTransaction(authTx2.Tx,
+		append(queryOptions,
+			neutrino.PeerConnectTimeout(3*time.Second))...)
 	if err != nil && !strings.Contains(err.Error(), "already have") {
 		t.Fatalf("Unable to send transaction to network: %s", err)
 	}
@@ -840,6 +846,7 @@ func TestSetup(t *testing.T) {
 	// is somewhat random, depending on how quickly the nodes process each
 	// other's notifications vs finding new blocks, but the two nodes should
 	// remain fully synchronized with each other at the end.
+	neutrino.CFHMinPeers = 2
 	go h2.Node.Generate(75)
 	h1.Node.Generate(50)
 
@@ -1163,8 +1170,8 @@ func testRandomBlocks(t *testing.T, svc *neutrino.ChainService,
 				&blockHash, wire.GCSFilterRegular)
 			if err != nil {
 				errChan <- fmt.Errorf("Couldn't get basic "+
-					"filter for block %d via RPC: %s",
-					height, err)
+					"filter for block %d (%s) via RPC: %s",
+					height, blockHash, err)
 				return
 			}
 			// Check that network and RPC cfilters match.
@@ -1174,14 +1181,18 @@ func testRandomBlocks(t *testing.T, svc *neutrino.ChainService,
 				if err != nil {
 					errChan <- fmt.Errorf("Couldn't get "+
 						"basic filter for block %d "+
-						"via P2P: %s", height, err)
+						"(%s) via P2P: %s", height,
+						blockHash, err)
 					return
 				}
 			}
 			if !bytes.Equal(haveBytes, wantFilter.Data) {
 				errChan <- fmt.Errorf("Basic filter from P2P "+
 					"network/DB doesn't match RPC value "+
-					"for block %d", height)
+					"for block %d (%s):\nRPC: %s\nNet: %s",
+					height, blockHash,
+					hex.EncodeToString(wantFilter.Data),
+					hex.EncodeToString(haveBytes))
 				return
 			}
 			// Calculate basic filter from block.
@@ -1204,7 +1215,8 @@ func testRandomBlocks(t *testing.T, svc *neutrino.ChainService,
 			if !bytes.Equal(haveBytes, calcBytes) {
 				errChan <- fmt.Errorf("Basic filter from P2P "+
 					"network/DB doesn't match calculated "+
-					"value for block %d", height)
+					"value for block %d (%s)", height,
+					blockHash)
 				return
 			}
 			// Get previous basic filter header from the database.
@@ -1218,11 +1230,12 @@ func testRandomBlocks(t *testing.T, svc *neutrino.ChainService,
 				return
 			}
 			// Get current basic filter header from the database.
-			curHeader, err := svc.RegFilterHeaders.FetchHeader(&blockHash)
+			curHeader, err := svc.RegFilterHeaders.FetchHeader(
+				&blockHash)
 			if err != nil {
 				errChan <- fmt.Errorf("Couldn't get basic "+
 					"filter header for block %d (%s) from "+
-					"DB: %s", height-1, blockHash, err)
+					"DB: %s", height, blockHash, err)
 				return
 			}
 			// Check that the filter and header line up.
@@ -1231,7 +1244,7 @@ func testRandomBlocks(t *testing.T, svc *neutrino.ChainService,
 			if err != nil {
 				errChan <- fmt.Errorf("Couldn't calculate "+
 					"header for basic filter for block "+
-					"%d: %s", height, err)
+					"%d (%s): %s", height, blockHash, err)
 				return
 			}
 			if !bytes.Equal(curHeader[:], calcHeader[:]) {
@@ -1252,8 +1265,8 @@ func testRandomBlocks(t *testing.T, svc *neutrino.ChainService,
 				&blockHash, wire.GCSFilterExtended)
 			if err != nil {
 				errChan <- fmt.Errorf("Couldn't get extended "+
-					"filter for block %d via RPC: %s",
-					height, err)
+					"filter for block %d (%s) via RPC: %s",
+					height, blockHash, err)
 				return
 			}
 			// Check that network and RPC cfilters match
@@ -1262,7 +1275,8 @@ func testRandomBlocks(t *testing.T, svc *neutrino.ChainService,
 				if err != nil {
 					errChan <- fmt.Errorf("Couldn't get "+
 						"extended filter for block %d "+
-						"via P2P: %s", height, err)
+						"(%s) via P2P: %s", height,
+						blockHash, err)
 					return
 				}
 			} else {
@@ -1271,7 +1285,10 @@ func testRandomBlocks(t *testing.T, svc *neutrino.ChainService,
 			if !bytes.Equal(haveBytes, wantFilter.Data) {
 				errChan <- fmt.Errorf("Extended filter from "+
 					"P2P network/DB doesn't match RPC "+
-					"value for block %d", height)
+					"for block %d (%s):\nRPC: %s\nNet: %s",
+					height, blockHash,
+					hex.EncodeToString(wantFilter.Data),
+					hex.EncodeToString(haveBytes))
 				return
 			}
 			// Calculate extended filter from block
@@ -1294,9 +1311,9 @@ func testRandomBlocks(t *testing.T, svc *neutrino.ChainService,
 			if !bytes.Equal(haveBytes, calcBytes) {
 				errChan <- fmt.Errorf("Extended filter from "+
 					"P2P network/DB doesn't match "+
-					"calculated value for block %d: "+
+					"calculated value for block %d (%s): "+
 					"got\n%+v\nwant\n%+v\n", height,
-					haveFilter, calcFilter)
+					blockHash, haveFilter, calcFilter)
 				return
 			}
 			// Get previous extended filter header from the
@@ -1311,12 +1328,12 @@ func testRandomBlocks(t *testing.T, svc *neutrino.ChainService,
 				return
 			}
 			// Get current basic filter header from the database.
-			curHeader, err = svc.ExtFilterHeaders.FetchHeader(&blockHash)
+			curHeader, err = svc.ExtFilterHeaders.FetchHeader(
+				&blockHash)
 			if err != nil {
 				errChan <- fmt.Errorf("Couldn't get extended "+
 					"filter header for block %d (%s) from "+
-					"DB: %s", height-1,
-					blockHash, err)
+					"DB: %s", height, blockHash, err)
 				return
 			}
 			// Check that the filter and header line up.
@@ -1325,7 +1342,7 @@ func testRandomBlocks(t *testing.T, svc *neutrino.ChainService,
 			if err != nil {
 				errChan <- fmt.Errorf("Couldn't calculate "+
 					"header for extended filter for block "+
-					"%d: %s", height, err)
+					"%d (%s): %s", height, blockHash, err)
 				return
 			}
 			if !bytes.Equal(curHeader[:], calcHeader[:]) {

--- a/sync_test.go
+++ b/sync_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btclog"
-	"github.com/lightninglabs/neutrino"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -24,12 +22,14 @@ import (
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/gcs/builder"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/lightninglabs/neutrino"
 )
 
 var (


### PR DESCRIPTION
This PR, based on #59, updates two additional places, and those which depend on them:

* The `queryPeers()` function is modified to re-check the connected peers before attempting to query them. This prevents queries failing due to peers disconnecting, since it allows to wait some time for new or reconnected peers. This refactor also reduces the number of goroutines used per query, which improves query speed. The per-peer query function is also factored out, allowing it to be used in other schedulers.

* The `sendGetcfheaders()` function is modified to wait for a minimum number of peers to be connected prior to broadcasting a request. This works *most* of the time in an environment of rapidly-changing peers such as the sync reorg tests; however, an update currently in development will replace this code with query-based code that's optimized for handling this case correctly.

In addition, tests are updated to provide more error information and to support the new code; some small concurrency fixes are also added.