### PR TITLE
 banman: add BanStore interface with implementation

### DIFF
--- a/banman/codec.go
+++ b/banman/codec.go
@@ -1,0 +1,83 @@
+package banman
+
+import (
+	"io"
+	"net"
+)
+
+// ipType represents the different types of IP addresses supported by the
+// BanStore interface.
+type ipType = byte
+
+const (
+	// ipv4 represents an IP address of type IPv4.
+	ipv4 ipType = 0
+
+	// ipv6 represents an IP address of type IPv6.
+	ipv6 ipType = 1
+)
+
+// encodeIPNet serializes the IP network into the given reader.
+func encodeIPNet(w io.Writer, ipNet *net.IPNet) error {
+	// Determine the appropriate IP type for the IP address contained in the
+	// network.
+	var (
+		ip     []byte
+		ipType ipType
+	)
+	switch {
+	case ipNet.IP.To4() != nil:
+		ip = ipNet.IP.To4()
+		ipType = ipv4
+	case ipNet.IP.To16() != nil:
+		ip = ipNet.IP.To16()
+		ipType = ipv6
+	default:
+		return ErrUnsupportedIP
+	}
+
+	// Write the IP type first in order to properly identify it when
+	// deserializing it, followed by the IP itself and its mask.
+	if _, err := w.Write([]byte{ipType}); err != nil {
+		return err
+	}
+	if _, err := w.Write(ip); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte(ipNet.Mask)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// decodeIPNet deserialized an IP network from the given reader.
+func decodeIPNet(r io.Reader) (*net.IPNet, error) {
+	// Read the IP address type and determine whether it is supported.
+	var ipType [1]byte
+	if _, err := r.Read(ipType[:]); err != nil {
+		return nil, err
+	}
+
+	var ipLen int
+	switch ipType[0] {
+	case ipv4:
+		ipLen = net.IPv4len
+	case ipv6:
+		ipLen = net.IPv6len
+	default:
+		return nil, ErrUnsupportedIP
+	}
+
+	// Once we have the type and its corresponding length, attempt to read
+	// it and its mask.
+	ip := make([]byte, ipLen)
+	if _, err := r.Read(ip[:]); err != nil {
+		return nil, err
+	}
+	mask := make([]byte, ipLen)
+	if _, err := r.Read(mask[:]); err != nil {
+		return nil, err
+	}
+	return &net.IPNet{IP: ip, Mask: mask}, nil
+}

--- a/banman/codec_test.go
+++ b/banman/codec_test.go
@@ -1,0 +1,107 @@
+package banman
+
+import (
+	"bytes"
+	"net"
+	"reflect"
+	"testing"
+)
+
+// TestIPNetSerialization ensures that we can serialize different supported IP
+// networks and deserialize them into their expected result.
+func TestIPNetSerialization(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		ipNet *net.IPNet
+		err   error
+	}{
+		{
+			name: "ipv4 without mask",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("172.217.6.46"),
+				Mask: net.IPv4Mask(0x00, 0x00, 0x00, 0x00),
+			},
+		},
+		{
+			name: "ipv4 with default mask",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("172.217.6.46"),
+				Mask: defaultIPv4Mask,
+			},
+		},
+		{
+			name: "ipv4 with non-default mask",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("172.217.6.46"),
+				Mask: net.IPv4Mask(0xff, 0xff, 0x00, 0x00),
+			},
+		},
+		{
+			name: "ipv6 without mask",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+				Mask: net.IPMask(make([]byte, net.IPv6len)),
+			},
+		},
+		{
+			name: "ipv6 with default mask",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+				Mask: defaultIPv6Mask,
+			},
+		},
+		{
+			name: "ipv6 with non-default mask",
+			ipNet: &net.IPNet{
+				IP: net.ParseIP("2001:db8:a0b:12f0::1"),
+				Mask: net.IPMask([]byte{
+					0xff, 0xff, 0x00, 0x00, 0x00, 0xff,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00,
+				}),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		success := t.Run(testCase.name, func(t *testing.T) {
+			// Serialize the IP network and deserialize it back.
+			// We'll do this to ensure we are properly serializing
+			// and deserializing them.
+			var b bytes.Buffer
+			err := encodeIPNet(&b, testCase.ipNet)
+			if testCase.err != nil && err != testCase.err {
+				t.Fatalf("encoding IP network %v expected "+
+					"error \"%v\", got \"%v\"",
+					testCase.ipNet, testCase.err, err)
+			}
+			ipNet, err := decodeIPNet(&b)
+			if testCase.err != nil && err != testCase.err {
+				t.Fatalf("decoding IP network %v expected "+
+					"error \"%v\", got \"%v\"",
+					testCase.ipNet, testCase.err, err)
+			}
+
+			// If the test did not expect a result, i.e., an invalid
+			// IP network, then we can exit now.
+			if testCase.err != nil {
+				return
+			}
+
+			// Otherwise, ensure the result is what we expect.
+			if !ipNet.IP.Equal(testCase.ipNet.IP) {
+				t.Fatalf("expected IP %v, got %v",
+					testCase.ipNet.IP, ipNet.IP)
+			}
+			if !reflect.DeepEqual(ipNet.Mask, testCase.ipNet.Mask) {
+				t.Fatalf("expected mask %#v, got %#v",
+					testCase.ipNet.Mask, ipNet.Mask)
+			}
+		})
+		if !success {
+			return
+		}
+	}
+}

