### PR TITLE
headerfs: re-initialize filter header store after removal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/lightningnetwork/lnd/queue v1.0.1
 	go.etcd.io/bbolt v1.3.2 // indirect
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 // indirect
+	google.golang.org/genproto v0.0.0-20190201180003-4b09977fb922 // indirect
 )


### PR DESCRIPTION
This is necessary as otherwise the filter header store would maintain the removed invalid filter header state in memory, causing us to still query for it.