### PR TITLE
utxoscanner: reuse options where possible

### DIFF
--- a/utxoscanner.go
+++ b/utxoscanner.go
@@ -297,6 +297,7 @@ func (s *UtxoScanner) scanFromHeight(initHeight uint32) error {
 	)
 
 	reporter := newBatchSpendReporter()
+	options := defaultRescanOptions()
 
 scanToEnd:
 	// Scan forward through the blockchain and look for any transactions that
@@ -324,11 +325,9 @@ scanToEnd:
 		// outpoints.
 		fetch := len(newReqs) > 0
 		if !fetch {
-			options := rescanOptions{
-				watchList: reporter.filterEntries,
-			}
+			options.watchList = reporter.filterEntries
 
-			match, err := s.cfg.BlockFilterMatches(&options, hash)
+			match, err := s.cfg.BlockFilterMatches(options, hash)
 			if err != nil {
 				return reporter.FailRemaining(err)
 			}


### PR DESCRIPTION
On startup, noticed that if there are a lot of `filterEntries` leads to high mem usage, they all get copied here:
```
options = &rescanOptions{
     watchList: reporter.filterEntries,
}
```
and they continually get copied until a match is found. With pprof, noticed about 38MB, sometimes more depending on the `channel.db` I was using:
```
   38.01MB    38.01MB    321:			options := rescanOptions{
         .          .    322:				watchList: reporter.filterEntries,
         .          .    323:			}
```

With this change, pprof doesn't even log the memory since it's so low. :) 

EDIT: I know that with batching filter requests, this probably isn't necessary, but for now it's a nice memory improvement.