--- a/banman/reason.go
+++ b/banman/reason.go
@@ -1,0 +1,43 @@
+package banman
+
+// Reason includes the different possible reasons which caused us to ban a peer.
+type Reason uint8
+
+// We prevent using `iota` to ensure the order does not have the value since
+// these are serialized within the database.
+const (
+	// ExcedeedBanThreshold signals that a peer exceeded its ban threshold.
+	ExceededBanThreshold Reason = 1
+
+	// NoCompactFilters signals that a peer was unable to serve us compact
+	// filters.
+	NoCompactFilters Reason = 2
+
+	// InvalidFilterHeader signals that a peer served us an invalid filter
+	// header.
+	InvalidFilterHeader Reason = 3
+
+	// InvalidFilterHeaderCheckpoint signals that a peer served us an
+	// invalid filter header checkpoint.
+	InvalidFilterHeaderCheckpoint Reason = 4
+)
+
+// String returns a human-readable description for the reason a peer was banned.
+func (r Reason) String() string {
+	switch r {
+	case ExceededBanThreshold:
+		return "peer exceeded ban threshold"
+
+	case NoCompactFilters:
+		return "peer was unable to serve compact filters"
+
+	case InvalidFilterHeader:
+		return "peer served invalid filter header"
+
+	case InvalidFilterHeaderCheckpoint:
+		return "peer served invalid filter header checkpoint"
+
+	default:
+		return "unknown reason"
+	}
+}

