### PR TITLE
neutrino: don't request new connections once max peers is reached

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -1251,16 +1251,14 @@ func (s *ChainService) handleDonePeerMsg(state *peerState, sp *ServerPeer) {
 		list = state.outboundPeers
 	}
 	if _, ok := list[sp.ID()]; ok {
-		if !sp.Inbound() && sp.VersionKnown() {
+		if sp.VersionKnown() {
 			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
 		}
-		if !sp.Inbound() {
-			if sp.persistent {
-				s.connManager.Disconnect(sp.connReq.ID())
-			} else {
-				s.connManager.Remove(sp.connReq.ID())
-				go s.connManager.NewConnReq()
-			}
+		if sp.persistent {
+			s.connManager.Disconnect(sp.connReq.ID())
+		} else {
+			s.connManager.Remove(sp.connReq.ID())
+			go s.connManager.NewConnReq()
 		}
 		delete(list, sp.ID())
 		log.Debugf("Removed peer %s", sp)

--- a/neutrino.go
+++ b/neutrino.go
@@ -1254,7 +1254,7 @@ func (s *ChainService) handleDonePeerMsg(state *peerState, sp *ServerPeer) {
 		if !sp.Inbound() && sp.VersionKnown() {
 			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
 		}
-		if !sp.Inbound() && sp.connReq != nil {
+		if !sp.Inbound() {
 			if sp.persistent {
 				s.connManager.Disconnect(sp.connReq.ID())
 			} else {
@@ -1268,13 +1268,8 @@ func (s *ChainService) handleDonePeerMsg(state *peerState, sp *ServerPeer) {
 	}
 
 	// We'll always remove peers that are not persistent.
-	if sp.connReq != nil {
-		s.connManager.Remove(sp.connReq.ID())
-		go s.connManager.NewConnReq()
-	}
-
-	// If we get here it means that either we didn't know about the peer
-	// or we purposefully deleted it.
+	s.connManager.Remove(sp.connReq.ID())
+	go s.connManager.NewConnReq()
 }
 
 // disconnectPeer attempts to drop the connection of a tageted peer in the

--- a/neutrino.go
+++ b/neutrino.go
@@ -1251,16 +1251,14 @@ func (s *ChainService) handleDonePeerMsg(state *peerState, sp *ServerPeer) {
 		list = state.outboundPeers
 	}
 	if _, ok := list[sp.ID()]; ok {
-		if sp.VersionKnown() {
-			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
-		}
+		state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
+		delete(list, sp.ID())
 		if sp.persistent {
 			s.connManager.Disconnect(sp.connReq.ID())
 		} else {
 			s.connManager.Remove(sp.connReq.ID())
 			go s.connManager.NewConnReq()
 		}
-		delete(list, sp.ID())
 		log.Debugf("Removed peer %s", sp)
 		return
 	}


### PR DESCRIPTION
Doing so would get us in a loop where we continue to request connections but we end up disconnecting them due to already having our maximum number of peers.