### PR TITLE
Use lru cache for filters.

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,28 @@
+package cache
+
+import "fmt"
+
+var (
+	// ErrElementNotFound is returned when element isn't found in the cache.
+	ErrElementNotFound = fmt.Errorf("unable to find element")
+)
+
+// Cache represents a generic cache.
+type Cache interface {
+	// Put stores the given (key,value) pair, replacing existing value if
+	// key already exists.
+	Put(key interface{}, value Value) error
+
+	// Get returns the value for a given key.
+	Get(key interface{}) (Value, error)
+
+	// Len returns number of elements in the cache.
+	Len() int
+}
+
+// Value represents a value stored in the Cache.
+type Value interface {
+	// Size determines how big this entry would be in the cache. For
+	// example, for a filter, it could be the size of the filter in bytes.
+	Size() (uint64, error)
+}

--- a/cache/cacheable_filter.go
+++ b/cache/cacheable_filter.go
@@ -1,0 +1,18 @@
+package cache
+
+import "github.com/btcsuite/btcutil/gcs"
+
+// CacheableFilter is a wrapper around Filter type which provides a Size method
+// used by the cache to target certain memory usage.
+type CacheableFilter struct {
+	*gcs.Filter
+}
+
+// Size returns size of this filter in bytes.
+func (c *CacheableFilter) Size() (uint64, error) {
+	f, err := c.Filter.NBytes()
+	if err != nil {
+		return 0, err
+	}
+	return uint64(len(f)), nil
+}

--- a/cache/lru/lru.go
+++ b/cache/lru/lru.go
@@ -1,0 +1,162 @@
+package lru
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+
+	"github.com/lightninglabs/neutrino/cache"
+)
+
+// elementMap is an alias for a map from a generic interface to a list.Element.
+type elementMap map[interface{}]*list.Element
+
+// entry represents a (key,value) pair entry in the Cache. The Cache's list
+// stores entries which let us get the cache key when an entry is evicted.
+type entry struct {
+	key   interface{}
+	value cache.Value
+}
+
+// Cache provides a generic thread-safe lru cache that can be used for
+// storing filters, blocks, etc.
+type Cache struct {
+	// capacity represents how much this cache can hold. It could be number
+	// of elements or a number of bytes, decided by the cache.Value's Size.
+	capacity uint64
+
+	// size represents the size of all the elements currenty in the cache.
+	size uint64
+
+	// ll is a doubly linked list which keeps track of recency of used
+	// elements by moving them to the front.
+	ll *list.List
+
+	// cache is a generic cache which allows us to find an elements position
+	// in the ll list from a given key.
+	cache elementMap
+
+	// mtx is used to make sure the Cache is thread-safe.
+	mtx sync.RWMutex
+}
+
+// NewCache return a cache with specified capacity, the cache's size can't
+// exceed that given capacity.
+func NewCache(capacity uint64) *Cache {
+	return &Cache{
+		capacity: capacity,
+		ll:       list.New(),
+		cache:    make(elementMap),
+	}
+}
+
+// evict will evict as many elements as necessary to make enough space for a new
+// element with size needed to be inserted.
+func (c *Cache) evict(needed uint64) error {
+	if needed > c.capacity {
+		return fmt.Errorf("can't evict %v elements in size, since"+
+			"capacity is %v", needed, c.capacity)
+	}
+
+	for c.capacity-c.size < needed {
+		// We still need to evict some more elements.
+		if c.ll.Len() == 0 {
+			// We should never reach here.
+			return fmt.Errorf("all elements got evicted, yet "+
+				"still need to evict %v, likelihood of error "+
+				"during size calculation",
+				needed-(c.capacity-c.size))
+		}
+
+		// Find the least recently used item.
+		if elr := c.ll.Back(); elr != nil {
+			// Determine lru item's size.
+			ce := elr.Value.(*entry)
+			es, err := ce.value.Size()
+			if err != nil {
+				return fmt.Errorf("couldn't determine size of "+
+					"existing cache value %v", err)
+			}
+
+			// Account for that element's removal in evicted and
+			// cache size.
+			c.size -= es
+
+			// Remove the element from the cache.
+			c.ll.Remove(elr)
+			delete(c.cache, ce.key)
+		}
+	}
+
+	return nil
+}
+
+// Put inserts a given (key,value) pair into the cache, if the key already
+// exists, it will replace value and update it to be most recent item in cache.
+func (c *Cache) Put(key interface{}, value cache.Value) error {
+	vs, err := value.Size()
+	if err != nil {
+		return fmt.Errorf("couldn't determine size of cache value: %v",
+			err)
+	}
+
+	if vs > c.capacity {
+		return fmt.Errorf("can't insert entry of size %v into cache "+
+			"with capacity %v", vs, c.capacity)
+	}
+
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	// If the element already exists, remove it and decrease cache's size.
+	el, ok := c.cache[key]
+	if ok {
+		es, err := el.Value.(*entry).value.Size()
+		if err != nil {
+			return fmt.Errorf("couldn't determine size of existing"+
+				"cache value %v", err)
+		}
+		c.ll.Remove(el)
+		c.size -= es
+	}
+
+	// Then we need to make sure we have enough space for the element, evict
+	// elements if we need more space.
+	if err := c.evict(vs); err != nil {
+		return err
+	}
+
+	// We have made enough space in the cache, so just insert it.
+	el = c.ll.PushFront(&entry{key, value})
+	c.cache[key] = el
+	c.size += vs
+
+	return nil
+}
+
+// Get will return value for a given key, making the element the most recently
+// accessed item in the process. Will return nil if the key isn't found.
+func (c *Cache) Get(key interface{}) (cache.Value, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	el, ok := c.cache[key]
+	if !ok {
+		// Element not found in the cache.
+		return nil, cache.ErrElementNotFound
+	}
+
+	// When the cache needs to evict a element to make space for another
+	// one, it starts eviction from the back, so by moving this element to
+	// the front, it's eviction is delayed because it's recently accessed.
+	c.ll.MoveToFront(el)
+	return el.Value.(*entry).value, nil
+}
+
+// Len returns number of elements in the cache.
+func (c *Cache) Len() int {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+
+	return c.ll.Len()
+}

