### PR TITLE
Batch filter fetching

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -10,8 +10,9 @@ var (
 // Cache represents a generic cache.
 type Cache interface {
 	// Put stores the given (key,value) pair, replacing existing value if
-	// key already exists.
-	Put(key interface{}, value Value) error
+	// key already exists. The return value indicates whether items had to
+	// be evicted to make room for the new element.
+	Put(key interface{}, value Value) (bool, error)
 
 	// Get returns the value for a given key.
 	Get(key interface{}) (Value, error)

--- a/cache/lru/lru_test.go
+++ b/cache/lru/lru_test.go
@@ -131,7 +131,7 @@ func TestCacheFailsInsertionSizeBiggerCapacity(t *testing.T) {
 	t.Parallel()
 	c := NewCache(2)
 
-	err := c.Put(1, &sizeable{value: 1, size: 3})
+	_, err := c.Put(1, &sizeable{value: 1, size: 3})
 	if err == nil {
 		t.Fatal("shouldn't be able to put elements larger than cache")
 	}
@@ -145,7 +145,7 @@ func TestManySmallElementCanInsertAfterBigEviction(t *testing.T) {
 	t.Parallel()
 	c := NewCache(3)
 
-	err := c.Put(1, &sizeable{value: 1, size: 3})
+	_, err := c.Put(1, &sizeable{value: 1, size: 3})
 	if err != nil {
 		t.Fatal("couldn't insert element")
 	}
@@ -218,7 +218,7 @@ func TestConcurrencySimple(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			err := c.Put(i, &sizeable{value: i, size: 1})
+			_, err := c.Put(i, &sizeable{value: i, size: 1})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -252,7 +252,7 @@ func TestConcurrencySmallCache(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			err := c.Put(i, &sizeable{value: i, size: 1})
+			_, err := c.Put(i, &sizeable{value: i, size: 1})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -286,7 +286,7 @@ func TestConcurrencyBigCache(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			err := c.Put(i, &sizeable{value: i, size: 1})
+			_, err := c.Put(i, &sizeable{value: i, size: 1})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/headerfs/file.go
+++ b/headerfs/file.go
@@ -3,6 +3,7 @@ package headerfs
 import (
 	"bytes"
 	"fmt"
+	"os"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -49,9 +50,10 @@ func (h *headerStore) readRaw(seekDist uint64) ([]byte, error) {
 	return rawHeader[:], nil
 }
 
-// readHeaderRange will attempt to fetch a series of headers within the target
-// height range. This method batches a set of reads into a single system call
-// thereby increasing performance when reading a set of contiguous headers.
+// readHeaderRange will attempt to fetch a series of block headers within the
+// target height range. This method batches a set of reads into a single system
+// call thereby increasing performance when reading a set of contiguous
+// headers.
 //
 // NOTE: The end height is _inclusive_ so we'll fetch all headers from the
 // startHeight up to the end height, including the final header.
@@ -59,38 +61,17 @@ func (h *blockHeaderStore) readHeaderRange(startHeight uint32,
 	endHeight uint32) ([]wire.BlockHeader, error) {
 
 	// Based on the defined header type, we'll determine the number of
-	// bytes that we need to read past the sync point.
-	var headerSize uint32
-	switch h.indexType {
-	case Block:
-		headerSize = 80
-
-	case RegularFilter:
-		headerSize = 32
-
-	default:
-		return nil, fmt.Errorf("unknown index type: %v", h.indexType)
-	}
-
-	// Each header is 80 bytes, so using this information, we'll seek a
-	// distance to cover that height based on the size of block headers.
-	seekDistance := uint64(startHeight) * uint64(headerSize)
-
-	// Based on the number of headers in the range, we'll allocate a single
-	// slice that's able to hold the entire range of headers.
-	numHeaders := endHeight - startHeight + 1
-	rawHeaderBytes := make([]byte, headerSize*numHeaders)
-
-	// Now that we have our slice allocated, we'll read out the entire
-	// range of headers with a single system call.
-	_, err := h.file.ReadAt(rawHeaderBytes, int64(seekDistance))
+	// bytes that we need to read from the file.
+	headerReader, err := readHeadersFromFile(
+		h.file, BlockHeaderSize, startHeight, endHeight,
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	// We'll now incrementally parse out the set of individual headers from
 	// our set of serialized contiguous raw headers.
-	headerReader := bytes.NewReader(rawHeaderBytes)
+	numHeaders := endHeight - startHeight + 1
 	headers := make([]wire.BlockHeader, 0, numHeaders)
 	for headerReader.Len() != 0 {
 		var nextHeader wire.BlockHeader
@@ -140,4 +121,28 @@ func (f *FilterHeaderStore) readHeader(height uint32) (*chainhash.Hash, error) {
 	}
 
 	return chainhash.NewHash(rawHeader)
+}
+
+// readHeadersFromFile reads a chunk of headers, each of size headerSize, from
+// the given file, from startHeight to endHeight.
+func readHeadersFromFile(f *os.File, headerSize, startHeight,
+	endHeight uint32) (*bytes.Reader, error) {
+
+	// Each header is headerSize bytes, so using this information, we'll
+	// seek a distance to cover that height based on the size the headers.
+	seekDistance := uint64(startHeight) * uint64(headerSize)
+
+	// Based on the number of headers in the range, we'll allocate a single
+	// slice that's able to hold the entire range of headers.
+	numHeaders := endHeight - startHeight + 1
+	rawHeaderBytes := make([]byte, headerSize*numHeaders)
+
+	// Now that we have our slice allocated, we'll read out the entire
+	// range of headers with a single system call.
+	_, err := f.ReadAt(rawHeaderBytes, int64(seekDistance))
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes.NewReader(rawHeaderBytes), nil
 }

--- a/headerfs/index.go
+++ b/headerfs/index.go
@@ -58,6 +58,15 @@ const (
 	RegularFilter
 )
 
+const (
+	// BlockHeaderSize is the size in bytes of the Block header type.
+	BlockHeaderSize = 80
+
+	// RegularFilterHeaderSize is the size in bytes of the RegularFilter
+	// header type.
+	RegularFilterHeaderSize = 32
+)
+
 // headerIndex is an index stored within the database that allows for random
 // access into the on-disk header file. This, in conjunction with a flat file
 // of headers consists of header database. The keys have been specifically

--- a/neutrino.go
+++ b/neutrino.go
@@ -70,9 +70,13 @@ var (
 	// from DNS.
 	DisableDNSSeed = false
 
-	// DefaultFilterCacheSize is the size (in bytes) of filters neutrino will
-	// keep in memory if no size is specified in the neutrino.Config.
-	DefaultFilterCacheSize uint64 = 4096 * 1000
+	// DefaultFilterCacheSize is the size (in bytes) of filters neutrino
+	// will keep in memory if no size is specified in the neutrino.Config.
+	// Since we utilize the cache during batch filter fetching, it is
+	// beneficial if it is able to to keep a whole batch. The current batch
+	// size is 1000, so we default to 30 MB, which can fit about 1450 to
+	// 2300 mainnet filters.
+	DefaultFilterCacheSize uint64 = 3120 * 10 * 1000
 
 	// DefaultBlockCacheSize is the size (in bytes) of blocks neutrino will
 	// keep in memory if no size is specified in the neutrino.Config.

--- a/query.go
+++ b/query.go
@@ -719,7 +719,7 @@ func (s *ChainService) getFilterFromCache(blockHash *chainhash.Hash,
 
 // putFilterToCache inserts a given filter in ChainService's FilterCache.
 func (s *ChainService) putFilterToCache(blockHash *chainhash.Hash,
-	filterType filterdb.FilterType, filter *gcs.Filter) error {
+	filterType filterdb.FilterType, filter *gcs.Filter) (bool, error) {
 
 	cacheKey := cache.FilterCacheKey{*blockHash, filterType}
 	return s.FilterCache.Put(cacheKey, &cache.CacheableFilter{Filter: filter})
@@ -862,7 +862,7 @@ func (s *ChainService) GetCFilter(blockHash chainhash.Hash,
 	if filter != nil {
 		// If we found a filter, put it in the cache and persistToDisk if
 		// the caller requested it.
-		err := s.putFilterToCache(&blockHash, dbFilterType, filter)
+		_, err := s.putFilterToCache(&blockHash, dbFilterType, filter)
 		if err != nil {
 			log.Warnf("couldn't write filter to cache: %v", err)
 		}
@@ -999,7 +999,7 @@ func (s *ChainService) GetBlock(blockHash chainhash.Hash,
 	}
 
 	// Add block to the cache before returning it.
-	err = s.BlockCache.Put(*inv, &cache.CacheableBlock{foundBlock})
+	_, err = s.BlockCache.Put(*inv, &cache.CacheableBlock{foundBlock})
 	if err != nil {
 		log.Warnf("couldn't write block to cache: %v", err)
 	}

--- a/rescan.go
+++ b/rescan.go
@@ -981,7 +981,14 @@ func blockFilterMatches(chain ChainSource, ro *rescanOptions,
 	blockHash *chainhash.Hash) (bool, error) {
 
 	// TODO(roasbeef): need to ENSURE always get filter
-	filter, err := chain.GetCFilter(*blockHash, wire.GCSFilterRegular)
+
+	// Since this method is called when we are not current, and from the
+	// utxoscanner, we expect more calls to follow for the subsequent
+	// filters. To speed up the fetching, we make an optimistic batch
+	// query.
+	filter, err := chain.GetCFilter(
+		*blockHash, wire.GCSFilterRegular, OptimisticBatch(),
+	)
 	if err != nil {
 		if err == headerfs.ErrHashNotFound {
 			// Block has been reorged out from under us.


### PR DESCRIPTION
This PR implements batch filter fetching. This is achieved by giving the callers of `GetCFilter` the option to make a "optimistic batch query", where the filters following the requested filters are also fetched, and added to the filter cache.

I ran this on mainnet to find cache size needed to keep a whole filter batch, and a size of 30 MB could hold at minimum 1483 elements (tested on filters at height > 515110), which should give us some wiggle room.