### PR TITLE
query: cleanup unknown peers, prevent nil panic

### DIFF
--- a/query.go
+++ b/query.go
@@ -405,7 +405,8 @@ func (s *ChainService) queryBatch(
 		}
 
 		for peer, quitChan := range peerQuits {
-			if !s.PeerByAddr(peer).Connected() {
+			p := s.PeerByAddr(peer)
+			if p == nil || !p.Connected() {
 				close(quitChan)
 				close(matchSignals[peer])
 				delete(peerQuits, peer)


### PR DESCRIPTION
This commit fixes a known issue where that causes
the batch fetching to panic if the peer has been
removed from the peer set. If the peer is not
found, we initiate the cleanup logic as if the
peer were found, but no longer connected.