### PR TITLE
Add PersistToDisk property to ChainService

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -570,6 +570,12 @@ type Config struct {
 	// cache will hold in memory at most.
 	BlockCacheSize uint64
 
+	// persistToDisk indicates whether the filter should also be written
+	// to disk in addition to the memory cache. For "normal" wallets, they'll
+	// almost never need to re-match a filter once it's been fetched unless
+	// they're doing something like a key import.
+	PersistToDisk bool
+
 	// AssertFilterHeader is an optional field that allows the creator of
 	// the ChainService to ensure that if any chain data exists, it's
 	// compliant with the expected filter header state. If neutrino starts
@@ -597,6 +603,7 @@ type ChainService struct {
 	FilterDB         filterdb.FilterDatabase
 	BlockHeaders     headerfs.BlockHeaderStore
 	RegFilterHeaders *headerfs.FilterHeaderStore
+	persistToDisk    bool
 
 	FilterCache *lru.Cache
 	BlockCache  *lru.Cache
@@ -689,6 +696,7 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		userAgentVersion:  UserAgentVersion,
 		nameResolver:      nameResolver,
 		dialer:            dialer,
+		persistToDisk:     cfg.PersistToDisk,
 	}
 	s.workManager = query.New(&query.Config{
 		ConnectedPeers: s.ConnectedPeers,

--- a/query.go
+++ b/query.go
@@ -78,12 +78,6 @@ type queryOptions struct {
 	// it's run in a goroutine.
 	doneChan chan<- struct{}
 
-	// persistToDisk indicates whether the filter should also be written
-	// to disk in addition to the memory cache. For "normal" wallets, they'll
-	// almost never need to re-match a filter once it's been fetched unless
-	// they're doing something like a key import.
-	persistToDisk bool
-
 	// optimisticBatch indicates whether we expect more calls to follow,
 	// and that we should attempt to batch more items with the query such
 	// that they can be cached, avoiding the extra round trip.
@@ -170,14 +164,6 @@ func Encoding(encoding wire.MessageEncoding) QueryOption {
 func DoneChan(doneChan chan<- struct{}) QueryOption {
 	return func(qo *queryOptions) {
 		qo.doneChan = doneChan
-	}
-}
-
-// PersistToDisk allows the caller to tell that the filter should be kept
-// on disk once it's found.
-func PersistToDisk() QueryOption {
-	return func(qo *queryOptions) {
-		qo.persistToDisk = true
 	}
 }
 
@@ -770,7 +756,7 @@ func (s *ChainService) handleCFiltersResponse(q *cfiltersQuery,
 
 	qo := defaultQueryOptions()
 	qo.applyQueryOptions(q.options...)
-	if qo.persistToDisk {
+	if s.persistToDisk {
 		err = s.FilterDB.PutFilter(
 			&response.BlockHash, gotFilter, dbFilterType,
 		)


### PR DESCRIPTION
Fix #193 
Currently PersisToDisk is an option to GetCFilter.
The problem is that the option is not working well with the in-memory
FilterCache. The biggest problem is that if there are two calls of
GetCFilter, the first one without the PersistToDisk option, and the second
one with the PersistToDisk option, the second one returns the filter from
the cache and doesn't write it persistently to the disk.
Consequently, if a filter was already queried, there is no way to write it
to disk. So for instance if a neutrino user (mainly lnd) is closed before
it is fully synchronized, it need to re-download all the filters when it
runs again.
When handling the PersistToDisk in the ChainService itself, the caller of
NewChainService decides in _one place_ if the filters need to be stored
in the disk, and that will not depend on the order of calls to
GetCFilter.