### PR TITLE
Cache key fix

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,114 @@
+package cache_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcutil/gcs"
+	"github.com/lightninglabs/neutrino/cache"
+	"github.com/lightninglabs/neutrino/cache/lru"
+	"github.com/lightninglabs/neutrino/filterdb"
+)
+
+// TestBlockFilterCaches tests that we can put and retrieve elements from all
+// implementations of the filter and block caches.
+func TestBlockFilterCaches(t *testing.T) {
+	t.Parallel()
+
+	const filterType = filterdb.RegularFilter
+
+	// Create a cache large enough to not evict any item. We do this so we
+	// don't have to worry about the eviction strategy of the tested
+	// caches.
+	const numElements = 10
+	const cacheSize = 100000
+
+	// Initialize all types of caches we want to test, for both filters and
+	// blocks. Currently the LRU cache is the only implementation.
+	filterCaches := []cache.Cache{lru.NewCache(cacheSize)}
+	blockCaches := []cache.Cache{lru.NewCache(cacheSize)}
+
+	// Generate a list of hashes, filters and blocks that we will use as
+	// cache keys an values.
+	var (
+		blockHashes []chainhash.Hash
+		filters     []*gcs.Filter
+		blocks      []*btcutil.Block
+	)
+	for i := 0; i < numElements; i++ {
+		var blockHash chainhash.Hash
+		if _, err := rand.Read(blockHash[:]); err != nil {
+			t.Fatalf("unable to read rand: %v", err)
+		}
+
+		blockHashes = append(blockHashes, blockHash)
+
+		filter, err := gcs.FromBytes(
+			uint32(i), uint8(i), uint64(i), []byte{byte(i)},
+		)
+		if err != nil {
+			t.Fatalf("unable to create filter: %v", err)
+		}
+		filters = append(filters, filter)
+
+		// Put the generated filter in the filter caches.
+		cacheKey := cache.FilterCacheKey{blockHash, filterType}
+		for _, c := range filterCaches {
+			c.Put(cacheKey, &cache.CacheableFilter{Filter: filter})
+		}
+
+		msgBlock := &wire.MsgBlock{}
+		block := btcutil.NewBlock(msgBlock)
+		blocks = append(blocks, block)
+
+		// Add the block to the block caches, using the block INV
+		// vector as key.
+		blockKey := wire.NewInvVect(
+			wire.InvTypeWitnessBlock, &blockHash,
+		)
+		for _, c := range blockCaches {
+			c.Put(*blockKey, &cache.CacheableBlock{block})
+		}
+	}
+
+	// Now go through the list of block hashes, and make sure we can
+	// retrieve all elements from the caches.
+	for i, blockHash := range blockHashes {
+		// Check filter caches.
+		cacheKey := cache.FilterCacheKey{blockHash, filterType}
+		for _, c := range filterCaches {
+			e, err := c.Get(cacheKey)
+			if err != nil {
+				t.Fatalf("Unable to get filter: %v", err)
+			}
+
+			// Ensure we got the correct filter.
+			filter := e.(*cache.CacheableFilter).Filter
+			if filter != filters[i] {
+				t.Fatalf("Filters not equal: %v vs %v ",
+					filter, filters[i])
+			}
+		}
+
+		// Check block caches.
+		blockKey := wire.NewInvVect(
+			wire.InvTypeWitnessBlock, &blockHash,
+		)
+		for _, c := range blockCaches {
+			b, err := c.Get(*blockKey)
+			if err != nil {
+				t.Fatalf("Unable to get block: %v", err)
+			}
+
+			// Ensure it is the same block.
+			block := b.(*cache.CacheableBlock).Block
+			if block != blocks[i] {
+				t.Fatalf("Not equal: %v vs %v ",
+					block, blocks[i])
+			}
+		}
+	}
+}

--- a/cache/cacheable_filter.go
+++ b/cache/cacheable_filter.go
@@ -8,7 +8,7 @@ import (
 
 // filterCacheKey represents the key used to access filters in the FilterCache.
 type FilterCacheKey struct {
-	BlockHash  *chainhash.Hash
+	BlockHash  chainhash.Hash
 	FilterType filterdb.FilterType
 }
 

--- a/cache/cacheable_filter.go
+++ b/cache/cacheable_filter.go
@@ -1,6 +1,16 @@
 package cache
 
-import "github.com/btcsuite/btcutil/gcs"
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcutil/gcs"
+	"github.com/lightninglabs/neutrino/filterdb"
+)
+
+// filterCacheKey represents the key used to access filters in the FilterCache.
+type FilterCacheKey struct {
+	BlockHash  *chainhash.Hash
+	FilterType filterdb.FilterType
+}
 
 // CacheableFilter is a wrapper around Filter type which provides a Size method
 // used by the cache to target certain memory usage.

--- a/query.go
+++ b/query.go
@@ -700,7 +700,7 @@ checkResponses:
 func (s *ChainService) getFilterFromCache(blockHash *chainhash.Hash,
 	filterType filterdb.FilterType) (*gcs.Filter, error) {
 
-	cacheKey := cache.FilterCacheKey{blockHash, filterType}
+	cacheKey := cache.FilterCacheKey{*blockHash, filterType}
 
 	filterValue, err := s.FilterCache.Get(cacheKey)
 	if err != nil {
@@ -714,7 +714,7 @@ func (s *ChainService) getFilterFromCache(blockHash *chainhash.Hash,
 func (s *ChainService) putFilterToCache(blockHash *chainhash.Hash,
 	filterType filterdb.FilterType, filter *gcs.Filter) error {
 
-	cacheKey := cache.FilterCacheKey{blockHash, filterType}
+	cacheKey := cache.FilterCacheKey{*blockHash, filterType}
 	return s.FilterCache.Put(cacheKey, &cache.CacheableFilter{Filter: filter})
 }
 

--- a/query.go
+++ b/query.go
@@ -74,12 +74,6 @@ type queryOptions struct {
 	persistToDisk bool
 }
 
-// filterCacheKey represents the key used for FilterCache of the ChainService.
-type filterCacheKey struct {
-	blockHash  *chainhash.Hash
-	filterType filterdb.FilterType
-}
-
 // QueryOption is a functional option argument to any of the network query
 // methods, such as GetBlock and GetCFilter (when that resorts to a network
 // query). These are always processed in order, with later options overriding
@@ -706,7 +700,7 @@ checkResponses:
 func (s *ChainService) getFilterFromCache(blockHash *chainhash.Hash,
 	filterType filterdb.FilterType) (*gcs.Filter, error) {
 
-	cacheKey := filterCacheKey{blockHash: blockHash, filterType: filterType}
+	cacheKey := cache.FilterCacheKey{blockHash, filterType}
 
 	filterValue, err := s.FilterCache.Get(cacheKey)
 	if err != nil {
@@ -720,7 +714,7 @@ func (s *ChainService) getFilterFromCache(blockHash *chainhash.Hash,
 func (s *ChainService) putFilterToCache(blockHash *chainhash.Hash,
 	filterType filterdb.FilterType, filter *gcs.Filter) error {
 
-	cacheKey := filterCacheKey{blockHash: blockHash, filterType: filterType}
+	cacheKey := cache.FilterCacheKey{blockHash, filterType}
 	return s.FilterCache.Put(cacheKey, &cache.CacheableFilter{Filter: filter})
 }
 


### PR DESCRIPTION
Using a block hash pointer in the filter cache key would lead to the key
not being equal even when the block hash matched.