### PR TITLE
Make chain service API expose best block as min(block header, filter header)

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -330,7 +330,7 @@ func (b *blockManager) handleNewPeerMsg(peers *list.List, sp *ServerPeer) {
 			err)
 		return
 	}
-	if b.BlockHeadersSynced() && height < uint32(sp.StartingHeight()) {
+	if height < uint32(sp.StartingHeight()) && b.BlockHeadersSynced() {
 		locator, err := b.server.BlockHeaders.LatestBlockLocator()
 		if err != nil {
 			log.Criticalf("Couldn't retrieve latest block "+
@@ -2296,7 +2296,7 @@ func (b *blockManager) handleHeadersMsg(hmsg *headersMsg) {
 
 	// If not current, request the next batch of headers starting from the
 	// latest known header and ending with the next checkpoint.
-	if !b.BlockHeadersSynced() || b.server.chainParams.Net == chaincfg.SimNetParams.Net {
+	if b.server.chainParams.Net == chaincfg.SimNetParams.Net || !b.BlockHeadersSynced() {
 		locator := blockchain.BlockLocator([]*chainhash.Hash{finalHash})
 		nextHash := zeroHash
 		if b.nextCheckpoint != nil {

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1777,6 +1777,31 @@ func (b *blockManager) startSync(peers *list.List) {
 	}
 }
 
+// IsFullySynced returns whether or not the block manager believed it is fully
+// synced to the connected peers, meaning both block headers and filter headers
+// are current.
+func (b *blockManager) IsFullySynced() bool {
+	_, blockHeaderHeight, err := b.server.BlockHeaders.ChainTip()
+	if err != nil {
+		return false
+	}
+
+	_, filterHeaderHeight, err := b.server.RegFilterHeaders.ChainTip()
+	if err != nil {
+		return false
+	}
+
+	// If the block headers and filter headers are not at the same height,
+	// we cannot be fully synced.
+	if blockHeaderHeight != filterHeaderHeight {
+		return false
+	}
+
+	// Block and filter headers being at the same height, return whether
+	// our block headers are synced.
+	return b.BlockHeadersSynced()
+}
+
 // BlockHeadersSynced returns whether or not the block manager believes its
 // block headers are synced with the connected peers.
 func (b *blockManager) BlockHeadersSynced() bool {

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1698,7 +1698,7 @@ func (b *blockManager) startSync(peers *list.List) {
 		return
 	}
 
-	best, err := b.server.BestSnapshot()
+	_, bestHeight, err := b.server.BlockHeaders.ChainTip()
 	if err != nil {
 		log.Errorf("Failed to get hash and height for the "+
 			"latest block: %s", err)
@@ -1719,7 +1719,7 @@ func (b *blockManager) startSync(peers *list.List) {
 		// equal, it will likely have one soon so it is a reasonable
 		// choice.  It also allows the case where both are at 0 such as
 		// during regression test.
-		if sp.LastBlock() < best.Height {
+		if sp.LastBlock() < int32(bestHeight) {
 			peers.Remove(e)
 			continue
 		}
@@ -1757,15 +1757,15 @@ func (b *blockManager) startSync(peers *list.List) {
 		// If we're still within the range of the set checkpoints, then
 		// we'll use the next checkpoint to guide the set of headers we
 		// fetch, setting our stop hash to the next checkpoint hash.
-		if b.nextCheckpoint != nil && best.Height < b.nextCheckpoint.Height {
+		if b.nextCheckpoint != nil && int32(bestHeight) < b.nextCheckpoint.Height {
 			log.Infof("Downloading headers for blocks %d to "+
-				"%d from peer %s", best.Height+1,
+				"%d from peer %s", bestHeight+1,
 				b.nextCheckpoint.Height, bestPeer.Addr())
 
 			stopHash = b.nextCheckpoint.Hash
 		} else {
 			log.Infof("Fetching set of headers from tip "+
-				"(height=%v) from peer %s", best.Height,
+				"(height=%v) from peer %s", bestHeight,
 				bestPeer.Addr())
 		}
 

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1850,16 +1850,6 @@ func (b *blockManager) BlockHeadersSynced() bool {
 	return b.syncPeer.LastBlock() >= b.syncPeer.StartingHeight()
 }
 
-// FilterHeaderTip returns the current height of the filter header chain tip.
-//
-// NOTE: This method is safe for concurrent access.
-func (b *blockManager) FilterHeaderTip() uint32 {
-	b.newFilterHeadersMtx.RLock()
-	defer b.newFilterHeadersMtx.RUnlock()
-
-	return b.filterHeaderTip
-}
-
 // SynchronizeFilterHeaders allows the caller to execute a function closure
 // that depends on synchronization with the current set of filter headers. This
 // allows the caller to execute an action that depends on the current filter
@@ -1871,16 +1861,6 @@ func (b *blockManager) SynchronizeFilterHeaders(f func(uint32) error) error {
 	defer b.newFilterHeadersMtx.RUnlock()
 
 	return f(b.filterHeaderTip)
-}
-
-// BlockHeaderTip returns the current height of the block header chain tip.
-//
-// NOTE: This method is safe for concurrent access.
-func (b *blockManager) BlockHeaderTip() uint32 {
-	b.newHeadersMtx.RLock()
-	defer b.newHeadersMtx.RUnlock()
-
-	return b.headerTip
 }
 
 // QueueInv adds the passed inv message and peer to the block handling queue.

--- a/neutrino.go
+++ b/neutrino.go
@@ -1278,7 +1278,7 @@ func (s *ChainService) Stop() error {
 // IsCurrent lets the caller know whether the chain service's block manager
 // thinks its view of the network is current.
 func (s *ChainService) IsCurrent() bool {
-	return s.blockManager.BlockHeadersSynced()
+	return s.blockManager.IsFullySynced()
 }
 
 // PeerByAddr lets the caller look up a peer address in the service's peer

--- a/neutrino.go
+++ b/neutrino.go
@@ -1278,7 +1278,7 @@ func (s *ChainService) Stop() error {
 // IsCurrent lets the caller know whether the chain service's block manager
 // thinks its view of the network is current.
 func (s *ChainService) IsCurrent() bool {
-	return s.blockManager.IsCurrent()
+	return s.blockManager.BlockHeadersSynced()
 }
 
 // PeerByAddr lets the caller look up a peer address in the service's peer

--- a/neutrino.go
+++ b/neutrino.go
@@ -783,6 +783,24 @@ func (s *ChainService) GetBlockHash(height int64) (*chainhash.Hash, error) {
 	return &hash, err
 }
 
+// GetBlockHeader returns the block header for the given block hash, or an
+// error if the hash doesn't exist or is unknown.
+func (s *ChainService) GetBlockHeader(
+	blockHash *chainhash.Hash) (*wire.BlockHeader, error) {
+	header, _, err := s.BlockHeaders.FetchHeader(blockHash)
+	return header, err
+}
+
+// GetBlockHeight gets the height of a block by its hash. An error is returned
+// if the given block hash is unknown.
+func (s *ChainService) GetBlockHeight(hash *chainhash.Hash) (int32, error) {
+	_, height, err := s.BlockHeaders.FetchHeader(hash)
+	if err != nil {
+		return 0, err
+	}
+	return int32(height), nil
+}
+
 // BanPeer bans a peer that has already been connected to the server by ip.
 func (s *ChainService) BanPeer(sp *ServerPeer) {
 	s.banPeers <- sp

--- a/neutrino.go
+++ b/neutrino.go
@@ -742,21 +742,6 @@ func NewChainService(cfg Config) (*ChainService, error) {
 	return &s, nil
 }
 
-// BestSnapshot retrieves the most recent block headers's height and hash. Note
-// that filter headers may not be synced to the header chain yet, and you
-// probably want to use BestBlock.
-func (s *ChainService) BestSnapshot() (*waddrmgr.BlockStamp, error) {
-	bestHeader, bestHeight, err := s.BlockHeaders.ChainTip()
-	if err != nil {
-		return nil, err
-	}
-
-	return &waddrmgr.BlockStamp{
-		Height: int32(bestHeight),
-		Hash:   bestHeader.BlockHash(),
-	}, nil
-}
-
 // BestBlock retrieves the most recent block's height and hash where we
 // have both the header and filter header ready.
 func (s *ChainService) BestBlock() (*waddrmgr.BlockStamp, error) {

--- a/neutrino.go
+++ b/neutrino.go
@@ -732,7 +732,7 @@ func NewChainService(cfg Config) (*ChainService, error) {
 	}
 
 	s.utxoScanner = NewUtxoScanner(&UtxoScannerConfig{
-		BestSnapshot:       s.BestSnapshot,
+		BestSnapshot:       s.BestBlock,
 		GetBlockHash:       s.GetBlockHash,
 		BlockFilterMatches: s.blockFilterMatches,
 		GetBlock:           s.GetBlock,

--- a/rescan.go
+++ b/rescan.go
@@ -238,8 +238,11 @@ func (s *ChainService) rescan(options ...RescanOption) error {
 		curHeader wire.BlockHeader
 		curStamp  waddrmgr.BlockStamp
 	)
+
+	// If no start block is specified, start the scan from our current best
+	// block.
 	if ro.startBlock == nil {
-		bs, err := s.BestSnapshot()
+		bs, err := s.BestBlock()
 		if err != nil {
 			return err
 		}

--- a/rescan.go
+++ b/rescan.go
@@ -476,20 +476,6 @@ rescanLoop:
 					continue rescanLoop
 				}
 
-				// Do not process block until we have all
-				// filter headers. Don't worry, the block will
-				// get re-queued every time there is a new
-				// filter available. However, if it's a
-				// duplicate block notification, then we can
-				// re-process it without any issues.
-				if header.BlockHash() != curStamp.Hash &&
-					!s.hasFilterHeadersByHeight(uint32(curStamp.Height+1)) {
-					log.Warnf("Missing filter header for "+
-						"height=%v, skipping",
-						curStamp.Height+1)
-					continue rescanLoop
-				}
-
 				// As this could be a re-try, we'll ensure that
 				// we don't incorrectly increment our current
 				// time stamp.
@@ -499,8 +485,8 @@ rescanLoop:
 					curStamp.Height++
 				}
 
-				log.Tracef("Rescan got block %d (%s)", curStamp.Height,
-					curStamp.Hash)
+				log.Tracef("Rescan got block %d (%s)",
+					curStamp.Height, curStamp.Hash)
 
 				// We're only scanning if the header is beyond
 				// the horizon of our start time.
@@ -884,13 +870,6 @@ func (s *ChainService) blockFilterMatches(ro *rescanOptions,
 	// meantime, we return false if the basic filter didn't match our
 	// watch list.
 	return false, nil
-}
-
-// hasFilterHeadersByHeight checks whether both the basic and extended filter
-// headers for a particular height are known.
-func (s *ChainService) hasFilterHeadersByHeight(height uint32) bool {
-	_, regFetchErr := s.RegFilterHeaders.FetchHeaderByHeight(height)
-	return regFetchErr == nil
 }
 
 // updateFilter atomically updates the filter and rewinds to the specified

--- a/rescan.go
+++ b/rescan.go
@@ -525,6 +525,9 @@ rescanLoop:
 				// trying to fetch from are in the progress of
 				// a re-org.
 				if blockFilter == nil {
+					// TODO(halseth): this is racy, as
+					// blocks can come in before we
+					// refetch.
 					resetBlockReFetchTimer(
 						header, curStamp.Height,
 					)

--- a/rescan.go
+++ b/rescan.go
@@ -200,7 +200,9 @@ func (s *ChainService) rescan(options ...RescanOption) error {
 		// If the end block hash is non-nil, then we'll query the
 		// database to find out the stop height.
 		if (ro.endBlock.Hash != chainhash.Hash{}) {
-			_, height, err := s.BlockHeaders.FetchHeader(&ro.endBlock.Hash)
+			_, height, err := s.BlockHeaders.FetchHeader(
+				&ro.endBlock.Hash,
+			)
 			if err != nil {
 				ro.endBlock.Hash = chainhash.Hash{}
 			} else {
@@ -279,9 +281,9 @@ func (s *ChainService) rescan(options ...RescanOption) error {
 		}
 	}
 
-	s.blockManager.newFilterHeadersMtx.Lock()
+	s.blockManager.newFilterHeadersMtx.RLock()
 	filterHeaderHeight := s.blockManager.filterHeaderTip
-	s.blockManager.newFilterHeadersMtx.Unlock()
+	s.blockManager.newFilterHeadersMtx.RUnlock()
 
 	log.Debugf("Waiting for filter headers (height=%v) to catch up the "+
 		"rescan start (height=%v)", filterHeaderHeight, curStamp.Height)
@@ -605,7 +607,9 @@ rescanLoop:
 			for {
 				select {
 				case update := <-ro.update:
-					_, err := ro.updateFilter(update, &curStamp, &curHeader)
+					_, err := ro.updateFilter(
+						update, &curStamp, &curHeader,
+					)
 					if err != nil {
 						return err
 					}

--- a/sync_test.go
+++ b/sync_test.go
@@ -779,7 +779,7 @@ func testRescanResults(harness *neutrinoHarness, t *testing.T) {
 // TODO: Make this a benchmark instead.
 func testRandomBlocks(harness *neutrinoHarness, t *testing.T) {
 	var haveBest *waddrmgr.BlockStamp
-	haveBest, err := harness.svc.BestSnapshot()
+	haveBest, err := harness.svc.BestBlock()
 	if err != nil {
 		t.Fatalf("Couldn't get best snapshot from ChainService: %s", err)
 	}
@@ -1168,7 +1168,7 @@ func waitForSync(t *testing.T, svc *neutrino.ChainService,
 		t.Logf("Syncing to %d (%s)", knownBestHeight, knownBestHash)
 	}
 	var haveBest *waddrmgr.BlockStamp
-	haveBest, err = svc.BestSnapshot()
+	haveBest, err = svc.BestBlock()
 	if err != nil {
 		return fmt.Errorf("Couldn't get best snapshot from "+
 			"ChainService: %s", err)
@@ -1185,7 +1185,7 @@ func waitForSync(t *testing.T, svc *neutrino.ChainService,
 		}
 		time.Sleep(syncUpdate)
 		total += syncUpdate
-		haveBest, err = svc.BestSnapshot()
+		haveBest, err = svc.BestBlock()
 		if err != nil {
 			return fmt.Errorf("Couldn't get best snapshot from "+
 				"ChainService: %s", err)


### PR DESCRIPTION
This PR changes how the Neutrino `ChainService` is reporting the current best block. The best block known by the backend is now the minimum of the synced block headers and filter headers.

This fixes several issues seen, where the user of the ChainService would query for the best block, then attempt to use the chain from the reported height, even though Neutrino is not ready to handle queries before the filter headers are synced.

This also makes the `IsCurrent` API only report that we are current when filter headers are fully synced.

Builds on #98, #99 

Fixes #97 