### PR TITLE
chain service: defer WaitGroup Done in peerHandler

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -1059,6 +1059,8 @@ func (s *ChainService) NetTotals() (uint64, uint64) {
 // peers to and from the server, banning peers, and broadcasting messages to
 // peers.  It must be run in a goroutine.
 func (s *ChainService) peerHandler() {
+	defer s.wg.Done()
+
 	state := &peerState{
 		persistentPeers: make(map[int32]*ServerPeer),
 		outboundPeers:   make(map[int32]*ServerPeer),
@@ -1133,7 +1135,7 @@ cleanup:
 			break cleanup
 		}
 	}
-	s.wg.Done()
+
 	log.Tracef("Peer handler done")
 }
 


### PR DESCRIPTION
The `(*ChainService).peerHandler` should only call `s.wg.Done` when it is really done, which includes use of the logger.  Put the `Done` call at the top of the defer stack, which is generally good practice and consistent with the rest of the neutrino code base.

As far as impact of the resolved issue, consumers that wait on `ChainService` shutdown before tearing down the logger backend rely on `ChainService` actually being done with the logger.  Another possible reason is that certain use cases might want to set a new log backend after closing up neutrino and before making a new instance, and doing so would be a race unless it is really done with the logger.  We've encountered this issue in both scenarios.