### PR TITLE
pushtx/broadcaster: make rebroadcast tx async

### DIFF
--- a/pushtx/broadcaster_test.go
+++ b/pushtx/broadcaster_test.go
@@ -131,7 +131,7 @@ func TestRebroadcast(t *testing.T) {
 
 		for i := 0; i < len(expectedOrder); i++ {
 			tx := <-broadcastChan
-			if tx != expectedOrder[i] {
+			if tx.TxHash() != expectedOrder[i].TxHash() {
 				t.Fatalf("expected transaction %v, got %v",
 					expectedOrder[i].TxHash(), tx.TxHash())
 			}
@@ -154,10 +154,10 @@ func TestRebroadcast(t *testing.T) {
 	// as confirmed, and the second as it being accepted into the mempool.
 	broadcaster.cfg.Broadcast = func(tx *wire.MsgTx) error {
 		broadcastChan <- tx
-		if tx == txs[0] {
+		if tx.TxHash() == txs[0].TxHash() {
 			return &BroadcastError{Code: Confirmed}
 		}
-		if tx == txs[1] {
+		if tx.TxHash() == txs[1].TxHash() {
 			return &BroadcastError{Code: Mempool}
 		}
 		return nil


### PR DESCRIPTION
This commit makes the rebroadcast logic being run in a goroutine. This
is done to ensure we don't block the whole broadcast loop while
performing a rebroadcast.

Rebroadcasts can be slow if the number of transactions are large (each
broadcast has a timeout of 0.5s), which would cause publishing new
transactions to block. With this commit we let the rebroadcast continue
in the background, while we can keep pushing new txs.


### TODO
- [x] unit tests