### PR TITLE
Validate received filters after block download, update filter checkpoints

### DIFF
--- a/chainsync/filtercontrol.go
+++ b/chainsync/filtercontrol.go
@@ -17,26 +17,28 @@ var ErrCheckpointMismatch = fmt.Errorf("checkpoint doesn't match")
 // expected filter headers.
 var filterHeaderCheckpoints = map[wire.BitcoinNet]map[uint32]*chainhash.Hash{
 	// Mainnet filter header checkpoints.
-	chaincfg.MainNetParams.Net: map[uint32]*chainhash.Hash{
+	chaincfg.MainNetParams.Net: {
 		100000: hashFromStr("f28cbc1ab369eb01b7b5fe8bf59763abb73a31471fe404a26a06be4153aa7fa5"),
 		200000: hashFromStr("e5031471732f4fbfe7a25f6a03acc1413300d5c56ae8e06b95046b8e4c0f32b3"),
 		300000: hashFromStr("1bd50220fcdde929ca3143c91d2dd9a9bfedb38c452ba98dbb51e719bff8aa5b"),
 		400000: hashFromStr("5d973ab1f1c569c70deec1c1a8fb2e317a260f1656edb3b262c65f78ef192e3a"),
 		500000: hashFromStr("5d16ca293c9bdc0a9bc279b63f99fb661be38b095a59a44200a807caaa631a3c"),
-		540000: hashFromStr("bbabb3b757ff0776971c5719e58a4fdc7f2a8159c9028be62896bc17ba14dda1"),
+		600000: hashFromStr("bde0854d0b2f4386a860462547140e0c6817f5b4b2ab515ef70e204e377598f8"),
+		660000: hashFromStr("08312375fabc082b17fa8ee88443feb350c19a34bb7483f94f7478fa4ad33032"),
 	},
 
 	// Testnet filter header checkpoints.
-	chaincfg.TestNet3Params.Net: map[uint32]*chainhash.Hash{
+	chaincfg.TestNet3Params.Net: {
 		100000:  hashFromStr("97c0633f14625627fcd133250ad8cc525937e776b5f3fd272b06d02c58b65a1c"),
 		200000:  hashFromStr("51aa817e5abe3acdcf103616b1a5736caf84bc3773a7286e9081108ecc38cc87"),
 		400000:  hashFromStr("4aab9b3d4312cd85cfcd48a08b36c4402bfdc1e8395dcf4236c3029dfa837c48"),
 		600000:  hashFromStr("713d9c9198e2dba0739e85aab6875cb951c36297b95a2d51131aa6919753b55d"),
 		800000:  hashFromStr("0dafdff27269a70293c120b14b1f5e9a72a5e8688098cfc6140b9d64f8325b99"),
 		1000000: hashFromStr("c2043fa2f6eb5f8f8d2c5584f743187f36302ed86b62c302e31155f378da9c5f"),
-		1390000: hashFromStr("ec71c508c02f59b2af2f34b64dfd79ffba55d9ef7d00589b0a2c3178da89e4c0"),
 		1400000: hashFromStr("f9ae1750483d4c8ce82512616b1ded932886af46decb8d3e575907930542d9b3"),
 		1500000: hashFromStr("dc0cfa13daf09df9b8dbe7532f75ebdb4255860b295016b2ca4b789394bc5090"),
+		1800000: hashFromStr("67083b2d5dfc9ca1415bffa14e43a5bbe595e2e8b7ffbcc7a4ea78fa069a9c8d"),
+		1900000: hashFromStr("96a31467f9edcaa3297770bc6cdf66926d5d17dfad70cb0cac285bfe9075c494"),
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/btcsuite/btcwallet/wtxmgr v1.2.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/lightningnetwork/lnd/queue v1.0.1
+	github.com/stretchr/testify v1.5.1 // indirect
 )
 
 go 1.13

--- a/neutrino.go
+++ b/neutrino.go
@@ -860,9 +860,11 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		BlockFilterMatches: func(ro *rescanOptions,
 			blockHash *chainhash.Hash) (bool, error) {
 
-			return blockFilterMatches(
+			matches, _, err := blockFilterMatches(
 				&RescanChainSource{&s}, ro, blockHash,
 			)
+
+			return matches, err
 		},
 	})
 

--- a/rescan.go
+++ b/rescan.go
@@ -953,8 +953,19 @@ func extractBlockMatches(chain ChainSource, ro *rescanOptions,
 		return nil, err
 	}
 	if block == nil {
-		return nil, fmt.Errorf("Couldn't get block %d (%s) from "+
+		return nil, fmt.Errorf("couldn't get block %d (%s) from "+
 			"network", curStamp.Height, curStamp.Hash)
+	}
+
+	// Before we go through the transactions, let's make sure the filter we
+	// got from our peer is valid and includes all spent previous output
+	// scripts. If there's a problem, the error returned here will be
+	// interpreted by the block manager to disconnect/ban said peer.
+	if _, err := VerifyBasicBlockFilter(filter, block); err != nil {
+		return nil, fmt.Errorf("error verifying filter against "+
+			"downloaded block %d (%s), possibly got invalid "+
+			"filter from peer: %v", curStamp.Height, curStamp.Hash,
+			err)
 	}
 
 	blockHeader := block.MsgBlock().Header

--- a/verification.go
+++ b/verification.go
@@ -1,0 +1,154 @@
+package neutrino
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcutil/gcs"
+	"github.com/btcsuite/btcutil/gcs/builder"
+)
+
+// VerifyBasicBlockFilter asserts that a given block filter was constructed
+// correctly and according to the rules of BIP-0158 to contain both the output's
+// pk scripts as well as the pk scripts the inputs are spending.
+func VerifyBasicBlockFilter(filter *gcs.Filter, block *btcutil.Block) (int,
+	error) {
+
+	var (
+		opReturnMatches int
+		key             = builder.DeriveKey(block.Hash())
+	)
+	for idx, tx := range block.Transactions() {
+		// Skip coinbase transaction.
+		if idx == 0 {
+			continue
+		}
+
+		// Check outputs first.
+		for outIdx, txOut := range tx.MsgTx().TxOut {
+			switch {
+			// If the script itself is blank, then we'll skip this
+			// as it doesn't contain any useful information.
+			case len(txOut.PkScript) == 0:
+				continue
+
+			// We'll also skip any OP_RETURN scripts as well since
+			// we don't index these in order to avoid a circular
+			// dependency.
+			case txOut.PkScript[0] == txscript.OP_RETURN:
+				// Previous versions of the filters did include
+				// OP_RETURNs. To be able disconnect bad peers
+				// still serving these old filters we attempt to
+				// check if there's an unexpected match. Since
+				// there might be false positives, an OP_RETURN
+				// can still match filters not including them.
+				// Therefore, we count the number of such
+				// unexpected matches for each peer, such that
+				// we can ban peers matching more than the rest.
+				match, err := filter.Match(key, txOut.PkScript)
+				if err != nil {
+					// Mark peer bad if we cannot match on
+					// its filter.
+					return 0, fmt.Errorf("error "+
+						"validating block %v outpoint "+
+						"%v:%d script %x: %v",
+						block.Hash(), tx.Hash(), outIdx,
+						txOut.PkScript, err)
+				}
+
+				// If it matches on the OP_RETURN output, we
+				// increase the op return counter.
+				if match {
+					opReturnMatches++
+				}
+
+				continue
+			}
+
+			// This is a "normal" script where we definitely expect
+			// a match.
+			match, err := filter.Match(key, txOut.PkScript)
+			if err != nil {
+				return 0, fmt.Errorf("error validating block "+
+					"%v outpoint %v:%d script %x: %v",
+					block.Hash(), tx.Hash(), outIdx,
+					txOut.PkScript, err)
+			}
+
+			if !match {
+				return 0, fmt.Errorf("filter for block %v is "+
+					"invalid, outpoint %v:%d script %x "+
+					"wasn't matched by filter",
+					block.Hash(), tx.Hash(), outIdx,
+					txOut.PkScript)
+			}
+		}
+
+		// Now we can go through all inputs and check that the filter
+		// also included any pk scripts of the outputs being _spent_.
+		// We can do this for witness items since the witness always
+		// contains the full script as the last element on the stack.
+		for inIdx, in := range tx.MsgTx().TxIn {
+			// There are too many edge cases to cover for non-
+			// witness scripts. And in LN land we're interested in
+			// witness spends only anyway. Therefore let's skip any
+			// input that has no witness.
+			//
+			// TODO(guggero): Add all those edge cases to
+			// ComputePkScript?
+			if len(in.Witness) == 0 {
+				continue
+			}
+
+			// The only input type that has both set is a nested
+			// P2PKH (P2SH-P2WKH). We can verify that one because
+			// the script hash has to be HASH160(OP_PUSH32 <PKH>).
+			script, err := txscript.ComputePkScript(
+				in.SignatureScript, in.Witness,
+			)
+
+			// Just skip any inputs that we can't derive the pk
+			// script from.
+			if err == txscript.ErrUnsupportedScriptType {
+				log.Tracef("Skipping filter validation for "+
+					"input %d of tx %v in block %v "+
+					"because script type is not supported "+
+					"for validating against filter", inIdx,
+					tx.Hash(), block.Hash())
+
+				continue
+			}
+
+			// Something else went wrong. We can't really say the
+			// filter is faulty though so we also just skip over
+			// this input.
+			if err != nil {
+				log.Debug("Skipping filter validation for "+
+					"input %d of tx %v in block %v "+
+					"because computing the script failed: "+
+					"%v", inIdx, block.Hash(), err)
+
+				continue
+			}
+
+			match, err := filter.Match(key, script.Script())
+			if err != nil {
+				return 0, fmt.Errorf("error validating block "+
+					"%v input %d of tx %v script %x: %v",
+					block.Hash(), inIdx, tx.Hash(),
+					script.Script(), err)
+			}
+
+			if !match {
+				return 0, fmt.Errorf("filter for block %v is "+
+					"invalid, input %d of tx %v spends "+
+					"pk script %x which wasn't matched by "+
+					"filter", block.Hash(), inIdx,
+					tx.Hash(), script.Script())
+			}
+		}
+	}
+
+	return opReturnMatches, nil
+}

--- a/verification_test.go
+++ b/verification_test.go
@@ -1,0 +1,368 @@
+package neutrino
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcutil/gcs"
+	"github.com/btcsuite/btcutil/gcs/builder"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	chainParams = &chaincfg.RegressionNetParams
+
+	dummySignaturePush = []byte{
+		txscript.OP_DATA_72,
+		0x30, 0x45, 0x02, 0x21, 0x00, 0xad, 0x08, 0x51,
+		0xc6, 0x9d, 0xd7, 0x56, 0xb4, 0x51, 0x90, 0xb5,
+		0xa8, 0xe9, 0x7c, 0xb4, 0xac, 0x3c, 0x2b, 0x0f,
+		0xa2, 0xf2, 0xaa, 0xe2, 0x3a, 0xed, 0x6c, 0xa9,
+		0x7a, 0xb3, 0x3b, 0xf8, 0x83, 0x02, 0x20, 0x0b,
+		0x24, 0x85, 0x93, 0xab, 0xc1, 0x25, 0x95, 0x12,
+		0x79, 0x3e, 0x7d, 0xea, 0x61, 0x03, 0x6c, 0x60,
+		0x17, 0x75, 0xeb, 0xb2, 0x36, 0x40, 0xa0, 0x12,
+		0x0b, 0x0d, 0xba, 0x2c, 0x34, 0xb7, 0x90, 0x01,
+	}
+)
+
+// TestVerifyBlockFilter tests that a filter is correctly inspected for validity
+// against a downloaded block.
+func TestVerifyBlockFilter(t *testing.T) {
+	privKey, err := btcec.NewPrivateKey(btcec.S256())
+	require.NoError(t, err)
+
+	pubKey := privKey.PubKey()
+	pubKey2 := incrementKey(pubKey)
+
+	// We'll create an initial block with just one TX that spends to all
+	// currently known standard output types (P2PKH, P2SH, NP2WKH, P2WKH and
+	// P2WSH). All those outputs are then spent in the next block in a
+	// single TX that references all of them.
+	prevTx := &wire.MsgTx{
+		Version: 2,
+		TxIn:    []*wire.TxIn{},
+		TxOut: []*wire.TxOut{{
+			Value:    999,
+			PkScript: makeP2PK(t, pubKey),
+		}, {
+			Value:    999,
+			PkScript: makeP2PKH(t, pubKey),
+		}, {
+			Value:    999,
+			PkScript: makeP2SH(t, pubKey),
+		}, {
+			Value:    999,
+			PkScript: makeNP2WKH(t, pubKey),
+		}, {
+			Value:    999,
+			PkScript: makeP2WKH(t, pubKey),
+		}, {
+			Value:    999,
+			PkScript: makeP2WSH(t, pubKey),
+		}},
+	}
+	prevBlock := &wire.MsgBlock{
+		Header: wire.BlockHeader{
+			PrevBlock:  [32]byte{1, 2, 3},
+			MerkleRoot: [32]byte{3, 2, 1},
+		},
+		Transactions: []*wire.MsgTx{
+			{}, // Fake coinbase TX.
+			prevTx,
+		},
+	}
+
+	// The spend TX is the transaction that has an input to spend each of
+	// the different output types we created in the previous block/TX.
+	spendTx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{
+			spendP2PK(t, pubKey, prevTx, 0),
+			spendP2PKH(t, pubKey, prevTx, 1),
+			spendP2SH(t, pubKey, prevTx, 2),
+			spendNP2WKH(t, pubKey, prevTx, 3),
+			spendP2WKH(t, pubKey, prevTx, 4),
+			spendP2WSH(t, pubKey, prevTx, 5),
+		},
+		TxOut: []*wire.TxOut{{
+			Value:    999,
+			PkScript: makeP2WKH(t, pubKey2),
+		}, {
+			Value:    999,
+			PkScript: makeP2WSH(t, pubKey2),
+		}, {
+			Value:    999,
+			PkScript: []byte{txscript.OP_RETURN},
+		}},
+	}
+	spendBlock := &wire.MsgBlock{
+		Header: wire.BlockHeader{
+			PrevBlock:  prevBlock.BlockHash(),
+			MerkleRoot: [32]byte{3, 2, 1},
+		},
+		Transactions: []*wire.MsgTx{
+			{}, // Fake coinbase TX.
+			spendTx,
+		},
+	}
+
+	// We now create two filters from our block. One that is fully valid and
+	// contains all the entries we require according to BIP-158 and one that
+	// is missing the pk scripts of the _spent_ outputs.
+	utxoSet := []*wire.MsgTx{prevTx}
+	validFilter := filterFromBlock(t, utxoSet, spendBlock, true)
+	invalidFilter := filterFromBlock(t, utxoSet, spendBlock, false)
+	b := btcutil.NewBlock(spendBlock)
+
+	opReturnValid, err := VerifyBasicBlockFilter(validFilter, b)
+	require.NoError(t, err)
+	require.Equal(t, 1, opReturnValid)
+
+	opReturnInvalid, err := VerifyBasicBlockFilter(invalidFilter, b)
+	require.Error(t, err)
+	require.Equal(t, 0, opReturnInvalid)
+}
+
+func filterFromBlock(t *testing.T, utxoSet []*wire.MsgTx,
+	block *wire.MsgBlock, withInputPrevOut bool) *gcs.Filter {
+
+	var filterContent [][]byte
+	for idx, tx := range block.Transactions {
+		// Skip coinbase transaction.
+		if idx == 0 {
+			continue
+		}
+
+		// Add all output pk scripts. Normally we'd need to filter out
+		// any OP_RETURNs but for the test we want to make sure they're
+		// counted correctly so we leave them in.
+		for _, out := range tx.TxOut {
+			filterContent = append(filterContent, out.PkScript)
+		}
+
+		// To create an invalid filter we just skip the pk scripts of
+		// the spent outputs.
+		if !withInputPrevOut {
+			continue
+		}
+
+		// Add all previous output scripts of all transactions.
+		for _, in := range tx.TxIn {
+			utxo := locateUtxo(t, utxoSet, in)
+			filterContent = append(filterContent, utxo.PkScript)
+		}
+	}
+
+	blockHash := block.BlockHash()
+	key := builder.DeriveKey(&blockHash)
+	filter, err := gcs.BuildGCSFilter(
+		builder.DefaultP, builder.DefaultM, key, filterContent,
+	)
+	require.NoError(t, err)
+
+	return filter
+}
+
+func locateUtxo(t *testing.T, utxoSet []*wire.MsgTx, in *wire.TxIn) *wire.TxOut {
+	for _, utxo := range utxoSet {
+		if utxo.TxHash() == in.PreviousOutPoint.Hash {
+			return utxo.TxOut[in.PreviousOutPoint.Index]
+		}
+	}
+
+	require.Fail(t, "utxo for outpoint %v not found", in.PreviousOutPoint)
+	return nil
+}
+
+func spendP2PK(_ *testing.T, _ *btcec.PublicKey, prevTx *wire.MsgTx,
+	idx uint32) *wire.TxIn {
+
+	return &wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  prevTx.TxHash(),
+			Index: idx,
+		},
+		SignatureScript: dummySignaturePush,
+	}
+}
+
+func spendP2PKH(_ *testing.T, pubKey *btcec.PublicKey, prevTx *wire.MsgTx,
+	idx uint32) *wire.TxIn {
+
+	return &wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  prevTx.TxHash(),
+			Index: idx,
+		},
+		SignatureScript: append(
+			dummySignaturePush, pubKey.SerializeCompressed()...,
+		),
+	}
+}
+
+func spendP2SH(t *testing.T, pubKey *btcec.PublicKey, prevTx *wire.MsgTx,
+	idx uint32) *wire.TxIn {
+
+	return &wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  prevTx.TxHash(),
+			Index: idx,
+		},
+		SignatureScript: append(
+			dummySignaturePush, scriptP2PKH(t, pubKey)...,
+		),
+	}
+}
+
+func spendNP2WKH(t *testing.T, pubKey *btcec.PublicKey, prevTx *wire.MsgTx,
+	idx uint32) *wire.TxIn {
+
+	pkHash := btcutil.Hash160(pubKey.SerializeCompressed())
+
+	witAddr, err := btcutil.NewAddressWitnessPubKeyHash(pkHash, chainParams)
+	require.NoError(t, err)
+
+	witnessProgram, err := txscript.PayToAddrScript(witAddr)
+	require.NoError(t, err)
+
+	return &wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  prevTx.TxHash(),
+			Index: idx,
+		},
+		SignatureScript: witAddr.ScriptAddress(),
+		Witness:         [][]byte{dummySignaturePush, witnessProgram},
+	}
+}
+
+func spendP2WKH(_ *testing.T, pubKey *btcec.PublicKey, prevTx *wire.MsgTx,
+	idx uint32) *wire.TxIn {
+
+	return &wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  prevTx.TxHash(),
+			Index: idx,
+		},
+		Witness: [][]byte{
+			dummySignaturePush, pubKey.SerializeCompressed(),
+		},
+	}
+}
+
+func spendP2WSH(t *testing.T, pubKey *btcec.PublicKey, prevTx *wire.MsgTx,
+	idx uint32) *wire.TxIn {
+
+	script := scriptP2PKH(t, pubKey)
+
+	return &wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  prevTx.TxHash(),
+			Index: idx,
+		},
+		Witness: [][]byte{dummySignaturePush, script},
+	}
+}
+
+func makeP2PK(t *testing.T, pubKey *btcec.PublicKey) []byte {
+	addr, err := btcutil.NewAddressPubKey(
+		pubKey.SerializeCompressed(), chainParams,
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+	return pkScript
+}
+
+func makeP2PKH(t *testing.T, pubKey *btcec.PublicKey) []byte {
+	pkHash := btcutil.Hash160(pubKey.SerializeCompressed())
+	addr, err := btcutil.NewAddressPubKeyHash(pkHash, chainParams)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+	return pkScript
+}
+
+func makeP2SH(t *testing.T, pubKey *btcec.PublicKey) []byte {
+	script := scriptP2PKH(t, pubKey)
+
+	addr, err := btcutil.NewAddressScriptHash(script, chainParams)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+	return pkScript
+}
+
+func makeNP2WKH(t *testing.T, pubKey *btcec.PublicKey) []byte {
+	pkHash := btcutil.Hash160(pubKey.SerializeCompressed())
+
+	witAddr, err := btcutil.NewAddressWitnessPubKeyHash(pkHash, chainParams)
+	require.NoError(t, err)
+
+	witnessProgram, err := txscript.PayToAddrScript(witAddr)
+	require.NoError(t, err)
+
+	addr, err := btcutil.NewAddressScriptHash(witnessProgram, chainParams)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+	return pkScript
+}
+
+func makeP2WKH(t *testing.T, pubKey *btcec.PublicKey) []byte {
+	pkHash := btcutil.Hash160(pubKey.SerializeCompressed())
+
+	addr, err := btcutil.NewAddressWitnessPubKeyHash(pkHash, chainParams)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+	return pkScript
+}
+
+func makeP2WSH(t *testing.T, pubKey *btcec.PublicKey) []byte {
+	witnessScript := scriptP2PKH(t, pubKey)
+	scriptHash := sha256.Sum256(witnessScript)
+
+	addr, err := btcutil.NewAddressWitnessScriptHash(
+		scriptHash[:], chainParams,
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+	return pkScript
+}
+
+func scriptP2PKH(t *testing.T, pubKey *btcec.PublicKey) []byte {
+	// A simple P2PKH script but wrapped as P2SH.
+	// <pubKey> OP_CHECKSIG
+	b := txscript.NewScriptBuilder()
+
+	b.AddData(pubKey.SerializeCompressed())
+	b.AddOp(txscript.OP_CHECKSIG)
+
+	script, err := b.Script()
+	require.NoError(t, err)
+
+	return script
+}
+
+func incrementKey(key *btcec.PublicKey) *btcec.PublicKey {
+	curveParams := key.Curve.Params()
+	newX, newY := key.Curve.Add(key.X, key.Y, curveParams.Gx, curveParams.Gy)
+	return &btcec.PublicKey{
+		X:     newX,
+		Y:     newY,
+		Curve: btcec.S256(),
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/neutrino/issues/207.

Whenever we download a block, we want to make sure that the filter we
had for it was correct. It's trivial to check all output scripts of the
block's transactions were included in the filter. The trickier part is
to verify the scripts of the outputs being spent are also included in
the filter.
By looking at the signature script or witness we can derive the script
that's being spent and from that can make sure they are all included in
the filter.