### PR TITLE
Detect peers serving invalid filters

### DIFF
--- a/bamboozle_unit_test.go
+++ b/bamboozle_unit_test.go
@@ -38,12 +38,12 @@ type checkCFHTestCase struct {
 	mismatch bool
 }
 
-type resolveCFHTestCase struct {
-	name        string
-	block       *wire.MsgBlock
-	idx         int
-	peerFilters map[string]*gcs.Filter
-	badPeers    []string
+type resolveFilterTestCase struct {
+	name         string
+	block        *wire.MsgBlock
+	banThreshold int
+	peerFilters  map[string]*gcs.Filter
+	badPeers     []string
 }
 
 var (
@@ -332,7 +332,7 @@ var (
 		},
 	}
 
-	resolveCFHTestCases = []*resolveCFHTestCase{
+	resolveFilterTestCases = []*resolveFilterTestCase{
 		{
 			name:  "all bad 1",
 			block: block,
@@ -340,8 +340,8 @@ var (
 				"a": fakeFilter1,
 				"b": fakeFilter1,
 			},
-			idx:      0,
-			badPeers: []string{"a", "b"},
+			banThreshold: 1,
+			badPeers:     []string{"a", "b"},
 		},
 		{
 			name:  "all bad 2",
@@ -350,8 +350,8 @@ var (
 				"a": fakeFilter2,
 				"b": fakeFilter2,
 			},
-			idx:      0,
-			badPeers: []string{"a", "b"},
+			banThreshold: 1,
+			badPeers:     []string{"a", "b"},
 		},
 		{
 			name:  "all bad 3",
@@ -360,8 +360,8 @@ var (
 				"a": fakeFilter2,
 				"b": fakeFilter2,
 			},
-			idx:      0,
-			badPeers: []string{"a", "b"},
+			banThreshold: 1,
+			badPeers:     []string{"a", "b"},
 		},
 		{
 			name:  "all bad 4",
@@ -370,8 +370,8 @@ var (
 				"a": fakeFilter1,
 				"b": fakeFilter2,
 			},
-			idx:      0,
-			badPeers: []string{"a", "b"},
+			banThreshold: 1,
+			badPeers:     []string{"a", "b"},
 		},
 		{
 			name:  "all bad 5",
@@ -380,8 +380,8 @@ var (
 				"a": fakeFilter2,
 				"b": fakeFilter1,
 			},
-			idx:      1,
-			badPeers: []string{"a", "b"},
+			banThreshold: 1,
+			badPeers:     []string{"a", "b"},
 		},
 		{
 			name:  "one good",
@@ -391,8 +391,8 @@ var (
 				"b": fakeFilter1,
 				"c": fakeFilter2,
 			},
-			idx:      1,
-			badPeers: []string{"b", "c"},
+			banThreshold: 1,
+			badPeers:     []string{"b", "c"},
 		},
 		{
 			name:  "all good",
@@ -401,8 +401,8 @@ var (
 				"a": correctFilter,
 				"b": correctFilter,
 			},
-			idx:      1,
-			badPeers: []string{},
+			banThreshold: 1,
+			badPeers:     []string{},
 		},
 	}
 )
@@ -549,10 +549,11 @@ func TestCheckForCFHeadersMismatch(t *testing.T) {
 func TestResolveFilterMismatchFromBlock(t *testing.T) {
 	t.Parallel()
 
-	for _, testCase := range resolveCFHTestCases {
+	for _, testCase := range resolveFilterTestCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			badPeers, err := resolveFilterMismatchFromBlock(
 				block, wire.GCSFilterRegular, testCase.peerFilters,
+				testCase.banThreshold,
 			)
 			if err != nil {
 				t.Fatalf("Couldn't resolve cfheader "+

--- a/bamboozle_unit_test.go
+++ b/bamboozle_unit_test.go
@@ -546,12 +546,12 @@ func TestCheckForCFHeadersMismatch(t *testing.T) {
 	}
 }
 
-func TestResolveCFHeadersMismatch(t *testing.T) {
+func TestResolveFilterMismatchFromBlock(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range resolveCFHTestCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			badPeers, err := resolveCFHeaderMismatch(
+			badPeers, err := resolveFilterMismatchFromBlock(
 				block, wire.GCSFilterRegular, testCase.peerFilters,
 			)
 			if err != nil {

--- a/bamboozle_unit_test.go
+++ b/bamboozle_unit_test.go
@@ -125,6 +125,13 @@ var (
 	}
 	correctFilter, _ = builder.BuildBasicFilter(block, nil)
 
+	// a filter missing the first output of the block.
+	missingElementFilter, _ = builder.BuildBasicFilter(
+		&wire.MsgBlock{
+			Transactions: block.Transactions[1:],
+		}, nil,
+	)
+
 	fakeFilter1, _ = gcs.FromBytes(2, builder.DefaultP, builder.DefaultM, []byte{
 		0x30, 0x43, 0x02, 0x1f, 0x4d, 0x23, 0x81, 0xdc,
 		0x97, 0xf1, 0x82, 0xab, 0xd8, 0x18, 0x5f, 0x51,
@@ -403,6 +410,19 @@ var (
 			},
 			banThreshold: 1,
 			badPeers:     []string{},
+		},
+		{
+			// One peer is serving a filter tha lacks an element,
+			// we should immediately notice this and ban it.
+			name:  "filter missing element",
+			block: block,
+			peerFilters: map[string]*gcs.Filter{
+				"a": correctFilter,
+				"b": correctFilter,
+				"c": missingElementFilter,
+			},
+			banThreshold: 1,
+			badPeers:     []string{"c"},
 		},
 	}
 )

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1246,6 +1246,7 @@ func (b *blockManager) resolveConflict(
 
 	// Now we get all of the mismatched CFHeaders from peers, and check
 	// which ones are valid.
+	// TODO(halseth): check if peer serves headers that matches its checkpoints
 	startHeight := uint32(heightDiff) * wire.CFCheckptInterval
 	headers, numHeaders := b.getCFHeadersForAllPeers(startHeight, fType)
 
@@ -1377,8 +1378,8 @@ func (b *blockManager) detectBadPeers(headers map[string]*wire.MsgCFHeaders,
 	)
 
 	var badPeers []string
-	for peer, _ := range headers {
-		_, ok := filtersFromPeers[peer]
+	for peer, msg := range headers {
+		filter, ok := filtersFromPeers[peer]
 
 		// If a peer did not respond, ban it immediately.
 		if !ok {
@@ -1387,14 +1388,26 @@ func (b *blockManager) detectBadPeers(headers map[string]*wire.MsgCFHeaders,
 			badPeers = append(badPeers, peer)
 			continue
 		}
+
+		// If the peer is serving filters that isn't consistent with
+		// its filter hashes, ban it.
+		hash, err := builder.GetFilterHash(filter)
+		if err != nil {
+			return nil, err
+		}
+		if hash != *msg.FilterHashes[filterIndex] {
+			log.Warnf("Peer %v serving filters not consistent "+
+				"with filter hashes, considering bad.", peer)
+			badPeers = append(badPeers, peer)
+		}
 	}
 
 	if len(badPeers) != 0 {
 		return badPeers, nil
 	}
 
-	// If all peers responded, get the block and use it to detect who is
-	// serving bad filters.
+	// If all peers responded with consistent filters and hashes, get the
+	// block and use it to detect who is serving bad filters.
 	block, err := b.server.GetBlock(header.BlockHash())
 	if err != nil {
 		return nil, err

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1377,17 +1377,18 @@ func (b *blockManager) detectBadPeers(headers map[string]*wire.MsgCFHeaders,
 	filtersFromPeers := b.fetchFilterFromAllPeers(
 		targetHeight, header.BlockHash(), fType,
 	)
-	return resolveCFHeaderMismatch(
+	return resolveFilterMismatchFromBlock(
 		block.MsgBlock(), fType, filtersFromPeers,
 	)
 }
 
-// resolveCFHeaderMismatch will attempt to cross-reference each filter received
-// by each peer based on what we can reconstruct and verify from the filter in
-// question. We'll return all the peers that returned what we believe to in
-// invalid filter.
-func resolveCFHeaderMismatch(block *wire.MsgBlock, fType wire.FilterType,
-	filtersFromPeers map[string]*gcs.Filter) ([]string, error) {
+// resolveFilterMismatchFromBlock will attempt to cross-reference each filter
+// in filtersFromPeers with the given block, based on what we can reconstruct
+// and verify from the filter in question. We'll return all the peers that
+// returned what we believe to be an invalid filter.
+func resolveFilterMismatchFromBlock(block *wire.MsgBlock,
+	fType wire.FilterType, filtersFromPeers map[string]*gcs.Filter) (
+	[]string, error) {
 
 	badPeers := make(map[string]struct{})
 

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1447,8 +1447,13 @@ func resolveFilterMismatchFromBlock(block *wire.MsgBlock,
 				)
 				if err != nil {
 					// If we're unable to query this
-					// filter, then we'll skip this peer
-					// all together.
+					// filter, then we'll immediately ban
+					// this peer.
+					log.Warnf("Unable to check filter "+
+						"match for peer %v, marking "+
+						"as bad: %v", peerAddr, err)
+
+					badPeers[peerAddr] = struct{}{}
 					continue peerVerification
 				}
 

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1379,16 +1379,22 @@ func (b *blockManager) detectBadPeers(headers map[string]*wire.MsgCFHeaders,
 	)
 	return resolveFilterMismatchFromBlock(
 		block.MsgBlock(), fType, filtersFromPeers,
+
+		// We'll require a strict majority of our peers to agree on
+		// filters.
+		(len(filtersFromPeers)+2)/2,
 	)
 }
 
 // resolveFilterMismatchFromBlock will attempt to cross-reference each filter
 // in filtersFromPeers with the given block, based on what we can reconstruct
 // and verify from the filter in question. We'll return all the peers that
-// returned what we believe to be an invalid filter.
+// returned what we believe to be an invalid filter. The threshold argument is
+// the minimum number of peers we need to agree on a filter before banning the
+// other peers.
 func resolveFilterMismatchFromBlock(block *wire.MsgBlock,
-	fType wire.FilterType, filtersFromPeers map[string]*gcs.Filter) (
-	[]string, error) {
+	fType wire.FilterType, filtersFromPeers map[string]*gcs.Filter,
+	threshold int) ([]string, error) {
 
 	badPeers := make(map[string]struct{})
 

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1478,13 +1478,13 @@ func resolveFilterMismatchFromBlock(block *wire.MsgBlock,
 	// We'll now run through each peer and ensure that each output
 	// script is included in the filter that they responded with to
 	// our query.
+peerVerification:
 	for peerAddr, filter := range filtersFromPeers {
 		// We'll ensure that all the filters include every output
 		// script within the block.
 		//
 		// TODO(roasbeef): eventually just do a comparison against
 		// decompressed filters
-	peerVerification:
 		for _, tx := range block.Transactions {
 			for _, txOut := range tx.TxOut {
 				switch {

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1698,6 +1698,8 @@ func checkCFCheckptSanity(cp map[string][]*chainhash.Hash,
 // because the block manager controls which blocks are needed and how
 // the fetching should proceed.
 func (b *blockManager) blockHandler() {
+	defer b.wg.Done()
+
 	candidatePeers := list.New()
 out:
 	for {
@@ -1727,7 +1729,6 @@ out:
 		}
 	}
 
-	b.wg.Done()
 	log.Trace("Block handler done")
 }
 

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -6,10 +6,12 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/peer"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil/gcs"
@@ -668,4 +670,152 @@ func buildAllPkScriptsFilter(block *wire.MsgBlock) (*gcs.Filter, error) {
 	}
 
 	return b.Build()
+}
+
+func assertBadPeers(expBad map[string]struct{}, badPeers []string) error {
+	remBad := make(map[string]struct{})
+	for p := range expBad {
+		remBad[p] = struct{}{}
+	}
+	for _, peer := range badPeers {
+		_, ok := remBad[peer]
+		if !ok {
+			return fmt.Errorf("did not expect %v to be bad", peer)
+		}
+		delete(remBad, peer)
+	}
+
+	if len(remBad) != 0 {
+		return fmt.Errorf("did expect more bad peers")
+	}
+
+	return nil
+}
+
+type mockQueryAccess struct {
+	answers map[string]wire.Message
+}
+
+func (m *mockQueryAccess) queryAllPeers(
+	queryMsg wire.Message,
+	checkResponse func(sp *ServerPeer, resp wire.Message,
+		quit chan<- struct{}, peerQuit chan<- struct{}),
+	options ...QueryOption) {
+
+	for p, resp := range m.answers {
+		pp, err := peer.NewOutboundPeer(&peer.Config{}, p)
+		if err != nil {
+			panic(err)
+		}
+
+		sp := &ServerPeer{
+			Peer: pp,
+		}
+		checkResponse(sp, resp, make(chan struct{}), make(chan struct{}))
+	}
+}
+
+var _ QueryAccess = (*mockQueryAccess)(nil)
+
+// TestBlockManagerDetectBadPeers checks that we detect bad peers, like peers
+// not responding to our filter query, serving inconsistent filters etc.
+func TestBlockManagerDetectBadPeers(t *testing.T) {
+	t.Parallel()
+
+	var (
+		stopHash        = chainhash.Hash{}
+		prev            = chainhash.Hash{}
+		startHeight     = uint32(100)
+		badIndex        = uint32(5)
+		targetIndex     = startHeight + badIndex
+		fType           = wire.GCSFilterRegular
+		filterBytes, _  = correctFilter.NBytes()
+		filterHash, _   = builder.GetFilterHash(correctFilter)
+		blockHeader     = wire.BlockHeader{}
+		targetBlockHash = block.BlockHash()
+
+		peers  = []string{"good1:1", "good2:1", "bad:1", "good3:1"}
+		expBad = map[string]struct{}{
+			"bad:1": struct{}{},
+		}
+	)
+
+	testCases := []struct {
+		// filterAnswers is used by each testcase to set the anwers we
+		// want each peer to respond with on filter queries.
+		filterAnswers func(string, map[string]wire.Message)
+	}{
+		{
+			// We let the "bad" peers not respond to the filter
+			// query. They should be marked bad because they are
+			// unresponsive. We do this to ensure peers cannot
+			// only respond to us with headers, and stall our sync
+			// by not responding to filter requests.
+			filterAnswers: func(p string,
+				answers map[string]wire.Message) {
+
+				if strings.Contains(p, "bad") {
+					return
+				}
+
+				answers[p] = wire.NewMsgCFilter(
+					fType, &targetBlockHash, filterBytes,
+				)
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		// Create a mock block header store. We only need to be able to
+		// serve a header for the target index.
+		blockHeaders := newMockBlockHeaderStore()
+		blockHeaders.heights[targetIndex] = blockHeader
+		cs := &ChainService{
+			BlockHeaders: blockHeaders,
+		}
+
+		// We set up the mock QueryAccess to only respond according to
+		// the active testcase.
+		mock := &mockQueryAccess{
+			answers: make(map[string]wire.Message),
+		}
+		for _, peer := range peers {
+			test.filterAnswers(peer, mock.answers)
+		}
+
+		// For the CFHeaders, we pretend all peers responded with the same
+		// filter headers.
+		msg := &wire.MsgCFHeaders{
+			FilterType:       fType,
+			StopHash:         stopHash,
+			PrevFilterHeader: prev,
+		}
+
+		for i := uint32(0); i < 2*badIndex; i++ {
+			msg.AddCFHash(&filterHash)
+		}
+
+		headers := make(map[string]*wire.MsgCFHeaders)
+		for _, peer := range peers {
+			headers[peer] = msg
+		}
+
+		bm := &blockManager{
+			server:  cs,
+			queries: mock,
+		}
+
+		// Now trying to detect which peers are bad, we should detect the
+		// bad ones.
+		badPeers, err := bm.detectBadPeers(
+			headers, targetIndex, badIndex, fType,
+		)
+		if err != nil {
+			t.Fatalf("failed to detect bad peers: %v", err)
+		}
+
+		if err := assertBadPeers(expBad, badPeers); err != nil {
+			t.Fatal(err)
+		}
+	}
 }

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -763,6 +763,22 @@ func TestBlockManagerDetectBadPeers(t *testing.T) {
 				)
 			},
 		},
+		{
+			// We let the "bad" peers serve filters that don't hash
+			// to the filter headers they have sent.
+			filterAnswers: func(p string,
+				answers map[string]wire.Message) {
+
+				filterData := filterBytes
+				if strings.Contains(p, "bad") {
+					filterData, _ = fakeFilter1.NBytes()
+				}
+
+				answers[p] = wire.NewMsgCFilter(
+					fType, &targetBlockHash, filterData,
+				)
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/mock_store.go
+++ b/mock_store.go
@@ -14,6 +14,7 @@ import (
 // a simple map.
 type mockBlockHeaderStore struct {
 	headers map[chainhash.Hash]wire.BlockHeader
+	heights map[uint32]wire.BlockHeader
 }
 
 // A compile-time check to ensure the mockBlockHeaderStore adheres to the
@@ -24,9 +25,10 @@ var _ headerfs.BlockHeaderStore = (*mockBlockHeaderStore)(nil)
 // backed by an in-memory map. This instance is meant to be used by callers
 // outside the package to unit test components that require a BlockHeaderStore
 // interface.
-func newMockBlockHeaderStore() headerfs.BlockHeaderStore {
+func newMockBlockHeaderStore() *mockBlockHeaderStore {
 	return &mockBlockHeaderStore{
 		headers: make(map[chainhash.Hash]wire.BlockHeader),
+		heights: make(map[uint32]wire.BlockHeader),
 	}
 }
 
@@ -39,11 +41,17 @@ func (m *mockBlockHeaderStore) LatestBlockLocator() (
 	blockchain.BlockLocator, error) {
 	return nil, nil
 }
+
 func (m *mockBlockHeaderStore) FetchHeaderByHeight(height uint32) (
 	*wire.BlockHeader, error) {
 
-	return nil, nil
+	if header, ok := m.heights[height]; ok {
+		return &header, nil
+	}
+
+	return nil, headerfs.ErrHeightNotFound
 }
+
 func (m *mockBlockHeaderStore) FetchHeaderAncestors(uint32,
 	*chainhash.Hash) ([]wire.BlockHeader, uint32, error) {
 

--- a/query.go
+++ b/query.go
@@ -50,6 +50,20 @@ var (
 	QueryEncoding = wire.WitnessEncoding
 )
 
+// QueryAccess is an interface that gives acces to query a set of peers in
+// different ways.
+type QueryAccess interface {
+	queryAllPeers(
+		queryMsg wire.Message,
+		checkResponse func(sp *ServerPeer, resp wire.Message,
+			quit chan<- struct{}, peerQuit chan<- struct{}),
+		options ...QueryOption)
+}
+
+// A compile-time check to ensure that ChainService implements the
+// QueryAccess interface.
+var _ QueryAccess = (*ChainService)(nil)
+
 // queries are a set of options that can be modified per-query, unlike global
 // options.
 //


### PR DESCRIPTION
This PR adds a set of extra consistency checks to downloaded filters, in an attempt to ban peers that are serving either old filter types, or filters that are inconsistent with the filter headers.

If we cannot determine directly from the filter headers that a peer is serving invalid filters we employ the following strategies in attempt to ban the smallest set of peers needed for the sync not to stall:

1. If a peers' filter doesn't match on a script that must match, we know the filter is invalid.
2. If a peers' filter matches on a script that _should not_ match, it is potentially invalid. In this case we ban peers that matches more such scripts than other peers.
3. If we cannot detect which filters are invalid from the block contents, we ban peers serving filters different from the majority of peers.

For the majority rule to kick in, we currently require the majority of peers serving the same filter to be **at least 6**. If this requirement is not met, we will need more peers for the sync to continue.
