### PR TITLE
rescan: use proper chan for filter re-fetch retries, close rescan loop if blocks are missed

### DIFF
--- a/rescan.go
+++ b/rescan.go
@@ -577,6 +577,12 @@ rescanLoop:
 
 				current = true
 
+				// Ensure we cancel the old subscroption if
+				// we're going back to scan for missed blocks.
+				if subscription != nil {
+					s.unsubscribeBlockMsgs(subscription)
+				}
+
 				// Subscribe to block notifications.
 				subscription, err = s.subscribeBlockMsg(
 					uint32(curStamp.Height), blockConnected,

--- a/rescan.go
+++ b/rescan.go
@@ -413,6 +413,12 @@ rescanLoop:
 						header.PrevBlock,
 						curStamp.Hash)
 
+					// If we've somehow missed a header in
+					// the range, then we'll mark ourselves
+					// as not current so we can walk down
+					// the chain and notify the callers of
+					// blocks we may have missed.
+					current = false
 					continue rescanLoop
 				}
 


### PR DESCRIPTION

In this PR,  we fix an existing bug that would prevent us from
actually re-fetching filter header that we missed either due to the peer
not responding, us fetching from the peer while it was mid-reorg, or the
peer simply not being synced yet. We also lower the retry interval to
force us to the best chain tip more aggressively.


We also add an additional level of defense to ensure that
we'll properly sync our rescan state to the current best chain tip.
Before this commit, if our retry timer failed to trigger, or we overrode
the timer with a newer block hash, then we should fail to properly
re-process all blocks before that last timer tick and our past rescan
chain tip. By setting current to false here, we'll now talk forwards in
the chain, catching up on any missed blocks in the process.