### PR TITLE
Handle async responses when getting checkpointed filters

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -765,7 +765,8 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 	// latest known checkpoint.
 	curHeader, curHeight, err := store.ChainTip()
 	if err != nil {
-		panic("getting chaintip from store")
+		panic(fmt.Sprintf("failed getting chaintip from filter "+
+			"store: %v", err))
 	}
 
 	initialFilterHeader := curHeader
@@ -813,14 +814,8 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 			endHeightRange,
 		)
 		if err != nil {
-			// Try to recover this.
-			select {
-			case <-b.quit:
-				return
-			case <-time.After(QueryTimeout):
-				currentInterval--
-				continue
-			}
+			panic(fmt.Sprintf("failed getting block header at "+
+				"height %v: %v", endHeightRange, err))
 		}
 		stopHash := stopHeader.BlockHash()
 

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -1,0 +1,230 @@
+package neutrino
+
+import (
+	"encoding/binary"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/lightninglabs/neutrino/headerfs"
+)
+
+// TestBlockManagerGetCheckpointedCFHeaders tests that the block manager is
+// able to handle multiple checkpointed filter header query responses in
+// parallel.
+func TestBlockManagerGetCheckpointedCFHeaders(t *testing.T) {
+	t.Parallel()
+
+	// Set up the block and filter header stores.
+	tempDir, err := ioutil.TempDir("", "neutrino")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %s", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	db, err := walletdb.Create("bdb", tempDir+"/weks.db")
+	if err != nil {
+		t.Fatalf("Error opening DB: %s", err)
+	}
+	defer db.Close()
+
+	hdrStore, err := headerfs.NewBlockHeaderStore(
+		tempDir, db, &chaincfg.SimNetParams,
+	)
+	if err != nil {
+		t.Fatalf("Error creating block header store: %s", err)
+	}
+
+	cfStore, err := headerfs.NewFilterHeaderStore(
+		tempDir, db, headerfs.RegularFilter, &chaincfg.SimNetParams,
+	)
+	if err != nil {
+		t.Fatalf("Error creating filter header store: %s", err)
+	}
+
+	// Keep track of the filter headers and block headers. Since the
+	// genesis headers are written automatically when the store is created,
+	// we query it to add to the slices.
+	genesisBlockHeader, _, err := hdrStore.ChainTip()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var blockHeaders []headerfs.BlockHeader
+	blockHeaders = append(blockHeaders, headerfs.BlockHeader{
+		BlockHeader: genesisBlockHeader,
+		Height:      0,
+	})
+
+	genesisFilterHeader, _, err := cfStore.ChainTip()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfHeaders []chainhash.Hash
+	cfHeaders = append(cfHeaders, *genesisFilterHeader)
+
+	// Also keep track of the current filter header. We use this to
+	// calculate the next filter header, as it commits to the previous.
+	currentCFHeader := *genesisFilterHeader
+
+	// checkpoints will be the checkpoints passed to
+	// getCheckpointedCFHeaders.
+	var checkpoints []*chainhash.Hash
+
+	maxHeight := 50 * uint32(wire.CFCheckptInterval)
+	for height := uint32(1); height <= maxHeight; height++ {
+		header := heightToHeader(height)
+		blockHeader := headerfs.BlockHeader{
+			BlockHeader: header,
+			Height:      height,
+		}
+
+		blockHeaders = append(blockHeaders, blockHeader)
+
+		// It doesn't really matter what filter the filter header
+		// commit to, so just use the height as a nonce.
+		filterHash := chainhash.Hash{}
+		binary.BigEndian.PutUint32(filterHash[:], height)
+		currentCFHeader = chainhash.DoubleHashH(
+			append(filterHash[:], currentCFHeader[:]...),
+		)
+		cfHeaders = append(cfHeaders, filterHash)
+
+		// Each interval we must record a checkpoint.
+		if height > 0 && height%wire.CFCheckptInterval == 0 {
+			// We must make a copy of the current header.
+			cfh := currentCFHeader
+			checkpoints = append(checkpoints, &cfh)
+		}
+
+	}
+
+	// Write all block headers but the genesis, since it is already in the
+	// store.
+	if err = hdrStore.WriteHeaders(blockHeaders[1:]...); err != nil {
+		t.Fatalf("Error writing batch of headers: %s", err)
+	}
+
+	var wg sync.WaitGroup
+
+	// Set up a chain service with a custom query batch method.
+	cs := &ChainService{
+		BlockHeaders: hdrStore,
+	}
+	cs.queryBatch = func(msgs []wire.Message, f func(*ServerPeer,
+		wire.Message, wire.Message) bool, q <-chan struct{},
+		qo ...QueryOption) {
+
+		// Craft response for each message.
+		for _, msg := range msgs {
+			// Only GetCFHeaders expected.
+			q, ok := msg.(*wire.MsgGetCFHeaders)
+			if !ok {
+				t.Fatalf("got unexpected message %T", msg)
+			}
+
+			// The start height must be set to a checkpoint
+			// height+1.
+			if q.StartHeight%wire.CFCheckptInterval != 1 {
+				t.Fatalf("unexpexted start height %v",
+					q.StartHeight)
+			}
+
+			var prevFilterHeader chainhash.Hash
+			switch q.StartHeight {
+
+			// If the start height is 1 the prevFilterHeader is set
+			// to the genesis header.
+			case 1:
+				prevFilterHeader = *genesisFilterHeader
+
+			// Otherwise we use one of the created checkpoints.
+			default:
+				j := q.StartHeight/wire.CFCheckptInterval - 1
+				prevFilterHeader = *checkpoints[j]
+			}
+
+			resp := &wire.MsgCFHeaders{
+				FilterType:       q.FilterType,
+				StopHash:         q.StopHash,
+				PrevFilterHeader: prevFilterHeader,
+			}
+
+			// Keep adding filter hashes until we reach the stop
+			// hash.
+			for h := q.StartHeight; ; h++ {
+				resp.FilterHashes = append(resp.FilterHashes,
+					&cfHeaders[h])
+
+				blockHash := blockHeaders[h].BlockHash()
+				if blockHash == q.StopHash {
+					break
+				}
+			}
+
+			// To ensure the block manager can handle responses
+			// coming potentially out of order, we launch a
+			// goroutine for each, and make it sleep a short while
+			// before calling the response handler.
+			wg.Add(1)
+			go func(query, response wire.Message) {
+				defer wg.Done()
+
+				r := rand.Intn(1000)
+				time.Sleep(time.Duration(r) * time.Millisecond)
+
+				if !f(nil, query, response) {
+					t.Fatalf("got response false")
+				}
+			}(q, resp)
+
+		}
+	}
+
+	// Set up a blockManager with the chain service we defined...
+	bm := blockManager{
+		server: cs,
+		blkHeaderProgressLogger: newBlockProgressLogger(
+			"Processed", "block", log,
+		),
+		fltrHeaderProgessLogger: newBlockProgressLogger(
+			"Verified", "filter header", log,
+		),
+	}
+	bm.newHeadersSignal = sync.NewCond(&bm.newHeadersMtx)
+	bm.newFilterHeadersSignal = sync.NewCond(&bm.newFilterHeadersMtx)
+
+	// ...and call the get checkpointed cf headers method with the
+	// checkpoints we created.
+	bm.getCheckpointedCFHeaders(
+		checkpoints, cfStore, wire.GCSFilterRegular,
+	)
+
+	// Wait for all the responses to be handled.
+	wg.Wait()
+
+	// Finally make sure the filter header tip is what we expect.
+	tip, tipHeight, err := cfStore.ChainTip()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tipHeight != maxHeight {
+		t.Fatalf("expected tip height to be %v, was %v", maxHeight,
+			tipHeight)
+	}
+
+	lastCheckpoint := checkpoints[len(checkpoints)-1]
+	if *tip != *lastCheckpoint {
+		t.Fatalf("expected tip to be %v, was %v",
+			lastCheckpoint, tip)
+	}
+}

