### PR TITLE
blockmanager: fix OP_RETURN bug

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1394,8 +1394,7 @@ func resolveCFHeaderMismatch(block *wire.MsgBlock, fType wire.FilterType,
 					// scripts as well since we don't index
 					// these in order to avoid a circular
 					// dependency.
-					case txOut.PkScript[0] == txscript.OP_RETURN &&
-						txscript.IsPushOnlyScript(txOut.PkScript[1:]):
+					case txOut.PkScript[0] == txscript.OP_RETURN:
 						continue
 					}
 

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -572,7 +572,7 @@ waitForHeaders:
 			checkpoints, store, fType,
 		)
 		if err != nil {
-			log.Debugf("got error attempting to determine correct "+
+			log.Warnf("got error attempting to determine correct "+
 				"cfheader checkpoints: %v, trying again", err)
 		}
 		if len(goodCheckpoints) == 0 {
@@ -1621,7 +1621,7 @@ func checkCFCheckptSanity(cp map[string][]*chainhash.Hash,
 
 			if *header != checkpoint {
 				log.Warnf("mismatch at height %v, expected %v got "+
-					"%v", ckptHeight, header, checkpoint)
+					"%v", ckptHeight, checkpoint, header)
 				return i, nil
 			}
 		}


### PR DESCRIPTION
In this commit, we fix a bug in the way we attempt to verify the filters
during conflict resolution. A bug was fixed in the `btcutil` library
that would add some OP_RETURN items to the filter incorrectly. This was
remedied in the library, but this check was never updated itself. We put
all libraries in line by skipping _all_ OP_RETURN outputs when we
attempt to verify the integrity of a filter.