--- a/banman/store.go
+++ b/banman/store.go
@@ -1,0 +1,221 @@
+package banman
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/btcsuite/btcwallet/walletdb"
+)
+
+var (
+	// byteOrder is the preferred byte order in which we should write things
+	// to disk.
+	byteOrder = binary.BigEndian
+
+	// banStoreBucket is the top level bucket of the Store that will contain
+	// all relevant sub-buckets.
+	banStoreBucket = []byte("ban-store")
+
+	// banBucket is the main index in which we keep track of IP networks and
+	// their absolute expiration time.
+	//
+	// The key is the IP network host and the value is the absolute
+	// expiration time.
+	banBucket = []byte("ban-index")
+
+	// reasonBucket is an index in which we keep track of why an IP network
+	// was banned.
+	//
+	// The key is the IP network and the value is the Reason.
+	reasonBucket = []byte("reason-index")
+
+	// ErrCorruptedStore is an error returned when we attempt to locate any
+	// of the ban-related buckets in the database but are unable to.
+	ErrCorruptedStore = errors.New("corrupted ban store")
+
+	// ErrUnsupportedIP is an error returned when we attempt to parse an
+	// unsupported IP address type.
+	ErrUnsupportedIP = errors.New("unsupported IP type")
+)
+
+// Status gathers all of the details regarding an IP network's ban status.
+type Status struct {
+	// Banned determines whether the IP network is currently banned.
+	Banned bool
+
+	// Reason is the reason for which the IP network was banned.
+	Reason Reason
+
+	// Expiration is the absolute time in which the ban will expire.
+	Expiration time.Time
+}
+
+// Store is the store responsible for maintaining records of banned IP networks.
+// It uses IP networks, rather than single IP addresses, in order to coalesce
+// multiple IP addresses that are likely to be correlated.
+type Store interface {
+	// BanIPNet creates a ban record for the IP network within the store for
+	// the given duration. A reason can also be provided to note why the IP
+	// network is being banned. The record will exist until a call to Status
+	// is made after the ban expiration.
+	BanIPNet(*net.IPNet, Reason, time.Duration) error
+
+	// Status returns the ban status for a given IP network.
+	Status(*net.IPNet) (Status, error)
+}
+
+// NewStore returns a Store backed by a database.
+func NewStore(db walletdb.DB) (Store, error) {
+	return newBanStore(db)
+}
+
+// banStore is a concrete implementation of the Store interface backed by a
+// database.
+type banStore struct {
+	db walletdb.DB
+}
+
+// A compile-time constraint to ensure banStore satisfies the Store interface.
+var _ Store = (*banStore)(nil)
+
+// newBanStore creates a concrete implementation of the Store interface backed
+// by a database.
+func newBanStore(db walletdb.DB) (*banStore, error) {
+	s := &banStore{db: db}
+
+	// We'll ensure the expected buckets are created upon initialization.
+	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		banStore, err := tx.CreateTopLevelBucket(banStoreBucket)
+		if err != nil {
+			return err
+		}
+		_, err = banStore.CreateBucketIfNotExists(banBucket)
+		if err != nil {
+			return err
+		}
+		_, err = banStore.CreateBucketIfNotExists(reasonBucket)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// BanIPNet creates a ban record for the IP network within the store for the
+// given duration. A reason can also be provided to note why the IP network is
+// being banned. The record will exist until a call to Status is made after the
+// ban expiration.
+func (s *banStore) BanIPNet(ipNet *net.IPNet, reason Reason, duration time.Duration) error {
+	return walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		banStore := tx.ReadWriteBucket(banStoreBucket)
+		if banStore == nil {
+			return ErrCorruptedStore
+		}
+		banIndex := banStore.NestedReadWriteBucket(banBucket)
+		if banIndex == nil {
+			return ErrCorruptedStore
+		}
+		reasonIndex := banStore.NestedReadWriteBucket(reasonBucket)
+		if reasonIndex == nil {
+			return ErrCorruptedStore
+		}
+
+		var ipNetBuf bytes.Buffer
+		if err := encodeIPNet(&ipNetBuf, ipNet); err != nil {
+			return fmt.Errorf("unable to encode %v: %v", ipNet, err)
+		}
+		k := ipNetBuf.Bytes()
+
+		return addBannedIPNet(banIndex, reasonIndex, k, reason, duration)
+	})
+}
+
+// addBannedIPNet adds an entry to the ban store for the given IP network.
+func addBannedIPNet(banIndex, reasonIndex walletdb.ReadWriteBucket,
+	ipNetKey []byte, reason Reason, duration time.Duration) error {
+
+	var v [8]byte
+	banExpiration := time.Now().Add(duration)
+	byteOrder.PutUint64(v[:], uint64(banExpiration.Unix()))
+
+	if err := banIndex.Put(ipNetKey, v[:]); err != nil {
+		return err
+	}
+	return reasonIndex.Put(ipNetKey, []byte{byte(reason)})
+}
+
+// Status returns the ban status for a given IP network.
+func (s *banStore) Status(ipNet *net.IPNet) (Status, error) {
+	var banStatus Status
+	err := walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		banStore := tx.ReadWriteBucket(banStoreBucket)
+		if banStore == nil {
+			return ErrCorruptedStore
+		}
+		banIndex := banStore.NestedReadWriteBucket(banBucket)
+		if banIndex == nil {
+			return ErrCorruptedStore
+		}
+		reasonIndex := banStore.NestedReadWriteBucket(reasonBucket)
+		if reasonIndex == nil {
+			return ErrCorruptedStore
+		}
+
+		var ipNetBuf bytes.Buffer
+		if err := encodeIPNet(&ipNetBuf, ipNet); err != nil {
+			return fmt.Errorf("unable to encode %v: %v", ipNet, err)
+		}
+		k := ipNetBuf.Bytes()
+
+		status := fetchStatus(banIndex, reasonIndex, k)
+
+		// If the IP network's ban duration has expired, we can remove
+		// its entry from the store.
+		if !time.Now().Before(status.Expiration) {
+			return removeBannedIPNet(banIndex, reasonIndex, k)
+		}
+
+		banStatus = status
+		return nil
+	})
+	if err != nil {
+		return Status{}, err
+	}
+
+	return banStatus, nil
+}
+
+// fetchStatus retrieves the ban status of the given IP network.
+func fetchStatus(banIndex, reasonIndex walletdb.ReadWriteBucket,
+	ipNetKey []byte) Status {
+
+	v := banIndex.Get(ipNetKey)
+	if v == nil {
+		return Status{}
+	}
+	reason := Reason(reasonIndex.Get(ipNetKey)[0])
+	banExpiration := time.Unix(int64(byteOrder.Uint64(v)), 0)
+
+	return Status{
+		Banned:     true,
+		Reason:     reason,
+		Expiration: banExpiration,
+	}
+}
+
+// removeBannedIPNet removes all references to a banned IP network within the
+// ban store.
+func removeBannedIPNet(banIndex, reasonIndex walletdb.ReadWriteBucket,
+	ipNetKey []byte) error {
+
+	if err := banIndex.Delete(ipNetKey); err != nil {
+		return err
+	}
+	return reasonIndex.Delete(ipNetKey)
+}

