### PR TITLE
peer handling: ban and remove non-filter peers

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -262,9 +262,14 @@ func (sp *ServerPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 	if peerServices&wire.SFNodeWitness != wire.SFNodeWitness ||
 		peerServices&wire.SFNodeCF != wire.SFNodeCF {
 
-		log.Infof("Disconnecting peer %v, cannot serve compact "+
+		log.Infof("Removing peer %v, cannot serve compact "+
 			"filters", sp)
-		sp.Disconnect()
+
+		sp.server.BanPeer(sp)
+		if sp.connReq != nil {
+			sp.server.connManager.Remove(sp.connReq.ID())
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
If a peer that couldn't serve compact filters were part of our set of
permanent peers we would disconnect and re-connect over and over again.

To avoid this happening we make the connmgr remove the peer instead, and
we also ban it to avoid connecting to it again later.