### PR TITLE
Catch up filter headers and block headers in parallel

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -123,14 +123,14 @@ type blockManager struct {
 	// switch over.
 	newHeadersSignal *sync.Cond
 
-	// filterHeaderTip will be set to the current filter header tip at all
-	// times.  Callers MUST hold the lock below each time they read/write
-	// from this field.
+	// filterHeaderTip will be set to the height of the current filter
+	// header tip at all times.  Callers MUST hold the lock below each time
+	// they read/write from this field.
 	filterHeaderTip uint32
 
 	// filterHeaderTipHash will be set to the current block hash of the
-	// fitler header tip at all times.  Callers MUST hold the lock below
-	// each time they read/write from this field.
+	// block at height filterHeaderTip at all times.  Callers MUST hold the
+	// lock below each time they read/write from this field.
 	filterHeaderTipHash chainhash.Hash
 
 	// newFilterHeadersMtx is the mutex that should be held when
@@ -225,7 +225,14 @@ func newBlockManager(s *ChainService) (*blockManager, error) {
 	if err != nil {
 		return nil, err
 	}
-	bm.filterHeaderTipHash = header.BlockHash()
+
+	// We must also ensure the the filter header tip hash is set to the
+	// block hash at the filter tip height.
+	fh, err := s.BlockHeaders.FetchHeaderByHeight(bm.filterHeaderTip)
+	if err != nil {
+		return nil, err
+	}
+	bm.filterHeaderTipHash = fh.BlockHash()
 
 	return &bm, nil
 }

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -609,6 +609,8 @@ waitForHeaders:
 		); err != nil {
 			log.Debugf("couldn't get uncheckpointed headers for "+
 				"%v: %v", fType, err)
+
+			time.Sleep(QueryTimeout)
 		}
 
 		// Quit if requested.

--- a/neutrino.go
+++ b/neutrino.go
@@ -816,10 +816,11 @@ func (s *ChainService) rollBackToHeight(height uint32) (*waddrmgr.BlockStamp, er
 
 		// Only roll back filter headers if they've caught up this far.
 		if uint32(bs.Height) <= regHeight {
-			_, err = s.RegFilterHeaders.RollbackLastBlock(newTip)
+			newFilterTip, err := s.RegFilterHeaders.RollbackLastBlock(newTip)
 			if err != nil {
 				return nil, err
 			}
+			regHeight = uint32(newFilterTip.Height)
 		}
 
 		bs, err = s.BlockHeaders.RollbackLastBlock()


### PR DESCRIPTION
Catch up filter headers and block headers in parallel. 

Also includes a fix for rollback of filter headers, and a proper fix to what was attempted in #95.