### PR TITLE
Validate received PrevFilterHeader

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1466,6 +1466,7 @@ func (b *blockManager) getCFHeadersForAllPeers(height uint32,
 	// Calculate the hash and use it to create the query message.
 	stopHash := stopHeader.BlockHash()
 	msg := wire.NewMsgGetCFHeaders(fType, height, &stopHash)
+	numHeaders := int(stopHeight - height + 1)
 
 	// Send the query to all peers and record their responses in the map.
 	b.server.queryAllPeers(
@@ -1475,7 +1476,9 @@ func (b *blockManager) getCFHeadersForAllPeers(height uint32,
 			switch m := resp.(type) {
 			case *wire.MsgCFHeaders:
 				if m.StopHash == stopHash &&
-					m.FilterType == fType {
+					m.FilterType == fType &&
+					len(m.FilterHashes) == numHeaders {
+
 					headers[sp.Addr()] = m
 
 					// We got an answer from this peer so

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -705,7 +705,7 @@ func (b *blockManager) getUncheckpointedCFHeaders(
 
 	// Query all peers for the responses.
 	startHeight := filtHeight + 1
-	headers := b.getCFHeadersForAllPeers(startHeight, fType)
+	headers, numHeaders := b.getCFHeadersForAllPeers(startHeight, fType)
 	if len(headers) == 0 {
 		return fmt.Errorf("couldn't get cfheaders from peers")
 	}
@@ -713,7 +713,7 @@ func (b *blockManager) getUncheckpointedCFHeaders(
 	// For each header, go through and check whether all headers messages
 	// have the same filter hash. If we find a difference, get the block,
 	// calculate the filter, and throw out any mismatching peers.
-	for i := 0; i < wire.MaxCFHeadersPerMsg; i++ {
+	for i := 0; i < numHeaders; i++ {
 		if checkForCFHeaderMismatch(headers, i) {
 			targetHeight := startHeight + uint32(i)
 
@@ -1215,7 +1215,7 @@ func (b *blockManager) resolveConflict(
 	// Now we get all of the mismatched CFHeaders from peers, and check
 	// which ones are valid.
 	startHeight := uint32(heightDiff) * wire.CFCheckptInterval
-	headers := b.getCFHeadersForAllPeers(startHeight, fType)
+	headers, numHeaders := b.getCFHeadersForAllPeers(startHeight, fType)
 
 	// Make sure we're working off the same baseline. Otherwise, we want to
 	// go back and get checkpoints again.
@@ -1232,7 +1232,7 @@ func (b *blockManager) resolveConflict(
 	// For each header, go through and check whether all headers messages
 	// have the same filter hash. If we find a difference, get the block,
 	// calculate the filter, and throw out any mismatching peers.
-	for i := 0; i < wire.MaxCFHeadersPerMsg; i++ {
+	for i := 0; i < numHeaders; i++ {
 		if checkForCFHeaderMismatch(headers, i) {
 			// Get the block header for this height, along with the
 			// block as well.
@@ -1443,9 +1443,10 @@ func resolveCFHeaderMismatch(block *wire.MsgBlock, fType wire.FilterType,
 }
 
 // getCFHeadersForAllPeers runs a query for cfheaders at a specific height and
-// returns a map of responses from all peers.
+// returns a map of responses from all peers. The second return value is the
+// number for cfheaders in each response.
 func (b *blockManager) getCFHeadersForAllPeers(height uint32,
-	fType wire.FilterType) map[string]*wire.MsgCFHeaders {
+	fType wire.FilterType) (map[string]*wire.MsgCFHeaders, int) {
 
 	// Create the map we're returning.
 	headers := make(map[string]*wire.MsgCFHeaders)
@@ -1459,7 +1460,7 @@ func (b *blockManager) getCFHeadersForAllPeers(height uint32,
 			height + wire.MaxCFHeadersPerMsg - 1,
 		)
 		if err != nil {
-			return headers
+			return nil, 0
 		}
 	}
 
@@ -1489,7 +1490,7 @@ func (b *blockManager) getCFHeadersForAllPeers(height uint32,
 		},
 	)
 
-	return headers
+	return headers, numHeaders
 }
 
 // fetchFilterFromAllPeers attempts to fetch a filter for the target filter


### PR DESCRIPTION
We could fail writing the received headers since they didn't match up with what we had already.