--- a/banman/store_test.go
+++ b/banman/store_test.go
@@ -1,0 +1,126 @@
+package banman_test
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcwallet/walletdb"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/lightninglabs/neutrino/banman"
+)
+
+// createTestBanStore creates a test Store backed by a boltdb instance.
+func createTestBanStore(t *testing.T) (banman.Store, func()) {
+	t.Helper()
+
+	dbDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unable to create db dir: %v", err)
+	}
+	dbPath := filepath.Join(dbDir, "test.db")
+
+	db, err := walletdb.Create("bdb", dbPath)
+	if err != nil {
+		os.RemoveAll(dbDir)
+		t.Fatalf("unable to create db: %v", err)
+	}
+
+	cleanUp := func() {
+		db.Close()
+		os.RemoveAll(dbDir)
+	}
+
+	banStore, err := banman.NewStore(db)
+	if err != nil {
+		cleanUp()
+		t.Fatalf("unable to create ban store: %v", err)
+	}
+
+	return banStore, cleanUp
+}
+
+// TestBanStore ensures that the BanStore's state correctly reflects the
+// BanStatus of IP networks.
+func TestBanStore(t *testing.T) {
+	t.Parallel()
+
+	// We'll start by creating our test BanStore backed by a boltdb
+	// instance.
+	banStore, cleanUp := createTestBanStore(t)
+	defer cleanUp()
+
+	// checkBanStore is a helper closure to ensure to the IP network's ban
+	// status is correctly reflected within the BanStore.
+	checkBanStore := func(ipNet *net.IPNet, banned bool,
+		reason banman.Reason, duration time.Duration) {
+
+		t.Helper()
+
+		banStatus, err := banStore.Status(ipNet)
+		if err != nil {
+			t.Fatalf("unable to determine %v's ban status: %v",
+				ipNet, err)
+		}
+		if banned && !banStatus.Banned {
+			t.Fatalf("expected %v to be banned", ipNet)
+		}
+		if !banned && banStatus.Banned {
+			t.Fatalf("expected %v to not be banned", ipNet)
+		}
+
+		if banned {
+			return
+		}
+
+		if banStatus.Reason != reason {
+			t.Fatalf("expected ban reason \"%v\", got \"%v\"",
+				reason, banStatus.Reason)
+		}
+		banDuration := banStatus.Expiration.Sub(time.Now())
+		if banStatus.Expiration.Sub(time.Now()) > duration {
+			t.Fatalf("expected ban duration to be within %v, got %v",
+				duration, banDuration)
+		}
+	}
+
+	// We'll create two IP networks, the first banned for an hour and the
+	// second for a second.
+	addr1 := "127.0.0.1:8333"
+	ipNet1, err := banman.ParseIPNet(addr1, nil)
+	if err != nil {
+		t.Fatalf("unable to parse IP network from %v: %v", addr1, err)
+	}
+	err = banStore.BanIPNet(ipNet1, banman.NoCompactFilters, time.Hour)
+	if err != nil {
+		t.Fatalf("unable to ban IP network: %v", err)
+	}
+	addr2 := "192.168.1.1:8333"
+	ipNet2, err := banman.ParseIPNet(addr2, nil)
+	if err != nil {
+		t.Fatalf("unable to parse IP network from %v: %v", addr2, err)
+	}
+	err = banStore.BanIPNet(ipNet2, banman.ExceededBanThreshold, time.Second)
+	if err != nil {
+		t.Fatalf("unable to ban IP network: %v", err)
+	}
+
+	// Both IP networks should be found within the BanStore with their
+	// expected reason since their ban has yet to expire.
+	checkBanStore(ipNet1, true, banman.NoCompactFilters, time.Hour)
+	checkBanStore(ipNet2, true, banman.ExceededBanThreshold, time.Second)
+
+	// Wait long enough for the second IP network's ban to expire.
+	<-time.After(time.Second)
+
+	// We should only find the first IP network within the BanStore.
+	checkBanStore(ipNet1, true, banman.NoCompactFilters, time.Hour)
+	checkBanStore(ipNet2, false, 0, 0)
+
+	// We'll query for second IP network again as it should now be unknown
+	// to the BanStore. We should expect not to find anything regarding it.
+	checkBanStore(ipNet2, false, 0, 0)
+}

