### PR TITLE
rescan: dispatch OnBlockConnected before OnFilteredBlockConnected

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/lightningnetwork/lnd/queue v1.0.1
 	go.etcd.io/bbolt v1.3.2 // indirect
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 // indirect
+	google.golang.org/genproto v0.0.0-20190201180003-4b09977fb922 // indirect
 )

--- a/rescan.go
+++ b/rescan.go
@@ -537,15 +537,15 @@ func rescan(chain ChainSource, options ...RescanOption) error {
 		// If we're not scanning or our watch list is empty, then we can
 		// just notify the block without fetching any filters/blocks.
 		if !scanning || len(ro.watchList) == 0 {
-			if ro.ntfn.OnFilteredBlockConnected != nil {
-				ro.ntfn.OnFilteredBlockConnected(
-					curStamp.Height, &curHeader, nil,
-				)
-			}
 			if ro.ntfn.OnBlockConnected != nil {
 				ro.ntfn.OnBlockConnected(
 					&curStamp.Hash, curStamp.Height,
 					curHeader.Timestamp,
+				)
+			}
+			if ro.ntfn.OnFilteredBlockConnected != nil {
+				ro.ntfn.OnFilteredBlockConnected(
+					curStamp.Height, &curHeader, nil,
 				)
 			}
 
@@ -612,15 +612,15 @@ func rescan(chain ChainSource, options ...RescanOption) error {
 
 		// Run through notifications. This is all single-threaded. We
 		// include deprecated calls as they're still used, for now.
-		if ro.ntfn.OnFilteredBlockDisconnected != nil {
-			ro.ntfn.OnFilteredBlockDisconnected(
-				curStamp.Height, &curHeader,
-			)
-		}
 		if ro.ntfn.OnBlockDisconnected != nil {
 			ro.ntfn.OnBlockDisconnected(
 				&curStamp.Hash, curStamp.Height,
 				curHeader.Timestamp,
+			)
+		}
+		if ro.ntfn.OnFilteredBlockDisconnected != nil {
+			ro.ntfn.OnFilteredBlockDisconnected(
+				curStamp.Height, &curHeader,
 			)
 		}
 
@@ -836,14 +836,15 @@ func notifyBlock(chain ChainSource, ro *rescanOptions,
 		}
 	}
 
-	if ro.ntfn.OnFilteredBlockConnected != nil {
-		ro.ntfn.OnFilteredBlockConnected(curStamp.Height, &curHeader,
-			relevantTxs)
-	}
-
 	if ro.ntfn.OnBlockConnected != nil {
-		ro.ntfn.OnBlockConnected(&curStamp.Hash,
-			curStamp.Height, curHeader.Timestamp)
+		ro.ntfn.OnBlockConnected(
+			&curStamp.Hash, curStamp.Height, curHeader.Timestamp,
+		)
+	}
+	if ro.ntfn.OnFilteredBlockConnected != nil {
+		ro.ntfn.OnFilteredBlockConnected(
+			curStamp.Height, &curHeader, relevantTxs,
+		)
 	}
 
 	return nil
@@ -941,14 +942,15 @@ func notifyBlockWithFilter(chain ChainSource, ro *rescanOptions,
 		}
 	}
 
-	if ro.ntfn.OnFilteredBlockConnected != nil {
-		ro.ntfn.OnFilteredBlockConnected(curStamp.Height, curHeader,
-			relevantTxs)
-	}
-
 	if ro.ntfn.OnBlockConnected != nil {
-		ro.ntfn.OnBlockConnected(&curStamp.Hash,
-			curStamp.Height, curHeader.Timestamp)
+		ro.ntfn.OnBlockConnected(
+			&curStamp.Hash, curStamp.Height, curHeader.Timestamp,
+		)
+	}
+	if ro.ntfn.OnFilteredBlockConnected != nil {
+		ro.ntfn.OnFilteredBlockConnected(
+			curStamp.Height, curHeader, relevantTxs,
+		)
 	}
 
 	return nil

--- a/sync_test.go
+++ b/sync_test.go
@@ -61,31 +61,33 @@ var (
 	// "fd":	OnFilteredBlockDisconnected
 	wantLog = func() (log []byte) {
 		for i := 1096; i <= 1100; i++ {
+			// BlockConnected
+			log = append(log, []byte("bc")...)
 			// FilteredBlockConnected
 			log = append(log, []byte("fc")...)
 			// 0 relevant TXs
 			log = append(log, 0x00)
-			// BlockConnected
-			log = append(log, []byte("bc")...)
 		}
 		// Block with one relevant (receive) transaction
-		log = append(log, []byte("rvfc")...)
-		log = append(log, 0x01)
+		log = append(log, []byte("rv")...)
 		log = append(log, []byte("bc")...)
+		log = append(log, []byte("fc")...)
+		log = append(log, 0x01)
 		// 124 blocks with nothing
 		for i := 1102; i <= 1225; i++ {
+			log = append(log, []byte("bc")...)
 			log = append(log, []byte("fc")...)
 			log = append(log, 0x00)
-			log = append(log, []byte("bc")...)
 		}
 		// Block with 1 redeeming transaction
-		log = append(log, []byte("rdfc")...)
-		log = append(log, 0x01)
+		log = append(log, []byte("rd")...)
 		log = append(log, []byte("bc")...)
+		log = append(log, []byte("fc")...)
+		log = append(log, 0x01)
 		// Block with nothing
+		log = append(log, []byte("bc")...)
 		log = append(log, []byte("fc")...)
 		log = append(log, 0x00)
-		log = append(log, []byte("bc")...)
 		// Update with rewind - rewind back to 1095, add another address,
 		// and see more interesting transactions.
 		for i := 1227; i >= 1096; i-- {
@@ -94,62 +96,66 @@ var (
 		}
 		// Forward to 1100
 		for i := 1096; i <= 1100; i++ {
+			// BlockConnected
+			log = append(log, []byte("bc")...)
 			// FilteredBlockConnected
 			log = append(log, []byte("fc")...)
 			// 0 relevant TXs
 			log = append(log, 0x00)
-			// BlockConnected
-			log = append(log, []byte("bc")...)
 		}
 		// Block with two relevant (receive) transactions
-		log = append(log, []byte("rvrvfc")...)
-		log = append(log, 0x02)
+		log = append(log, []byte("rvrv")...)
 		log = append(log, []byte("bc")...)
+		log = append(log, []byte("fc")...)
+		log = append(log, 0x02)
 		// 124 blocks with nothing
 		for i := 1102; i <= 1225; i++ {
+			log = append(log, []byte("bc")...)
 			log = append(log, []byte("fc")...)
 			log = append(log, 0x00)
-			log = append(log, []byte("bc")...)
 		}
 		// 2 blocks with 1 redeeming transaction each
 		for i := 1226; i <= 1227; i++ {
-			log = append(log, []byte("rdfc")...)
-			log = append(log, 0x01)
+			log = append(log, []byte("rd")...)
 			log = append(log, []byte("bc")...)
+			log = append(log, []byte("fc")...)
+			log = append(log, 0x01)
 		}
 		// Block with nothing
+		log = append(log, []byte("bc")...)
 		log = append(log, []byte("fc")...)
 		log = append(log, 0x00)
-		log = append(log, []byte("bc")...)
 		// 3 block rollback
 		for i := 1228; i >= 1226; i-- {
-			log = append(log, []byte("fdbd")...)
+			log = append(log, []byte("bdfd")...)
 		}
 		// 1 block reorg with 2 redeeming transactions
-		log = append(log, []byte("rdrdfc")...)
-		log = append(log, 0x02)
+		log = append(log, []byte("rdrd")...)
 		log = append(log, []byte("bc")...)
+		log = append(log, []byte("fc")...)
+		log = append(log, 0x02)
 		// 4 block empty reorg
 		for i := 1227; i <= 1230; i++ {
+			log = append(log, []byte("bc")...)
 			log = append(log, []byte("fc")...)
 			log = append(log, 0x00)
-			log = append(log, []byte("bc")...)
 		}
 		// 5 block rollback
 		for i := 1230; i >= 1226; i-- {
-			log = append(log, []byte("fdbd")...)
+			log = append(log, []byte("bdfd")...)
 		}
 		// 2 blocks with 1 redeeming transaction each
 		for i := 1226; i <= 1227; i++ {
-			log = append(log, []byte("rdfc")...)
-			log = append(log, 0x01)
+			log = append(log, []byte("rd")...)
 			log = append(log, []byte("bc")...)
+			log = append(log, []byte("fc")...)
+			log = append(log, 0x01)
 		}
 		// 8 block rest of reorg
 		for i := 1228; i <= 1235; i++ {
+			log = append(log, []byte("bc")...)
 			log = append(log, []byte("fc")...)
 			log = append(log, 0x00)
-			log = append(log, []byte("bc")...)
 		}
 		return log
 	}()


### PR DESCRIPTION
In this commit, we address a bug that would prevent the wallet from starting until a new block arrives if it was one block behind the tip of the chain. This is due to an implicit order in the way the Neutrino ChainSource within btcwallet handles RescanProgress and RescanFinished notifications. A RescanFinished notification (dispatched by the OnFilteredBlockConnected callback) can only get triggered after a RescanProgress notification (dispatched by the OnBlockConnected callback), so we swap the order of the two notification callbacks to ensure it matches the expected behavior.