### PR TITLE
pushtx: demote existing rebroadcast log to trace

### DIFF
--- a/pushtx/broadcaster.go
+++ b/pushtx/broadcaster.go
@@ -137,7 +137,7 @@ func (b *Broadcaster) broadcastHandler(sub *blockntfns.Subscription) {
 		// new goroutine to exectue a rebroadcast.
 		case <-rebroadcastSem:
 		default:
-			log.Debugf("Existing rebroadcast still in " +
+			log.Tracef("Existing rebroadcast still in " +
 				"progress")
 			return
 		}


### PR DESCRIPTION
It would log on every block, which during initial sync would fill the
logs.