### PR TITLE
blockmanager: ban peers that equivocate on filter headers/checkpoints

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -954,8 +954,10 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 				log.Warnf("Banning peer=%v for invalid "+
 					"checkpoints", sp)
 
-				b.server.BanPeer(sp)
-				sp.Disconnect()
+				go func() {
+					b.server.BanPeer(sp)
+					sp.Disconnect()
+				}()
 
 				return false
 			}

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -946,6 +946,17 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 			if !verifyCheckpoint(prevCheckpoint, nextCheckpoint, r) {
 				log.Warnf("Checkpoints at index %v don't match "+
 					"response!!!", checkPointIndex)
+
+				// If the peer gives us a header that doesn't
+				// match what we know to be the best
+				// checkpoint, then we'll ban the peer so we
+				// can re-allocate the query elsewhere.
+				log.Warnf("Banning peer=%v for invalid "+
+					"checkpoints", sp)
+
+				b.server.BanPeer(sp)
+				sp.Disconnect()
+
 				return false
 			}
 

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1655,7 +1655,7 @@ func checkCFCheckptSanity(cp map[string][]*chainhash.Hash,
 
 			if *header != checkpoint {
 				log.Warnf("mismatch at height %v, expected %v got "+
-					"%v", ckptHeight, checkpoint, header)
+					"%v", ckptHeight, header, checkpoint)
 				return i, nil
 			}
 		}

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1490,6 +1490,10 @@ func (b *blockManager) getCFHeadersForAllPeers(height uint32,
 		if err != nil {
 			return nil, 0
 		}
+
+		// We'll make sure we also update our stopHeight so we know how
+		// many headers to expect below.
+		stopHeight = height + wire.MaxCFHeadersPerMsg - 1
 	}
 
 	// Calculate the hash and use it to create the query message.

--- a/neutrino.go
+++ b/neutrino.go
@@ -703,6 +703,13 @@ func NewChainService(cfg Config) (*ChainService, error) {
 					break
 				}
 
+				// Ignore peers that we've already banned.
+				addrString := addrmgr.NetAddressKey(addr.NetAddress())
+				if s.IsBanned(addrString) {
+					log.Debugf("Ignoring banned peer: %v", addrString)
+					continue
+				}
+
 				// The peer behind this address should support
 				// all of our required services.
 				if addr.Services()&RequiredServices != RequiredServices {
@@ -732,7 +739,6 @@ func NewChainService(cfg Config) (*ChainService, error) {
 					continue
 				}
 
-				addrString := addrmgr.NetAddressKey(addr.NetAddress())
 				return s.addrStringToNetAddr(addrString)
 			}
 

--- a/query.go
+++ b/query.go
@@ -346,18 +346,15 @@ func queryChainServiceBatch(
 			case <-timeout:
 				// We failed, so set the query state back to
 				// zero and update our lastFailed state.
-				atomic.StoreUint32(&queryStates[handleQuery],
-					uint32(queryWaitSubmit))
-				if !sp.Connected() {
-					return
-				}
+				atomic.StoreUint32(
+					&queryStates[handleQuery], uint32(queryWaitSubmit),
+				)
 
 				log.Tracef("Query for #%v failed, moving "+
 					"on: %v", handleQuery,
 					newLogClosure(func() string {
 						return spew.Sdump(queryMsgs[handleQuery])
 					}))
-
 			case <-matchSignal:
 				// We got a match signal so we can mark this
 				// query a success.


### PR DESCRIPTION
Split off from #129, needs some re-working of the unit tests in order to be merged. Right now the tests require an entire `ChainSerivce`, but the current test version isn't full populated so we get panics for the block manager filter reconciliation tests. 


In this commit, we also now will ban peers that advertise a checkpoint, but then deliver 
an incorrect filter header in that checkpoint range. This can also happen 
if new peers (with invalid state) join after we've verified the checkpoints 
of all our starting peers. 