### PR TITLE
neutrino: increase timeout between inv and getmsg when sending tx 

### DIFF
--- a/query.go
+++ b/query.go
@@ -1128,15 +1128,10 @@ func (s *ChainService) sendTransaction(tx *wire.MsgTx, options ...QueryOption) e
 				rejections[*broadcastErr]++
 			}
 		},
-		// Default to 500ms timeout. Default for queryAllPeers is a
+		// Default to 10s timeout. Default for queryAllPeers is a
 		// single try.
-		//
-		// TODO(wilmer): Is this timeout long enough assuming a
-		// worst-case round trip? Also needs to take into account that
-		// the other peer must query its own state to determine whether
-		// it should accept the transaction.
 		append(
-			[]QueryOption{Timeout(time.Millisecond * 500)},
+			[]QueryOption{Timeout(time.Second * 10)},
 			options...,
 		)...,
 	)


### PR DESCRIPTION
The current time of 500ms can be too low if for example the network conditions are poor.
This increases the timeout window to 10s which should be sufficient to cover any scenarios.

This has been causing real issues with lnd (and bitcoind) where `SendCoins` and channel openings wouldn't get broadcasted.
https://github.com/lightningnetwork/lnd/issues/5130
https://github.com/hsjoberg/blixt-wallet/issues/278

@wpaulino I've removed your TODO-message which was directly related to this issue, if that's okay with you.

Cheers!