### PR TITLE
Remove unnecessary call to queryBatch in case of no queries.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -845,7 +845,12 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 		currentInterval++
 	}
 
-	log.Infof("Attempting to query for %v cfheader batches", len(queryMsgs))
+	batchesCount := len(queryMsgs)
+	if batchesCount == 0 {
+		return
+	}
+
+	log.Infof("Attempting to query for %v cfheader batches", batchesCount)
 
 	// With the set of messages constructed, we'll now request the batch
 	// all at once. This message will distributed the header requests


### PR DESCRIPTION
This PR is an attempt to reduce the time it takes for neutrino to sync on start.
It fixes a specific problem in the case where the current tip state has passed the last checkpoint therefore cfheaders queries of one of the checkpoints range is needed.
In that case we can skip the query call as when called with empty queries it just wait until timeout takes 3 seconds by default.