### PR TITLE
neutrino: pass firstPeerConnect as arg to blockManager constructor

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -162,6 +162,11 @@ type blockManager struct {
 	// peerChan is a channel for messages that come from peers
 	peerChan chan interface{}
 
+	// firstPeerSignal is a channel that's sent upon once the main daemon
+	// has made its first peer connection. We use this to ensure we don't
+	// try to perform any queries before we have our first peer.
+	firstPeerSignal <-chan struct{}
+
 	wg   sync.WaitGroup
 	quit chan struct{}
 
@@ -178,7 +183,9 @@ type blockManager struct {
 
 // newBlockManager returns a new bitcoin block manager.  Use Start to begin
 // processing asynchronous block and inv updates.
-func newBlockManager(s *ChainService) (*blockManager, error) {
+func newBlockManager(s *ChainService,
+	firstPeerSignal <-chan struct{}) (*blockManager, error) {
+
 	targetTimespan := int64(s.chainParams.TargetTimespan / time.Second)
 	targetTimePerBlock := int64(s.chainParams.TargetTimePerBlock / time.Second)
 	adjustmentFactor := s.chainParams.RetargetAdjustmentFactor
@@ -202,6 +209,7 @@ func newBlockManager(s *ChainService) (*blockManager, error) {
 		blocksPerRetarget:   int32(targetTimespan / targetTimePerBlock),
 		minRetargetTimespan: targetTimespan / adjustmentFactor,
 		maxRetargetTimespan: targetTimespan * adjustmentFactor,
+		firstPeerSignal:     firstPeerSignal,
 	}
 
 	// Next we'll create the two signals that goroutines will use to wait
@@ -250,7 +258,7 @@ func newBlockManager(s *ChainService) (*blockManager, error) {
 }
 
 // Start begins the core block handler which processes block and inv messages.
-func (b *blockManager) Start(firstPeerConnect <-chan struct{}) {
+func (b *blockManager) Start() {
 	// Already started?
 	if atomic.AddInt32(&b.started, 1) != 1 {
 		return
@@ -264,10 +272,10 @@ func (b *blockManager) Start(firstPeerConnect <-chan struct{}) {
 
 		log.Debug("Waiting for peer connection...")
 
-		// Before starting the cfHandler we want to make sure we are connected
-		// with at least one peer.
+		// Before starting the cfHandler we want to make sure we are
+		// connected with at least one peer.
 		select {
-		case <-firstPeerConnect:
+		case <-b.firstPeerSignal:
 		case <-b.quit:
 			return
 		}

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -70,7 +70,7 @@ func setupBlockManager() (*blockManager, headerfs.BlockHeaderStore,
 	}
 
 	// Set up a blockManager with the chain service we defined.
-	bm, err := newBlockManager(cs)
+	bm, err := newBlockManager(cs, nil)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("unable to create "+
 			"blockmanager: %v", err)

--- a/neutrino.go
+++ b/neutrino.go
@@ -659,7 +659,7 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		return nil, err
 	}
 
-	bm, err := newBlockManager(&s)
+	bm, err := newBlockManager(&s, s.firstPeerConnect)
 	if err != nil {
 		return nil, err
 	}
@@ -918,7 +918,7 @@ func (s *ChainService) peerHandler() {
 	// synchronize things, it's easier and slightly faster to simply start
 	// and stop them in this handler.
 	s.addrManager.Start()
-	s.blockManager.Start(s.firstPeerConnect)
+	s.blockManager.Start()
 	s.utxoScanner.Start()
 
 	state := &peerState{


### PR DESCRIPTION
In this commit, we perform a small refactoring to pass in the
`firstPeerConnect` channel as an argument to the constructor of the
blockManager rather than passing it via the start method.