--- a/banman/util.go
+++ b/banman/util.go
@@ -1,0 +1,48 @@
+package banman
+
+import (
+	"net"
+)
+
+var (
+	// defaultIPv4Mask is the default IPv4 mask used when parsing IP
+	// networks from an address. This ensures that the IP network only
+	// contains *one* IP address -- the one specified.
+	defaultIPv4Mask = net.CIDRMask(32, 32)
+
+	// defaultIPv6Mask is the default IPv6 mask used when parsing IP
+	// networks from an address. This ensures that the IP network only
+	// contains *one* IP address -- the one specified.
+	defaultIPv6Mask = net.CIDRMask(128, 128)
+)
+
+// ParseIPNet parses the IP network that contains the given address. An optional
+// mask can be provided, to expand the scope of the IP network, otherwise the
+// IP's default is used.
+//
+// NOTE: This assumes that the address has already been resolved.
+func ParseIPNet(addr string, mask net.IPMask) (*net.IPNet, error) {
+	// If the address includes a port, we'll remove it.
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// Address doesn't include a port.
+		host = addr
+	}
+
+	// Parse the IP from the host to ensure it is supported.
+	ip := net.ParseIP(host)
+	switch {
+	case ip.To4() != nil:
+		if mask == nil {
+			mask = defaultIPv4Mask
+		}
+	case ip.To16() != nil:
+		if mask == nil {
+			mask = defaultIPv6Mask
+		}
+	default:
+		return nil, ErrUnsupportedIP
+	}
+
+	return &net.IPNet{IP: ip.Mask(mask), Mask: mask}, nil
+}

