### PR TITLE
utxoscanner: break get utxo

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,9 @@ package neutrino
 import "errors"
 
 var (
+	// ErrGetUtxoCancelled signals that a GetUtxo request was cancelled.
+	ErrGetUtxoCancelled = errors.New("get utxo request cancelled")
+
 	// ErrShuttingDown signals that neutrino received a shutdown request.
 	ErrShuttingDown = errors.New("neutrino shutting down")
 )

--- a/rescan.go
+++ b/rescan.go
@@ -1167,7 +1167,7 @@ func (s *ChainService) GetUtxo(options ...RescanOption) (*SpendReport, error) {
 
 	// Wait for the result to be delivered by the rescan or until a shutdown
 	// is signaled.
-	report, err := req.Result()
+	report, err := req.Result(ro.quit)
 	if err != nil {
 		log.Debugf("Error finding spends for %s: %v",
 			ro.watchInputs[0].OutPoint.String(), err)

--- a/utxoscanner_test.go
+++ b/utxoscanner_test.go
@@ -348,7 +348,7 @@ func TestUtxoScannerScanBasic(t *testing.T) {
 		t.Fatalf("unable to enqueue utxo scan request: %v", err)
 	}
 
-	spendReport, scanErr = req.Result()
+	spendReport, scanErr = req.Result(nil)
 	if scanErr != nil {
 		t.Fatalf("unable to complete scan for utxo: %v", scanErr)
 	}
@@ -420,7 +420,7 @@ func TestUtxoScannerScanAddBlocks(t *testing.T) {
 	waitForSnapshot <- struct{}{}
 	waitForSnapshot <- struct{}{}
 
-	spendReport, scanErr = req.Result()
+	spendReport, scanErr = req.Result(nil)
 
 	if scanErr != nil {
 		t.Fatalf("unable to complete scan for utxo: %v", scanErr)


### PR DESCRIPTION
This PR adds the ability to cancel GetUtxo
requests via two means:
 * a configurable cancel channel
 * automatically when shutting down the utxoscanner

The first is accomplished by selecting on an extra
cancel, which returns ErrGetUtxoCancelled if signaled
before the result has arrived.

The second iterates through all requests which have
been queued but not started, and cancels them all
with ErrGetUtxoCancelled. This should enable to
dependent systems to break out of long-running
queries, especially during shutdown.