### PR TITLE
neutrino: reject address suggestions for already connected peers

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -1221,7 +1221,14 @@ func (s *ChainService) handleDonePeerMsg(state *peerState, sp *ServerPeer) {
 	}
 
 	if sp.connReq != nil {
-		s.connManager.Disconnect(sp.connReq.ID())
+		// If the peer has been banned, we'll remove the connection
+		// request from the manager to ensure we don't reconnect again.
+		// Otherwise, we'll just simply disconnect.
+		if s.isBanned(sp.connReq.Addr.String(), state) {
+			s.connManager.Remove(sp.connReq.ID())
+		} else {
+			s.connManager.Disconnect(sp.connReq.ID())
+		}
 	}
 
 	// Update the address' last seen time if the peer has acknowledged

--- a/neutrino.go
+++ b/neutrino.go
@@ -1349,6 +1349,13 @@ func (s *ChainService) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) 
 		return
 	}
 
+	// If we're already connected to this peer, then we'll close out the new
+	// connection and keep the old.
+	if s.PeerByAddr(peerAddr) != nil {
+		conn.Close()
+		return
+	}
+
 	sp := newServerPeer(s, c.Permanent)
 	p, err := peer.NewOutboundPeer(newPeerConfig(sp), peerAddr)
 	if err != nil {


### PR DESCRIPTION
We do this to ensure we don't have more than once active connection per peer. This is needed since the addrManager has no idea about the client's currently connected peers.

We also ensure we don't reconnect to banned peers -- there's no point in attempting to do so if we'll disconnect them anyway.