### PR TITLE
rescan+query: expose start and end block in GetCFilters

### DIFF
--- a/rescan_test.go
+++ b/rescan_test.go
@@ -278,11 +278,12 @@ func (c *mockChainSource) setFailGetFilter(b bool) {
 
 // GetCFilter returns the filter of the given type for the block with the given
 // hash.
-func (c *mockChainSource) GetCFilter(hash chainhash.Hash,
-	filterType wire.FilterType, options ...QueryOption) (*gcs.Filter, error) {
+func (c *mockChainSource) GetCFilters(startHash int32, endHash chainhash.Hash,
+	filterType wire.FilterType,
+	options ...QueryOption) (map[chainhash.Hash]*gcs.Filter, error) {
 
 	defer func() {
-		c.filtersQueried <- hash
+		c.filtersQueried <- endHash
 	}()
 
 	c.mu.Lock()
@@ -292,11 +293,7 @@ func (c *mockChainSource) GetCFilter(hash chainhash.Hash,
 		return nil, errors.New("failed filter")
 	}
 
-	filter, ok := c.filters[hash]
-	if !ok {
-		return nil, errors.New("filter not found")
-	}
-	return filter, nil
+	return c.filters, nil
 }
 
 // overrideSubscribe allows us to override the mockChainSource's Subscribe

--- a/sync_test.go
+++ b/sync_test.go
@@ -863,12 +863,21 @@ func testRandomBlocks(harness *neutrinoHarness, t *testing.T) {
 				return
 			}
 			// Get basic cfilter from network.
-			haveFilter, err := harness.svc.GetCFilter(blockHash,
-				wire.GCSFilterRegular, queryOptions...)
+			haveFilters, err := harness.svc.GetCFilters(
+				int32(height), blockHash, wire.GCSFilterRegular,
+				queryOptions...,
+			)
 			if err != nil {
 				errChan <- err
 				return
 			}
+
+			haveFilter, ok := haveFilters[blockHash]
+			if !ok {
+				errChan <- fmt.Errorf("filter not received")
+				return
+			}
+
 			// Get basic cfilter from RPC.
 			wantFilter, err := harness.h1.Node.GetCFilter(
 				&blockHash, wire.GCSFilterRegular)


### PR DESCRIPTION
In this commit, the GetCFilters method is altered to expose a start
block height and end block hash to the caller so that they can query for
a range of blocks.

This addresses step 1 of #68 . 

Waiting to get some feedback re if step 2&3 of the same issue are still needed (since the `OptimisticBatch` functional option is anyways used) before adding them onto this PR.
