### PR TITLE
neutrino+pushtx: make broadcast timeout configurable with fallback

### DIFF
--- a/pushtx/broadcaster.go
+++ b/pushtx/broadcaster.go
@@ -20,6 +20,10 @@ var (
 )
 
 const (
+	// DefaultBroadcastTimeout is the default timeout used when broadcasting
+	// transactions to network peers.
+	DefaultBroadcastTimeout = 5 * time.Second
+
 	// DefaultRebroadcastInterval is the default period that we'll wait
 	// between blocks to attempt another rebroadcast.
 	DefaultRebroadcastInterval = time.Minute

--- a/query.go
+++ b/query.go
@@ -1114,10 +1114,8 @@ func (s *ChainService) sendTransaction(tx *wire.MsgTx, options ...QueryOption) e
 				rejections[*broadcastErr]++
 			}
 		},
-		// Default to 10s timeout. Default for queryAllPeers is a
-		// single try.
 		append(
-			[]QueryOption{Timeout(time.Second * 10)},
+			[]QueryOption{Timeout(s.broadcastTimeout)},
 			options...,
 		)...,
 	)


### PR DESCRIPTION
This is useful for enabling shorter timeouts than we would use in a production environment in testing environments, resulting in shorter test execution times. If a timeout isn't provided, we'll use the default of 5 seconds.