### PR TITLE
blockmanager: address filter header tip lock inconsistency 

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1942,19 +1942,6 @@ func (b *blockManager) BlockHeadersSynced() bool {
 	return b.syncPeer.LastBlock() >= b.syncPeer.StartingHeight()
 }
 
-// SynchronizeFilterHeaders allows the caller to execute a function closure
-// that depends on synchronization with the current set of filter headers. This
-// allows the caller to execute an action that depends on the current filter
-// header state, thereby ensuring that the state would shift from underneath
-// them. Each execution of the closure will have the current filter header tip
-// passed in to ensue that the caller gets a consistent view.
-func (b *blockManager) SynchronizeFilterHeaders(f func(uint32) error) error {
-	b.newFilterHeadersMtx.RLock()
-	defer b.newFilterHeadersMtx.RUnlock()
-
-	return f(b.filterHeaderTip)
-}
-
 // QueueInv adds the passed inv message and peer to the block handling queue.
 func (b *blockManager) QueueInv(inv *wire.MsgInv, sp *ServerPeer) {
 	// No channel handling here because peers do not need to block on inv


### PR DESCRIPTION
There was a previous assumption that filterHeaderTip and filterHeaderTipHash were only being accessed within the cfHandler goroutine. This is no longer the case, as we require the filter header
tip in order to deliver a backlog of notifications for block notification subscribers.

We also establish a locking order when needing to acquire both newHeadersMtx and newFilterHeadersMtx in certain cases.

This attempts to address a deadlock found in this [goroutine dump](https://pastebin.com/raw/ZqbQKjpH).