### PR TITLE
headerfs: add ability to assert the state of the filter header chain

### DIFF
--- a/bamboozle_unit_test.go
+++ b/bamboozle_unit_test.go
@@ -433,7 +433,8 @@ func runCheckCFCheckptSanityTestCase(t *testing.T, testCase *cfCheckptTestCase) 
 	}
 
 	cfStore, err := headerfs.NewFilterHeaderStore(
-		tempDir, db, headerfs.RegularFilter, &chaincfg.SimNetParams,
+		tempDir, db, headerfs.RegularFilter,
+		&chaincfg.SimNetParams, nil,
 	)
 	if err != nil {
 		t.Fatalf("Error creating filter header store: %s", err)

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -54,7 +54,7 @@ func setupBlockManager() (*blockManager, headerfs.BlockHeaderStore,
 
 	cfStore, err := headerfs.NewFilterHeaderStore(
 		tempDir, db, headerfs.RegularFilter,
-		&chaincfg.SimNetParams,
+		&chaincfg.SimNetParams, nil,
 	)
 	if err != nil {
 		cleanUp()

--- a/headerfs/file.go
+++ b/headerfs/file.go
@@ -9,6 +9,12 @@ import (
 	"github.com/btcsuite/btcd/wire"
 )
 
+// ErrHeaderNotFound is returned when a target header on disk (flat file) can't
+// be found.
+type ErrHeaderNotFound struct {
+	error
+}
+
 // appendRaw appends a new raw header to the end of the flat file.
 func (h *headerStore) appendRaw(header []byte) error {
 	if _, err := h.file.Write(header); err != nil {
@@ -44,7 +50,7 @@ func (h *headerStore) readRaw(seekDist uint64) ([]byte, error) {
 	// buffer.
 	rawHeader := make([]byte, headerSize)
 	if _, err := h.file.ReadAt(rawHeader[:], int64(seekDist)); err != nil {
-		return nil, err
+		return nil, &ErrHeaderNotFound{err}
 	}
 
 	return rawHeader[:], nil

--- a/headerfs/store.go
+++ b/headerfs/store.go
@@ -81,7 +81,7 @@ var headerBufPool = sync.Pool{
 type headerStore struct {
 	mtx sync.RWMutex
 
-	filePath string
+	fileName string
 
 	file *os.File
 
@@ -122,7 +122,7 @@ func newHeaderStore(db walletdb.DB, filePath string,
 	}
 
 	return &headerStore{
-		filePath:    filePath,
+		fileName:    flatFileName,
 		file:        headerFile,
 		headerIndex: index,
 	}, nil
@@ -596,7 +596,8 @@ type FilterHeaderStore struct {
 // FilterHeaderStore, then the initial genesis filter header will need to be
 // inserted.
 func NewFilterHeaderStore(filePath string, db walletdb.DB,
-	filterType HeaderType, netParams *chaincfg.Params) (*FilterHeaderStore, error) {
+	filterType HeaderType, netParams *chaincfg.Params,
+	headerStateAssertion *FilterHeader) (*FilterHeaderStore, error) {
 
 	fStore, err := newHeaderStore(db, filePath, filterType)
 	if err != nil {
@@ -655,6 +656,15 @@ func NewFilterHeaderStore(filePath string, db walletdb.DB,
 		return fhs, nil
 	}
 
+	// If we have a state assertion then we'll check it now to see if we
+	// need to modify our filter header files before we proceed.
+	if headerStateAssertion != nil {
+		err := fhs.maybeResetHeaderState(headerStateAssertion)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// As a final initialization step, we'll ensure that the header tip
 	// within the flat files, is in sync with out database index.
 	tipHash, tipHeight, err := fhs.chainTip()
@@ -691,6 +701,34 @@ func NewFilterHeaderStore(filePath string, db walletdb.DB,
 	// TODO(roasbeef): make above into func
 
 	return fhs, nil
+}
+
+// maybeResetHeaderState will reset the header state if the header assertion
+// fails, but only if the target height is found.
+func (f *FilterHeaderStore) maybeResetHeaderState(
+	headerStateAssertion *FilterHeader) error {
+
+	// First, we'll attempt to locate the header at this height. If no such
+	// header is found, then we'll exit early.
+	assertedHeader, err := f.FetchHeaderByHeight(
+		headerStateAssertion.Height,
+	)
+	if _, ok := err.(*ErrHeaderNotFound); ok {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	// If our on disk state and the provided header assertion don't
+	// match, then we'll purge this state so we can sync it anew
+	// once we fully start up.
+	if *assertedHeader != headerStateAssertion.FilterHash {
+		if err := os.Remove(f.fileName); err != nil {
+			return err
+		}
+	}
+
+	return err
 }
 
 // FetchHeader returns the filter header that corresponds to the passed block

--- a/neutrino.go
+++ b/neutrino.go
@@ -536,6 +536,13 @@ type Config struct {
 	// BlockCacheSize indicates the size (in bytes) of blocks the block
 	// cache will hold in memory at most.
 	BlockCacheSize uint64
+
+	// AssertFilterHeader is an optional field that allows the creator of
+	// the ChainService to ensure that if any chain data exists, it's
+	// compliant with the expected filter header state. If neutrino starts
+	// up and this filter header state has diverged, then it'll remove the
+	// current on disk filter headers to sync them anew.
+	AssertFilterHeader *headerfs.FilterHeader
 }
 
 // ChainService is instantiated with functional options
@@ -685,7 +692,8 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		return nil, err
 	}
 	s.RegFilterHeaders, err = headerfs.NewFilterHeaderStore(
-		cfg.DataDir, cfg.Database, headerfs.RegularFilter, &cfg.ChainParams,
+		cfg.DataDir, cfg.Database, headerfs.RegularFilter,
+		&cfg.ChainParams, cfg.AssertFilterHeader,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In this commit, we add the ability to specify an expected filter header
state when the filter header store is being created. As the filter
headers aren't committed yet, it's at times useful to nudge existing
nodes towards a filter header chain that they themselves may not have
obtained previously.