--- a/banman/util_test.go
+++ b/banman/util_test.go
@@ -1,0 +1,89 @@
+package banman
+
+import (
+	"net"
+	"reflect"
+	"testing"
+)
+
+// TestParseIPNet ensures that we can parse different combinations of
+// IPs/addresses and masks.
+func TestParseIPNet(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		addr   string
+		mask   net.IPMask
+		result *net.IPNet
+	}{
+		{
+			name: "ipv4 with default mask",
+			addr: "192.168.1.1",
+			mask: nil,
+			result: &net.IPNet{
+				IP:   net.ParseIP("192.168.1.1"),
+				Mask: defaultIPv4Mask,
+			},
+		},
+		{
+			name: "ipv4 with port and non-default mask",
+			addr: "192.168.1.1:80",
+			mask: net.CIDRMask(16, 32),
+			result: &net.IPNet{
+				IP:   net.ParseIP("192.168.0.0"),
+				Mask: net.CIDRMask(16, 32),
+			},
+		},
+		{
+			name: "ipv6 with port and default mask",
+			addr: "[2001:db8:a0b:12f0::1]:80",
+			mask: nil,
+			result: &net.IPNet{
+				IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+				Mask: defaultIPv6Mask,
+			},
+		},
+		{
+			name: "ipv6 with non-default mask",
+			addr: "2001:db8:a0b:12f0::1",
+			mask: net.CIDRMask(32, 128),
+			result: &net.IPNet{
+				IP:   net.ParseIP("2001:db8::"),
+				Mask: net.CIDRMask(32, 128),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		success := t.Run(testCase.name, func(t *testing.T) {
+			// Parse the IP network from each test's address and
+			// mask.
+			ipNet, err := ParseIPNet(testCase.addr, testCase.mask)
+			if testCase.result != nil && err != nil {
+				t.Fatalf("unable to parse IP network for "+
+					"addr=%v and mask=%v: %v",
+					testCase.addr, testCase.mask, err)
+			}
+
+			// If the test did not expect a result, i.e., an invalid
+			// IP network, then we can exit now.
+			if testCase.result == nil {
+				return
+			}
+
+			// Otherwise, ensure the result is what we expect.
+			if !ipNet.IP.Equal(testCase.result.IP) {
+				t.Fatalf("expected IP %v, got %v",
+					testCase.result.IP, ipNet.IP)
+			}
+			if !reflect.DeepEqual(ipNet.Mask, testCase.result.Mask) {
+				t.Fatalf("expected mask %#v, got %#v",
+					testCase.result.Mask, ipNet.Mask)
+			}
+		})
+		if !success {
+			return
+		}
+	}
+}

--- a/neutrino.go
+++ b/neutrino.go
@@ -22,6 +22,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/lightninglabs/neutrino/banman"
 	"github.com/lightninglabs/neutrino/blockntfns"
 	"github.com/lightninglabs/neutrino/cache/lru"
 	"github.com/lightninglabs/neutrino/filterdb"
@@ -100,7 +101,6 @@ type updatePeerHeightsMsg struct {
 type peerState struct {
 	outboundPeers   map[int32]*ServerPeer
 	persistentPeers map[int32]*ServerPeer
-	banned          map[string]time.Time
 	outboundGroups  map[string]int
 }
 
@@ -209,26 +209,36 @@ func (sp *ServerPeer) addressKnown(na *wire.NetAddress) bool {
 // the score is above the ban threshold, the peer will be banned and
 // disconnected.
 func (sp *ServerPeer) addBanScore(persistent, transient uint32, reason string) {
-	// No warning is logged and no score is calculated if banning is disabled.
+	// No warning is logged and no score is calculated if banning is
+	// disabled.
 	warnThreshold := BanThreshold >> 1
 	if transient == 0 && persistent == 0 {
-		// The score is not being increased, but a warning message is still
-		// logged if the score is above the warn threshold.
+		// The score is not being increased, but a warning message is
+		// still logged if the score is above the warn threshold.
 		score := sp.banScore.Int()
 		if score > warnThreshold {
-			log.Warnf("Misbehaving peer %s: %s -- ban score is %d, "+
-				"it was not increased this time", sp, reason, score)
+			log.Warnf("Misbehaving peer %s: %s -- ban score is "+
+				"%d, it was not increased this time", sp,
+				reason, score)
 		}
 		return
 	}
+
 	score := sp.banScore.Increase(persistent, transient)
 	if score > warnThreshold {
 		log.Warnf("Misbehaving peer %s: %s -- ban score increased to %d",
 			sp, reason, score)
+
 		if score > BanThreshold {
-			log.Warnf("Misbehaving peer %s -- banning and disconnecting",
-				sp)
-			sp.server.BanPeer(sp)
+			peerAddr := sp.Addr()
+			err := sp.server.BanPeer(
+				peerAddr, banman.ExceededBanThreshold,
+			)
+			if err != nil {
+				log.Errorf("Unable to ban peer %v: %v",
+					peerAddr, err)
+			}
+
 			sp.Disconnect()
 		}
 	}
@@ -266,10 +276,12 @@ func (sp *ServerPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 	if peerServices&wire.SFNodeWitness != wire.SFNodeWitness ||
 		peerServices&wire.SFNodeCF != wire.SFNodeCF {
 
-		log.Infof("Removing peer %v, cannot serve compact "+
-			"filters", sp)
+		peerAddr := sp.Addr()
+		err := sp.server.BanPeer(peerAddr, banman.NoCompactFilters)
+		if err != nil {
+			log.Errorf("Unable to ban peer %v: %v", peerAddr, err)
+		}
 
-		sp.server.BanPeer(sp)
 		if sp.connReq != nil {
 			sp.server.connManager.Remove(sp.connReq.ID())
 		}
@@ -578,7 +590,6 @@ type ChainService struct {
 	blockSubscriptionMgr *blockntfns.SubscriptionManager
 	newPeers             chan *ServerPeer
 	donePeers            chan *ServerPeer
-	banPeers             chan *ServerPeer
 	query                chan interface{}
 	firstPeerConnect     chan struct{}
 	peerHeightsUpdate    chan updatePeerHeightsMsg
@@ -588,6 +599,7 @@ type ChainService struct {
 	services             wire.ServiceFlag
 	utxoScanner          *UtxoScanner
 	broadcaster          *pushtx.Broadcaster
+	banStore             banman.Store
 
 	// TODO: Add a map for more granular exclusion?
 	mtxCFilter sync.Mutex
@@ -639,7 +651,6 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		addrManager:       amgr,
 		newPeers:          make(chan *ServerPeer, MaxPeers),
 		donePeers:         make(chan *ServerPeer, MaxPeers),
-		banPeers:          make(chan *ServerPeer, MaxPeers),
 		query:             make(chan interface{}),
 		quit:              make(chan struct{}),
 		firstPeerConnect:  make(chan struct{}),
@@ -838,6 +849,11 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		RebroadcastInterval: pushtx.DefaultRebroadcastInterval,
 	})
 
+	s.banStore, err = banman.NewStore(cfg.Database)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize ban store: %v", err)
+	}
+
 	return &s, nil
 }
 
@@ -900,13 +916,41 @@ func (s *ChainService) GetBlockHeight(hash *chainhash.Hash) (int32, error) {
 	return int32(height), nil
 }
 
-// BanPeer bans a peer that has already been connected to the server by ip.
-func (s *ChainService) BanPeer(sp *ServerPeer) {
-	select {
-	case s.banPeers <- sp:
-	case <-s.quit:
-		return
+// BanPeer bans a peer due to a specific reason for a duration of BanDuration.
+func (s *ChainService) BanPeer(addr string, reason banman.Reason) error {
+	log.Warnf("Banning peer %v: duration=%v, reason=%v", addr, BanDuration,
+		reason)
+
+	ipNet, err := banman.ParseIPNet(addr, nil)
+	if err != nil {
+		return fmt.Errorf("unable to parse IP network for peer %v: %v",
+			addr, err)
 	}
+	return s.banStore.BanIPNet(ipNet, reason, BanDuration)
+}
+
+// IsBanned returns true if the peer is banned, and false otherwise.
+func (s *ChainService) IsBanned(addr string) bool {
+	ipNet, err := banman.ParseIPNet(addr, nil)
+	if err != nil {
+		log.Errorf("Unable to parse IP network for peer %v: %v", addr,
+			err)
+		return false
+	}
+	banStatus, err := s.banStore.Status(ipNet)
+	if err != nil {
+		log.Errorf("Unable to determine ban status for peer %v: %v",
+			addr, err)
+		return false
+	}
+
+	// Log how much time left the peer will remain banned for, if any.
+	if time.Now().Before(banStatus.Expiration) {
+		log.Debugf("Peer %v is banned for another %v", addr,
+			banStatus.Expiration.Sub(time.Now()))
+	}
+
+	return banStatus.Banned
 }
 
 // AddPeer adds a new peer that has already been connected to the server.
@@ -1000,7 +1044,6 @@ func (s *ChainService) peerHandler() {
 	state := &peerState{
 		persistentPeers: make(map[int32]*ServerPeer),
 		outboundPeers:   make(map[int32]*ServerPeer),
-		banned:          make(map[string]time.Time),
 		outboundGroups:  make(map[string]int),
 	}
 
@@ -1049,10 +1092,6 @@ out:
 		case umsg := <-s.peerHeightsUpdate:
 			s.handleUpdatePeerHeights(state, umsg)
 
-		// Peer to ban.
-		case p := <-s.banPeers:
-			s.handleBanPeerMsg(state, p)
-
 		case qmsg := <-s.query:
 			s.handleQuery(state, qmsg)
 
@@ -1073,7 +1112,6 @@ cleanup:
 		select {
 		case <-s.newPeers:
 		case <-s.donePeers:
-		case <-s.banPeers:
 		case <-s.peerHeightsUpdate:
 		case <-s.query:
 		default:
@@ -1149,38 +1187,6 @@ func (s *ChainService) handleUpdatePeerHeights(state *peerState, umsg updatePeer
 	})
 }
 
-// isBanned returns true if the passed peer address is still considered to be
-// banned.
-func (s *ChainService) isBanned(addr string, state *peerState) bool {
-	// First, we'll extract the host so we can consider it without taking
-	// into account the target port.
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		log.Debugf("can't split host/port: %s", err)
-		return false
-	}
-
-	// With the host obtained, we'll check on the ban status of this peer.
-	if banEnd, ok := state.banned[host]; ok {
-		// If the ban duration of this peer is still active, then we'll
-		// ignore it for now as it's still banned.
-		if time.Now().Before(banEnd) {
-			log.Debugf("Peer %s is banned for another %v - ignoring",
-				host, banEnd.Sub(time.Now()))
-			return true
-		}
-
-		// Otherwise, the peer was banned in the past, but is no longer
-		// banned, so we'll remove this ban entry and return back to
-		// the caller.
-		log.Infof("Peer %s is no longer banned", host)
-		delete(state.banned, host)
-		return false
-	}
-
-	return false
-}
-
 // handleAddPeerMsg deals with adding new peers.  It is invoked from the
 // peerHandler goroutine.
 func (s *ChainService) handleAddPeerMsg(state *peerState, sp *ServerPeer) bool {
@@ -1196,7 +1202,7 @@ func (s *ChainService) handleAddPeerMsg(state *peerState, sp *ServerPeer) bool {
 	}
 
 	// Disconnect banned peers.
-	if s.isBanned(sp.Addr(), state) {
+	if s.IsBanned(sp.Addr()) {
 		sp.Disconnect()
 		return false
 	}
@@ -1256,7 +1262,7 @@ func (s *ChainService) handleDonePeerMsg(state *peerState, sp *ServerPeer) {
 		// If the peer has been banned, we'll remove the connection
 		// request from the manager to ensure we don't reconnect again.
 		// Otherwise, we'll just simply disconnect.
-		if s.isBanned(sp.connReq.Addr.String(), state) {
+		if s.IsBanned(sp.connReq.Addr.String()) {
 			s.connManager.Remove(sp.connReq.ID())
 		} else {
 			s.connManager.Disconnect(sp.connReq.ID())
@@ -1271,18 +1277,6 @@ func (s *ChainService) handleDonePeerMsg(state *peerState, sp *ServerPeer) {
 
 	// If we get here it means that either we didn't know about the peer
 	// or we purposefully deleted it.
-}
-
-// handleBanPeerMsg deals with banning peers.  It is invoked from the
-// peerHandler goroutine.
-func (s *ChainService) handleBanPeerMsg(state *peerState, sp *ServerPeer) {
-	host, _, err := net.SplitHostPort(sp.Addr())
-	if err != nil {
-		log.Debugf("can't split ban peer %s: %s", sp.Addr(), err)
-		return
-	}
-	log.Infof("Banned peer %s for %v", host, BanDuration)
-	state.banned[host] = time.Now().Add(BanDuration)
 }
 
 // disconnectPeer attempts to drop the connection of a tageted peer in the

--- a/notifications.go
+++ b/notifications.go
@@ -50,11 +50,6 @@ type forAllPeersMsg struct {
 	closure func(*ServerPeer)
 }
 
-type banQueryMsg struct {
-	addr  string
-	reply chan bool
-}
-
 // TODO: General - abstract out more of blockmanager into queries. It'll make
 // this way more maintainable and usable.
 
@@ -173,10 +168,6 @@ func (s *ChainService) handleQuery(state *peerState, querymsg interface{}) {
 		// Even though this is a query, there's no reply channel as the
 		// forAllPeers method doesn't return anything. An error might be
 		// useful in the future.
-
-	// A query to see if a peer is banned or not.
-	case banQueryMsg:
-		msg.reply <- s.isBanned(msg.addr, state)
 	}
 }
 
@@ -323,20 +314,5 @@ func (s *ChainService) ForAllPeers(closure func(sp *ServerPeer)) {
 	select {
 	case s.query <- forAllPeersMsg{closure: closure}:
 	case <-s.quit:
-	}
-}
-
-// IsBanned retursn true if the peer is banned, and false otherwise.
-func (s *ChainService) IsBanned(addr string) bool {
-	replyChan := make(chan bool, 1)
-
-	select {
-	case s.query <- banQueryMsg{
-		addr:  addr,
-		reply: replyChan,
-	}:
-		return <-replyChan
-	case <-s.quit:
-		return false
 	}
 }

--- a/sync_test.go
+++ b/sync_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
 	"github.com/lightninglabs/neutrino"
+	"github.com/lightninglabs/neutrino/banman"
 )
 
 var (
@@ -522,7 +523,7 @@ func testStartRescan(harness *neutrinoHarness, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't sign transaction: %s", err)
 	}
-	banPeer(harness.svc, harness.h2)
+	banPeer(t, harness.svc, harness.h2)
 	err = harness.svc.SendTransaction(authTx1.Tx)
 	if err != nil && !strings.Contains(err.Error(), "already have") {
 		t.Fatalf("Unable to send transaction to network: %s", err)
@@ -564,7 +565,7 @@ func testStartRescan(harness *neutrinoHarness, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't sign transaction: %s", err)
 	}
-	banPeer(harness.svc, harness.h2)
+	banPeer(t, harness.svc, harness.h2)
 	err = harness.svc.SendTransaction(authTx2.Tx)
 	if err != nil && !strings.Contains(err.Error(), "already have") {
 		t.Fatalf("Unable to send transaction to network: %s", err)
@@ -1483,13 +1484,25 @@ func checkRescanStatus() (int, int32, error) {
 
 // banPeer bans and disconnects the requested harness from the ChainService
 // instance for BanDuration seconds.
-func banPeer(svc *neutrino.ChainService, harness *rpctest.Harness) {
+func banPeer(t *testing.T, svc *neutrino.ChainService, harness *rpctest.Harness) {
+	t.Helper()
+
 	peers := svc.Peers()
 	for _, peer := range peers {
-		if peer.Addr() == harness.P2PAddress() {
-			svc.BanPeer(peer)
-			peer.Disconnect()
+		peerAddr := peer.Addr()
+		if peerAddr != harness.P2PAddress() {
+			continue
 		}
+
+		err := svc.BanPeer(peerAddr, banman.ExceededBanThreshold)
+		if err != nil {
+			if logLevel != btclog.LevelOff {
+				t.Fatalf("unable to ban peer %v: %v", peerAddr,
+					err)
+			}
+		}
+
+		peer.Disconnect()
 	}
 }
 


### PR DESCRIPTION
In this PR, we introduce a new BanStore interface, along with a concrete implementation that will be backed by a boltdb instance, that will serve as a persistent ban store for peers. This prevents us from reconnecting to known bad peers until their respective ban expires.