### PR TITLE
early draft: batch filter fetch

### DIFF
--- a/query.go
+++ b/query.go
@@ -696,16 +696,17 @@ func (s *ChainService) GetCFilter(filterType wire.FilterType,
 	// In addition to fetching the block header, we'll fetch the filter
 	// headers (for this particular filter type) from the database. These
 	// are required in order to verify the authenticity of the filter.
-	curHeader, err := getHeader(&stopHash)
-	if err != nil {
-		return nil, fmt.Errorf("Couldn't get cfheader for block %s "+
-			"from database", stopHash)
-	}
-	prevHeader, err := getHeader(&block.PrevBlock)
-	if err != nil {
-		return nil, fmt.Errorf("Couldn't get cfheader for block %s "+
-			"from database", stopHash)
-	}
+	// NEED TO BATCH VERIFY.
+	// curHeader, err := getHeader(&stopHash)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("Couldn't get cfheader for block %s "+
+	// 		"from database", stopHash)
+	// }
+	// prevHeader, err := getHeader(&block.PrevBlock)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("Couldn't get cfheader for block %s "+
+	// 		"from database", stopHash)
+	// }
 
 	// With all the necessary items retrieved, we'll launch our concurrent
 	// query to the set of connected peers.
@@ -752,12 +753,13 @@ func (s *ChainService) GetCFilter(filterType wire.FilterType,
 				// for the header _after_ the filter in the
 				// chain checks out. If not, we can ignore this
 				// response.
-				if gotHeader, err := builder.
-					MakeHeaderForFilter(gotFilter,
-						*prevHeader); err != nil ||
-					gotHeader != *curHeader {
-					return
-				}
+				// WILL NEED TO KEEP TRACK OF HEADERS TO BATCH VERIFY
+				// if gotHeader, err := builder.
+				// 	MakeHeaderForFilter(gotFilter,
+				// 		*prevHeader); err != nil ||
+				// 	gotHeader != *curHeader {
+				// 	return
+				// }
 
 				// At this point, the filter matches what we
 				// know about it and we declare it sane. We can

--- a/query.go
+++ b/query.go
@@ -628,8 +628,10 @@ checkResponses:
 // cfilter from the network and writes it to the database. If extended is true,
 // an extended filter will be queried for. Otherwise, we'll fetch the regular
 // filter.
-func (s *ChainService) GetCFilter(blockHash chainhash.Hash,
-	filterType wire.FilterType, options ...QueryOption) (*gcs.Filter,
+func (s *ChainService) GetCFilter(filterType wire.FilterType,
+	startHeight uint32,
+	stopHash chainhash.Hash,
+	options ...QueryOption) (*gcs.Filter,
 	error) {
 	// Only get one CFilter at a time to avoid redundancy from mutliple
 	// rescans running at once.
@@ -647,7 +649,7 @@ func (s *ChainService) GetCFilter(blockHash chainhash.Hash,
 
 	// First check the database to see if we already have this filter. If
 	// so, then we can return it an exit early.
-	filter, err := s.FilterDB.FetchFilter(&blockHash, dbFilterType)
+	filter, err := s.FilterDB.FetchFilter(&stopHash, dbFilterType)
 	if err == nil && filter != nil {
 		return filter, nil
 	}
@@ -659,34 +661,34 @@ func (s *ChainService) GetCFilter(blockHash chainhash.Hash,
 	// In order to verify the authenticity of the filter, we'll fetch the
 	// target block header so we can retrieve the hash of the prior block,
 	// which is required to fetch the filter header for that block.
-	block, height, err := s.BlockHeaders.FetchHeader(&blockHash)
+	block, height, err := s.BlockHeaders.FetchHeader(&stopHash)
 	if err != nil {
 		return nil, err
 	}
-	if block.BlockHash() != blockHash {
+	if block.BlockHash() != stopHash {
 		return nil, fmt.Errorf("Couldn't get header for block %s "+
-			"from database", blockHash)
+			"from database", stopHash)
 	}
 
 	// In addition to fetching the block header, we'll fetch the filter
 	// headers (for this particular filter type) from the database. These
 	// are required in order to verify the authenticity of the filter.
-	curHeader, err := getHeader(&blockHash)
+	curHeader, err := getHeader(&stopHash)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get cfheader for block %s "+
-			"from database", blockHash)
+			"from database", stopHash)
 	}
 	prevHeader, err := getHeader(&block.PrevBlock)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get cfheader for block %s "+
-			"from database", blockHash)
+			"from database", stopHash)
 	}
 
 	// With all the necessary items retrieved, we'll launch our concurrent
 	// query to the set of connected peers.
 	s.queryPeers(
 		// Send a wire.MsgGetCFilters
-		wire.NewMsgGetCFilters(filterType, height, &blockHash),
+		wire.NewMsgGetCFilters(filterType, height, &stopHash),
 
 		// Check responses and if we get one that matches, end the
 		// query early.
@@ -703,7 +705,7 @@ func (s *ChainService) GetCFilter(blockHash chainhash.Hash,
 
 				// If the response doesn't match our request.
 				// Ignore this message.
-				if blockHash != response.BlockHash ||
+				if stopHash != response.BlockHash ||
 					filterType != response.FilterType {
 					return
 				}
@@ -742,13 +744,13 @@ func (s *ChainService) GetCFilter(blockHash chainhash.Hash,
 
 	// If we've found a filter, write it to the database for next time.
 	if filter != nil {
-		err := s.FilterDB.PutFilter(&blockHash, filter, dbFilterType)
+		err := s.FilterDB.PutFilter(&stopHash, filter, dbFilterType)
 		if err != nil {
 			return nil, err
 		}
 
 		log.Tracef("Wrote filter for block %s, type %d",
-			blockHash, filterType)
+			stopHash, filterType)
 	}
 
 	return filter, nil

--- a/rescan.go
+++ b/rescan.go
@@ -539,7 +539,7 @@ func (s *ChainService) blockFilterMatches(ro *rescanOptions,
 	blockHash *chainhash.Hash) (bool, error) {
 
 	key := builder.DeriveKey(blockHash)
-	bFilter, err := s.GetCFilter(*blockHash, wire.GCSFilterRegular)
+	bFilter, err := s.GetCFilter(wire.GCSFilterRegular, 0, *blockHash)
 	if err != nil {
 		if err == headerfs.ErrHashNotFound {
 			// Block has been reorged out from under us.
@@ -960,8 +960,8 @@ func (s *ChainService) GetUtxo(options ...RescanOption) (*SpendReport, error) {
 	for {
 		// Check the basic filter for the spend and the extended filter
 		// for the transaction in which the outpoint is funded.
-		filter, err := s.GetCFilter(curStamp.Hash,
-			wire.GCSFilterRegular, ro.queryOptions...)
+		filter, err := s.GetCFilter(wire.GCSFilterRegular, 0, curStamp.Hash,
+			ro.queryOptions...)
 		if err != nil {
 			return nil, fmt.Errorf("Couldn't get basic "+
 				"filter for block %d (%s)", curStamp.Height,

--- a/sync_test.go
+++ b/sync_test.go
@@ -859,8 +859,8 @@ func testRandomBlocks(harness *neutrinoHarness, t *testing.T) {
 				return
 			}
 			// Get basic cfilter from network.
-			haveFilter, err := harness.svc.GetCFilter(blockHash,
-				wire.GCSFilterRegular, queryOptions...)
+			haveFilter, err := harness.svc.GetCFilter(wire.GCSFilterRegular,
+				0, blockHash, queryOptions...)
 			if err != nil {
 				errChan <- err
 				return
@@ -954,8 +954,8 @@ func testRandomBlocks(harness *neutrinoHarness, t *testing.T) {
 				return
 			}
 			// Get extended cfilter from network
-			haveFilter, err = harness.svc.GetCFilter(blockHash,
-				wire.GCSFilterExtended, queryOptions...)
+			haveFilter, err = harness.svc.GetCFilter(wire.GCSFilterExtended,
+				0, blockHash, queryOptions...)
 			if err != nil {
 				errChan <- err
 				return


### PR DESCRIPTION
This is just a draft to see if it's headed in the right direction.

A few questions I have is:
- should the return type from GetCFilter be an array of filters or a map of hash->filter ?
- should the same query be dispatched to one peer at a time until answered or broken up into multiple pieces and sent to different peers ? for example, say caller asks for filters 100-to-200, do we send that request to a peer, or should we do 100-to-150 from 1 peer and 150-to-200 from another peer ?
- I noticed that there are some functions are quite large, getcfilter itself is >100lines, it's relatively easy to follow, but difficult to unit-test individual parts, just wondering if integration tests are considered good enough ?

github context: https://github.com/lightninglabs/neutrino/issues/68