### PR TITLE
Fix rescan update deadlock

### DIFF
--- a/rescan.go
+++ b/rescan.go
@@ -1033,10 +1033,11 @@ func (r *Rescan) Start() <-chan error {
 
 	r.wg.Add(1)
 	go func() {
+		defer r.wg.Done()
+
 		rescanArgs := append(r.options, updateChan(r.updateChan))
 		err := r.chain.rescan(rescanArgs...)
 
-		r.wg.Done()
 		close(r.running)
 
 		r.errMtx.Lock()

--- a/rescan.go
+++ b/rescan.go
@@ -4,6 +4,7 @@ package neutrino
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -19,6 +20,12 @@ import (
 	"github.com/btcsuite/btcutil/gcs/builder"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/lightninglabs/neutrino/headerfs"
+)
+
+var (
+	// ErrRescanExit is an error returned to the caller in case the ongoing
+	// rescan exits.
+	ErrRescanExit = errors.New("rescan exited")
 )
 
 // rescanOptions holds the set of functional parameters for Rescan.
@@ -286,7 +293,7 @@ func (s *ChainService) rescan(options ...RescanOption) error {
 		select {
 		case <-ro.quit:
 			s.blockManager.newFilterHeadersMtx.Unlock()
-			return nil
+			return ErrRescanExit
 		default:
 		}
 	}
@@ -373,7 +380,7 @@ rescanLoop:
 			select {
 
 			case <-ro.quit:
-				return nil
+				return ErrRescanExit
 
 			// An update mesage has just come across, if it points
 			// to a prior point in the chain, then we may need to

--- a/rescan.go
+++ b/rescan.go
@@ -159,9 +159,9 @@ func updateChan(update <-chan *updateOptions) RescanOption {
 	}
 }
 
-// Rescan is a single-threaded function that uses headers from the database and
+// rescan is a single-threaded function that uses headers from the database and
 // functional options as arguments.
-func (s *ChainService) Rescan(options ...RescanOption) error {
+func (s *ChainService) rescan(options ...RescanOption) error {
 	// First, we'll apply the set of default options, then serially apply
 	// all the options that've been passed in.
 	ro := defaultRescanOptions()
@@ -1020,7 +1020,7 @@ func (r *Rescan) Start() <-chan error {
 	r.wg.Add(1)
 	go func() {
 		rescanArgs := append(r.options, updateChan(r.updateChan))
-		err := r.chain.Rescan(rescanArgs...)
+		err := r.chain.rescan(rescanArgs...)
 
 		r.wg.Done()
 		atomic.StoreUint32(&r.running, 0)

--- a/sync_test.go
+++ b/sync_test.go
@@ -762,6 +762,14 @@ func testRescanResults(harness *neutrinoHarness, t *testing.T) {
 	if err != neutrino.ErrRescanExit {
 		t.Fatalf("Rescan ended with error: %s", err)
 	}
+
+	// Immediately try to add a new update to to the rescan that was just
+	// shut down. This should fail as it is no longer running.
+	rescan.WaitForShutdown()
+	err = rescan.Update(neutrino.AddAddrs(addr2), neutrino.Rewind(1095))
+	if err == nil {
+		t.Fatalf("Expected update call to fail, it did not")
+	}
 }
 
 // testRandomBlocks goes through all blocks in random order and ensures we can

--- a/sync_test.go
+++ b/sync_test.go
@@ -759,7 +759,7 @@ func testRescanResults(harness *neutrinoHarness, t *testing.T) {
 	close(quitRescan)
 	err = <-errChan
 	quitRescan = nil
-	if err != nil {
+	if err != neutrino.ErrRescanExit {
 		t.Fatalf("Rescan ended with error: %s", err)
 	}
 }


### PR DESCRIPTION
This PR fixes an issue within the current `neutrino` rescan logic, which would cause a send on the `updateChan` to block indefinitely. 

This was caused by a caller of `Update` killing the current rescan at the same time, making the update never being read from the channel.

This PR fixes that by ensuring an error is returned if the rescan exits while the update is being enqueued, moving the responsibility to handle this case to the caller.

NOTE: The caller in this case is `btcwallet`, which must be updated to handle the returned error.