### PR TITLE
add block info to SpendReport for unspent outputs

### DIFF
--- a/batch_spend_reporter.go
+++ b/batch_spend_reporter.go
@@ -177,7 +177,7 @@ func (b *batchSpendReporter) findInitialTransactions(block *wire.MsgBlock,
 	// Iterate over the transactions in this block, hashing each and
 	// querying our reverse index to see if any requests depend on the txn.
 	initialTxns := make(map[wire.OutPoint]*SpendReport)
-	for _, tx := range block.Transactions {
+	for i, tx := range block.Transactions {
 		// If our reverse index has been cleared, we are done.
 		if len(txidReverseIndex) == 0 {
 			break
@@ -206,8 +206,13 @@ func (b *batchSpendReporter) findInitialTransactions(block *wire.MsgBlock,
 				continue
 			}
 
+			h := block.BlockHash()
+
 			initialTxns[op] = &SpendReport{
-				Output: txOuts[op.Index],
+				Output:      txOuts[op.Index],
+				BlockHash:   &h,
+				BlockHeight: height,
+				BlockIndex:  uint32(i),
 			}
 		}
 	}

--- a/rescan.go
+++ b/rescan.go
@@ -1419,6 +1419,25 @@ type SpendReport struct {
 	// NOTE: This field will only be populated if the target is still
 	// unspent.
 	Output *wire.TxOut
+
+	// BlockHash is the block hash of the block that includes the unspent
+	// output.
+	//
+	// NOTE: This field will only be populated if the target is still
+	// unspent.
+	BlockHash *chainhash.Hash
+
+	// BlockHeight is the height of the block that includes the unspent output.
+	//
+	// NOTE: This field will only be populated if the target is still
+	// unspent.
+	BlockHeight uint32
+
+	// BlockIndex is the index of the output's transaction in its block.
+	//
+	// NOTE: This field will only be populated if the target is still
+	// unspent.
+	BlockIndex uint32
 }
 
 // GetUtxo gets the appropriate TxOut or errors if it's spent. The option

--- a/sync_test.go
+++ b/sync_test.go
@@ -318,6 +318,8 @@ func testRescan(harness *neutrinoHarness, t *testing.T) {
 	secSrc = newSecSource(&modParams)
 
 	newPkScript := func() (btcutil.Address, []byte, *wire.TxOut) {
+		t.Helper()
+
 		privKey, err := btcec.NewPrivateKey(btcec.S256())
 		if err != nil {
 			t.Fatalf("Couldn't generate private key: %s", err)
@@ -338,6 +340,7 @@ func testRescan(harness *neutrinoHarness, t *testing.T) {
 
 	createTx := func(txOuts ...*wire.TxOut) *wire.MsgTx {
 		t.Helper()
+
 		// Fee rate is satoshis per byte
 		tx, err := harness.h1.CreateTransaction(
 			txOuts, 1000, true,


### PR DESCRIPTION
That modifies the `SpendReport` struct to add fields for `BlockHash`, `BlockHeight`, and `BlockIndex` for unspent outputs. The data was already available, just not being recorded.