--- a/headerfs/index.go
+++ b/headerfs/index.go
@@ -99,7 +99,7 @@ type headerEntry struct {
 
 // headerBatch is a batch of header entries to be written to disk.
 //
-// NOTE: The entries within a batch SHOULD be properly sorted by height in
+// NOTE: The entries within a batch SHOULD be properly sorted by hash in
 // order to ensure the batch is written in a sequential write.
 type headerBatch []headerEntry
 
@@ -134,7 +134,7 @@ func (h *headerIndex) addHeaders(batch headerBatch) error {
 	}
 
 	// In order to ensure optimal write performance, we'll ensure that the
-	// items are sorted before insertion into the database.
+	// items are sorted by their hash before insertion into the database.
 	sort.Sort(batch)
 
 	return walletdb.Update(h.db, func(tx walletdb.ReadWriteTx) error {

--- a/neutrino.go
+++ b/neutrino.go
@@ -515,6 +515,11 @@ type ChainService struct {
 	queryPeers func(wire.Message, func(*ServerPeer, wire.Message,
 		chan<- struct{}), ...QueryOption)
 
+	// queryBatch will be called to distribute a batch of messages across
+	// our connected peers.
+	queryBatch func([]wire.Message, func(*ServerPeer, wire.Message,
+		wire.Message) bool, <-chan struct{}, ...QueryOption)
+
 	chainParams       chaincfg.Params
 	addrManager       *addrmgr.AddrManager
 	connManager       *connmgr.ConnManager
@@ -609,6 +614,13 @@ func NewChainService(cfg Config) (*ChainService, error) {
 	s.queryPeers = func(msg wire.Message, f func(*ServerPeer,
 		wire.Message, chan<- struct{}), qo ...QueryOption) {
 		queryChainServicePeers(&s, msg, f, qo...)
+	}
+
+	// We do the same for queryBatch.
+	s.queryBatch = func(msgs []wire.Message, f func(*ServerPeer,
+		wire.Message, wire.Message) bool, q <-chan struct{},
+		qo ...QueryOption) {
+		queryChainServiceBatch(&s, msgs, f, q, qo...)
 	}
 
 	var err error

--- a/query.go
+++ b/query.go
@@ -190,21 +190,24 @@ const (
 // and provide some presets (including the ones below) prior to factoring out
 // the query API into its own package?
 
-// queryBatch is a helper function that sends a batch of queries to the entire
-// pool of peers, attempting to get them all answered unless the quit channel
-// is closed. It continues to update its view of the connected peers in case
-// peers connect or disconnect during the query. The package-level QueryTimeout
-// parameter, overridable by the Timeout option, determines how long a peer
-// waits for a query before moving onto the next one. The NumRetries option
-// and the QueryNumRetries package-level variable are ignored; the query
-// continues until it either completes or the passed quit channel is closed.
-// For memory efficiency, we attempt to get responses as close to ordered as
-// we can, so that the caller can cache as few responses as possible before
-// committing to storage.
+// queryChainServiceBatch is a helper function that sends a batch of queries to
+// the entire pool of peers of the given ChainService, attempting to get them
+// all answered unless the quit channel is closed. It continues to update its
+// view of the connected peers in case peers connect or disconnect during the
+// query. The package-level QueryTimeout parameter, overridable by the Timeout
+// option, determines how long a peer waits for a query before moving onto the
+// next one. The NumRetries option and the QueryNumRetries package-level
+// variable are ignored; the query continues until it either completes or the
+// passed quit channel is closed.  For memory efficiency, we attempt to get
+// responses as close to ordered as we can, so that the caller can cache as few
+// responses as possible before committing to storage.
 //
 // TODO(aakselrod): support for more than one in-flight query per peer to
 // reduce effects of latency.
-func (s *ChainService) queryBatch(
+func queryChainServiceBatch(
+	// s is the ChainService to use.
+	s *ChainService,
+
 	// queryMsgs is a slice of queries for which the caller wants responses.
 	queryMsgs []wire.Message,
 


### PR DESCRIPTION
This PR handles a set of race conditions that would occur when getting checkpointed cf headers. Since the responses would come in asynchronously, access to the local variables would be racy, and lead to weird nondeterministic behaviour.

A test to trigger these async responses is also added.

FIxes #100