--- a/cache/lru/lru_test.go
+++ b/cache/lru/lru_test.go
@@ -1,0 +1,308 @@
+package lru
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/lightninglabs/neutrino/cache"
+)
+
+func assertEqual(t *testing.T, a interface{}, b interface{}, message string) {
+	if a == b {
+		return
+	}
+	if len(message) == 0 {
+		message = fmt.Sprintf("%v != %v", a, b)
+	}
+	t.Fatal(message)
+}
+
+// sizeable is a simple struct that represents an element of arbitrary size
+// which holds a simple integer.
+type sizeable struct {
+	value int
+	size  uint64
+}
+
+// Size implements the CacheEntry interface on sizeable struct.
+func (s *sizeable) Size() (uint64, error) {
+	return s.size, nil
+}
+
+// getSizeableValue is a helper method used for converting the cache.Value
+// interface to sizeable struct and extracting the value from it.
+func getSizeableValue(generic cache.Value, _ error) int {
+	return generic.(*sizeable).value
+}
+
+// TestEmptyCacheSizeZero will check that an empty cache has a size of 0.
+func TestEmptyCacheSizeZero(t *testing.T) {
+	t.Parallel()
+	c := NewCache(10)
+	assertEqual(t, c.Len(), 0, "")
+}
+
+// TestCacheNeverExceedsSize inserts many filters into the cache and verifies
+// at each step that the cache never exceeds it's initial size.
+func TestCacheNeverExceedsSize(t *testing.T) {
+	t.Parallel()
+	c := NewCache(2)
+	c.Put(1, &sizeable{value: 1, size: 1})
+	c.Put(2, &sizeable{value: 2, size: 1})
+	assertEqual(t, c.Len(), 2, "")
+	for i := 0; i < 10; i++ {
+		c.Put(i, &sizeable{value: i, size: 1})
+		assertEqual(t, c.Len(), 2, "")
+	}
+}
+
+// TestCacheAlwaysHasLastAccessedItems will check that the last items that
+// were put in the cache are always available, it will also check the eviction
+// behavior when items put in the cache exceeds cache capacity.
+func TestCacheAlwaysHasLastAccessedItems(t *testing.T) {
+	t.Parallel()
+	c := NewCache(2)
+	c.Put(1, &sizeable{value: 1, size: 1})
+	c.Put(2, &sizeable{value: 2, size: 1})
+	two := getSizeableValue(c.Get(2))
+	one := getSizeableValue(c.Get(1))
+	assertEqual(t, two, 2, "")
+	assertEqual(t, one, 1, "")
+
+	c = NewCache(2)
+	c.Put(1, &sizeable{value: 1, size: 1})
+	c.Put(2, &sizeable{value: 2, size: 1})
+	c.Put(3, &sizeable{value: 3, size: 1})
+	oneEntry, _ := c.Get(1)
+	two = getSizeableValue(c.Get(2))
+	three := getSizeableValue(c.Get(3))
+	assertEqual(t, oneEntry, nil, "")
+	assertEqual(t, two, 2, "")
+	assertEqual(t, three, 3, "")
+
+	c = NewCache(2)
+	c.Put(1, &sizeable{value: 1, size: 1})
+	c.Put(2, &sizeable{value: 2, size: 1})
+	c.Get(1)
+	c.Put(3, &sizeable{value: 3, size: 1})
+	one = getSizeableValue(c.Get(1))
+	twoEntry, _ := c.Get(2)
+	three = getSizeableValue(c.Get(3))
+	assertEqual(t, one, 1, "")
+	assertEqual(t, twoEntry, nil, "")
+	assertEqual(t, three, 3, "")
+}
+
+// TestElementSizeCapacityEvictsEverything tests that Cache evicts everything
+// from cache when an element with size=capacity is inserted.
+func TestElementSizeCapacityEvictsEverything(t *testing.T) {
+	t.Parallel()
+	c := NewCache(3)
+
+	c.Put(1, &sizeable{value: 1, size: 1})
+	c.Put(2, &sizeable{value: 2, size: 1})
+	c.Put(3, &sizeable{value: 3, size: 1})
+
+	// Insert element with size=capacity of cache, should evict everything.
+	c.Put(4, &sizeable{value: 4, size: 3})
+	assertEqual(t, c.Len(), 1, "")
+	assertEqual(t, len(c.cache), 1, "")
+	four := getSizeableValue(c.Get(4))
+	assertEqual(t, four, 4, "")
+
+	c = NewCache(6)
+	c.Put(1, &sizeable{value: 1, size: 1})
+	c.Put(2, &sizeable{value: 2, size: 2})
+	c.Put(3, &sizeable{value: 3, size: 3})
+	assertEqual(t, c.size, uint64(6), "")
+
+	// Insert element with size=capacity of cache.
+	c.Put(4, &sizeable{value: 4, size: 6})
+	assertEqual(t, c.Len(), 1, "")
+	assertEqual(t, len(c.cache), 1, "")
+	four = getSizeableValue(c.Get(4))
+	assertEqual(t, four, 4, "")
+}
+
+// TestCacheFailsInsertionSizeBiggerCapacity tests that the cache fails the
+// put operation when the element's size is bigger than it's capacity.
+func TestCacheFailsInsertionSizeBiggerCapacity(t *testing.T) {
+	t.Parallel()
+	c := NewCache(2)
+
+	err := c.Put(1, &sizeable{value: 1, size: 3})
+	if err == nil {
+		t.Fatal("shouldn't be able to put elements larger than cache")
+	}
+	assertEqual(t, c.Len(), 0, "")
+}
+
+// TestManySmallElementCanInsertAfterBigEviction tests that when a big element
+// is evicted from the Cache, multiple smaller ones can be inserted without an
+// eviction taking place.
+func TestManySmallElementCanInsertAfterBigEviction(t *testing.T) {
+	t.Parallel()
+	c := NewCache(3)
+
+	err := c.Put(1, &sizeable{value: 1, size: 3})
+	if err != nil {
+		t.Fatal("couldn't insert element")
+	}
+
+	assertEqual(t, c.Len(), 1, "")
+
+	c.Put(2, &sizeable{value: 2, size: 1})
+	two := getSizeableValue(c.Get(2))
+	oneEntry, _ := c.Get(1)
+	assertEqual(t, c.Len(), 1, "")
+	assertEqual(t, two, 2, "")
+	assertEqual(t, oneEntry, nil, "")
+
+	c.Put(3, &sizeable{value: 3, size: 1})
+	assertEqual(t, c.Len(), 2, "")
+
+	c.Put(4, &sizeable{value: 4, size: 1})
+	assertEqual(t, c.Len(), 3, "")
+
+	two = getSizeableValue(c.Get(2))
+	three := getSizeableValue(c.Get(3))
+	four := getSizeableValue(c.Get(4))
+	assertEqual(t, two, 2, "")
+	assertEqual(t, three, 3, "")
+	assertEqual(t, four, 4, "")
+}
+
+// TestReplacingElementValueSmallerSize tests that if an existing element is
+// replaced with a value of size smaller, that the size shrinks and we can
+// insert without an eviction taking place.
+func TestReplacingElementValueSmallerSize(t *testing.T) {
+	t.Parallel()
+	c := NewCache(2)
+
+	c.Put(1, &sizeable{value: 1, size: 2})
+
+	c.Put(1, &sizeable{value: 1, size: 1})
+	c.Put(2, &sizeable{value: 2, size: 1})
+	one := getSizeableValue(c.Get(1))
+	two := getSizeableValue(c.Get(2))
+	assertEqual(t, one, 1, "")
+	assertEqual(t, two, 2, "")
+	assertEqual(t, c.Len(), 2, "")
+}
+
+// TestReplacingElementValueBiggerSize tests that if an existing element is
+// replaced with a value of size bigger, that it evicts accordingly.
+func TestReplacingElementValueBiggerSize(t *testing.T) {
+	t.Parallel()
+	c := NewCache(2)
+
+	c.Put(1, &sizeable{value: 1, size: 1})
+	c.Put(2, &sizeable{value: 2, size: 1})
+
+	c.Put(1, &sizeable{value: 3, size: 2})
+	assertEqual(t, c.Len(), 1, "")
+	one := getSizeableValue(c.Get(1))
+	assertEqual(t, one, 3, "")
+}
+
+// TestConcurrencySimple is a very simple test that checks concurrent access to
+// the lru cache. When running the test, "-race" option should be passed to
+// "go test" command.
+func TestConcurrencySimple(t *testing.T) {
+	t.Parallel()
+	c := NewCache(5)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			err := c.Put(i, &sizeable{value: i, size: 1})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}(i)
+	}
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := c.Get(i)
+			if err != nil && err != cache.ErrElementNotFound {
+				t.Fatal(err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestConcurrencySmallCache is a test that checks concurrent access to the
+// lru cache when the cache is smaller than the number of elements we want to
+// put and retrieve. When running the test, "-race" option should be passed to
+// "go test" command.
+func TestConcurrencySmallCache(t *testing.T) {
+	t.Parallel()
+	c := NewCache(5)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			err := c.Put(i, &sizeable{value: i, size: 1})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}(i)
+	}
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := c.Get(i)
+			if err != nil && err != cache.ErrElementNotFound {
+				t.Fatal(err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestConcurrencyBigCache is a test that checks concurrent access to the
+// lru cache when the cache is bigger than the number of elements we want to
+// put and retrieve. When running the test, "-race" option should be passed to
+// "go test" command.
+func TestConcurrencyBigCache(t *testing.T) {
+	t.Parallel()
+	c := NewCache(100)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			err := c.Put(i, &sizeable{value: i, size: 1})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}(i)
+	}
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := c.Get(i)
+			if err != nil && err != cache.ErrElementNotFound {
+				t.Fatal(err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}

--- a/query.go
+++ b/query.go
@@ -64,6 +64,12 @@ type queryOptions struct {
 	// doneChan lets the query signal the caller when it's done, in case
 	// it's run in a goroutine.
 	doneChan chan<- struct{}
+
+	// persistToDisk indicates whether the filter should also be written
+	// to disk in addition to the memory cache. For "normal" wallets, they'll
+	// almost never need to re-match a filter once it's been fetched unless
+	// they're doing something like a key import.
+	persistToDisk bool
 }
 
 // QueryOption is a functional option argument to any of the network query
@@ -127,6 +133,14 @@ func Encoding(encoding wire.MessageEncoding) QueryOption {
 func DoneChan(doneChan chan<- struct{}) QueryOption {
 	return func(qo *queryOptions) {
 		qo.doneChan = doneChan
+	}
+}
+
+// PersistToDisk allows the caller to tell that the filter should be kept
+// on disk once it's found.
+func PersistToDisk() QueryOption {
+	return func(qo *queryOptions) {
+		qo.persistToDisk = true
 	}
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,144 @@
+package neutrino
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcutil/gcs"
+	"github.com/btcsuite/btcutil/gcs/builder"
+	"github.com/lightninglabs/neutrino/cache"
+	"github.com/lightninglabs/neutrino/cache/lru"
+	"github.com/lightninglabs/neutrino/filterdb"
+)
+
+// genRandomBlockHash generates a random block hash using math/rand.
+func genRandomBlockHash() *chainhash.Hash {
+	var seed [32]byte
+	rand.Read(seed[:])
+	hash := chainhash.Hash(seed)
+	return &hash
+}
+
+// getRandFilter generates a random GCS filter that contains numElements. It
+// will then convert that filter into CacheableFilter to compute it's size for
+// convenience. It will return the filter along with it's size and randomly
+// generated block hash. testing.T is passed in as a convenience to deal with
+// errors in this method and making the test code more straigthforward. Method
+// originally taken from filterdb/db_test.go.
+func genRandFilter(numElements uint32, t *testing.T) (
+	*chainhash.Hash, *gcs.Filter, uint64) {
+	elements := make([][]byte, numElements)
+	for i := uint32(0); i < numElements; i++ {
+		var elem [20]byte
+		if _, err := rand.Read(elem[:]); err != nil {
+			t.Fatalf("unable to create random filter: %v", err)
+			return nil, nil, 0
+		}
+
+		elements[i] = elem[:]
+	}
+
+	var key [16]byte
+	if _, err := rand.Read(key[:]); err != nil {
+		t.Fatalf("unable to create random filter: %v", err)
+		return nil, nil, 0
+	}
+
+	filter, err := gcs.BuildGCSFilter(
+		builder.DefaultP, builder.DefaultM, key, elements)
+	if err != nil {
+		t.Fatalf("unable to create random filter: %v", err)
+		return nil, nil, 0
+	}
+
+	// Convert into CacheableFilter and compute Size.
+	c := &cache.CacheableFilter{Filter: filter}
+	s, err := c.Size()
+	if err != nil {
+		t.Fatalf("unable to create random filter: %v", err)
+		return nil, nil, 0
+	}
+
+	return genRandomBlockHash(), filter, s
+}
+
+// getFilter is a convenience method which will extract a value from the cache
+// and handle errors, it makes the test code easier to follow.
+func getFilter(cs *ChainService, b *chainhash.Hash, t *testing.T) *gcs.Filter {
+	val, err := cs.getFilterFromCache(b, filterdb.RegularFilter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return val
+}
+
+func assertEqual(t *testing.T, a interface{}, b interface{}, message string) {
+	if a == b {
+		return
+	}
+	if len(message) == 0 {
+		message = fmt.Sprintf("%v != %v", a, b)
+	}
+	t.Fatal(message)
+}
+
+// TestCacheBigEnoughHoldsAllFilter creates a cache big enough to hold all
+// filters, then gets them in random order and makes sure they are always there.
+func TestCacheBigEnoughHoldsAllFilter(t *testing.T) {
+	// Create different sized filters.
+	b1, f1, s1 := genRandFilter(1, t)
+	b2, f2, s2 := genRandFilter(10, t)
+	b3, f3, s3 := genRandFilter(100, t)
+
+	cs := &ChainService{
+		FilterCache: lru.NewCache(s1 + s2 + s3),
+	}
+
+	// Insert those filters into the cache making sure nothing gets evicted.
+	assertEqual(t, cs.FilterCache.Len(), 0, "")
+	cs.putFilterToCache(b1, filterdb.RegularFilter, f1)
+	assertEqual(t, cs.FilterCache.Len(), 1, "")
+	cs.putFilterToCache(b2, filterdb.RegularFilter, f2)
+	assertEqual(t, cs.FilterCache.Len(), 2, "")
+	cs.putFilterToCache(b3, filterdb.RegularFilter, f3)
+	assertEqual(t, cs.FilterCache.Len(), 3, "")
+
+	// Check that we can get those filters back independent of Get order.
+	assertEqual(t, getFilter(cs, b1, t), f1, "")
+	assertEqual(t, getFilter(cs, b2, t), f2, "")
+	assertEqual(t, getFilter(cs, b3, t), f3, "")
+	assertEqual(t, getFilter(cs, b2, t), f2, "")
+	assertEqual(t, getFilter(cs, b3, t), f3, "")
+	assertEqual(t, getFilter(cs, b1, t), f1, "")
+	assertEqual(t, getFilter(cs, b3, t), f3, "")
+
+	assertEqual(t, cs.FilterCache.Len(), 3, "")
+}
+
+// TestBigFilterEvictsEverything creates a cache big enough to hold a large
+// filter and inserts many smaller filters into. Then it inserts the big filter
+// and verifies that it's the only one remaining.
+func TestBigFilterEvictsEverything(t *testing.T) {
+	// Create different sized filters.
+	b1, f1, _ := genRandFilter(1, t)
+	b2, f2, _ := genRandFilter(3, t)
+	b3, f3, s3 := genRandFilter(10, t)
+
+	cs := &ChainService{
+		FilterCache: lru.NewCache(s3),
+	}
+
+	// Insert the smaller filters.
+	assertEqual(t, cs.FilterCache.Len(), 0, "")
+	cs.putFilterToCache(b1, filterdb.RegularFilter, f1)
+	assertEqual(t, cs.FilterCache.Len(), 1, "")
+	cs.putFilterToCache(b2, filterdb.RegularFilter, f2)
+	assertEqual(t, cs.FilterCache.Len(), 2, "")
+
+	// Insert the big filter and check all previous filters are evicted.
+	cs.putFilterToCache(b3, filterdb.RegularFilter, f3)
+	assertEqual(t, cs.FilterCache.Len(), 1, "")
+	assertEqual(t, getFilter(cs, b3, t), f3, "")
+}


### PR DESCRIPTION
Resolves #65.

First attempt at the filter cache.
A few things:
- ended up writing a very basic LRU instead of including the lib I pointed out (though it would have been a very lightweight dependency...),
- parse the queryOptions twice to see if persistToDisk was set, seems ugly, but otherwise, it would be necessary to parse it in GetCFilter and change the `queryPeers` signature to take a final queryOption, but then all the callers of `queryPeers` will need to parse it too.
- regular and extended filters share the same cache, should they have different caches ?
- default cache size is 20.