### PR TITLE
pushtx+rescan: stop rebroadcast on tx confirm

### DIFF
--- a/rescan.go
+++ b/rescan.go
@@ -1007,6 +1007,13 @@ func extractBlockMatches(chain ChainSource, ro *rescanOptions,
 
 		if relevant {
 			relevantTxs = append(relevantTxs, tx)
+
+			chainSource, ok := chain.(*RescanChainSource)
+			if ok {
+				chainSource.broadcaster.MarkAsConfirmed(
+					*tx.Hash(),
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR allows rescan to notify the `ChainServices` `broadcaster` that a relevant transaction is confirmed.

Fixes #206  using the approach mentioned [here](https://github.com/lightninglabs/neutrino/issues/206#issuecomment-887919095)

**Testing the PR**
- _To see the bug_: An easy way to test this just by running an lnd itest that creates some channels and then observing the logs. So currently, if you run `$ make itest backend=neutrino icase=....` (choose a test that creates a lot of channels) and then look at the logs: `[DBG] BTCN: Re-broadcasting %d transactions`  will show that the number of txs being rebroadcasted just keeps increasing. 
- _To see the fix:_ now in lnd go.mod, add: `replace github.com/lightninglabs/neutrino => github.com/ellemouton/neutrino v0.11.1-0.20210921111409-eb86c412013d` and re-run the same itest. You will see that the number of txs being rebroadcast no longer increases when a tx is confirmed.

Fixes https://github.com/lightninglabs/neutrino/issues/206