### PR TITLE
neutrino: manually apply service bits to DNS seed addrs

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -1053,10 +1053,7 @@ func (s *ChainService) peerHandler() {
 			s.nameResolver, func(addrs []*wire.NetAddress) {
 				var validAddrs []*wire.NetAddress
 				for _, addr := range addrs {
-					if addr.Services&RequiredServices !=
-						RequiredServices {
-						continue
-					}
+					addr.Services = RequiredServices
 
 					validAddrs = append(validAddrs, addr)
 				}


### PR DESCRIPTION
In order to be able to bootstrap a new node w/o having to manually use a
`connect` or `addpeer`, we'll now assume the returned addresses have the
proper service bits implicitly. Since the seeds return just A records,
unless we pack things into IPv6, they can't explicitly signal the
service bits they support. Many of the DNS seeds were recently upgraded
to be able to respond to the `x49` subdomain (full node, segwit, bip
158), so with this change, usersr can now bootstrap a new node w/o any
externally obtained addresses.

Note that with this approach, if they peer actually supports of subset
of the features we need, they'll be lost. However, As we grow to
eventually need these additional services, the RequiredServices constant
will be updated, allowing us to filter based on these new requirements.