### PR TITLE
Return error on failed CFilter queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - mkdir -p $GOPATH/src/github.com/btcsuite/
   - "[ -d $GOPATH/src/github.com/btcsuite/btcd ] || git clone https://github.com/btcsuite/btcd.git $GOPATH/src/github.com/btcsuite/btcd"
   - pushd $GOPATH/src/github.com/btcsuite/btcd
+  - git checkout .
   - $GOPATH/src/github.com/lightninglabs/neutrino/btcd_checkout.sh
   - go install . ./cmd/...
   - popd

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89 h1:12K8AlpT0/6QUXSfV0yi4Q0jkbq8NDtIKFtF61AoqV0=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jrick/logrotate v1.0.0 h1:lQ1bL/n9mBNeIXoTUoYRlK4dHuNJVofX9oWqBtPnSzI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=

--- a/rescan_test.go
+++ b/rescan_test.go
@@ -289,7 +289,7 @@ func (c *mockChainSource) GetCFilter(hash chainhash.Hash,
 	defer c.mu.Unlock()
 
 	if c.failGetFilter {
-		return nil, nil
+		return nil, errors.New("failed filter")
 	}
 
 	filter, ok := c.filters[hash]


### PR DESCRIPTION
Previously we would return a nil filter with nil error, which would mask
a failed filter fetch.