### PR TITLE
blockmanager: remove panic on failed WriteHeaders

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2359,8 +2359,8 @@ func (b *blockManager) handleHeadersMsg(hmsg *headersMsg) {
 		// is atomic.
 		err := b.server.BlockHeaders.WriteHeaders(headerWriteBatch...)
 		if err != nil {
-			panic(fmt.Sprintf("unable to write block header: %v",
-				err))
+			log.Errorf("Unable to write block headers: %v", err)
+			return
 		}
 	}
 


### PR DESCRIPTION
If headers were written while lnd was in the process of shutting down it
would panic with a "Database not open" error.