### PR TITLE
blockmanager: remove queryResponse length check

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -881,23 +881,17 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 				// last written set of cfheaders.
 				curHeight = checkPointIndex * wire.CFCheckptInterval
 
-				// Break if we've gotten to the end of the
-				// responses or we don't have the next one.
-				if checkPointIndex >= uint32(len(queryResponses)) {
-					break
-				}
-
 				// If we don't yet have the next response, then
 				// we'll break out so we can wait for the peers
 				// to respond with this message.
-				r := queryResponses[checkPointIndex]
-				if r == nil {
+				r, ok := queryResponses[checkPointIndex]
+				if !ok {
 					break
 				}
 
 				// We have another response to write, so delete
 				// it from the cache and write it.
-				queryResponses[checkPointIndex] = nil
+				delete(queryResponses, checkPointIndex)
 
 				log.Debugf("Writing cfheaders at height=%v to "+
 					"next checkpoint", curHeight)


### PR DESCRIPTION
queryResponses was recently changed from being a slice to a map.
Previously a length check was performed to make sure we didn't index out
of bounds, but after the change to using a map this is no longer
correct.

This would be apparent doing header download from multiple peers, as
responses would come asynchronously, and the headers wouldn't be written
because of this check.