### PR TITLE
verification: skip checking input scripts

### DIFF
--- a/verification.go
+++ b/verification.go
@@ -141,10 +141,12 @@ func VerifyBasicBlockFilter(filter *gcs.Filter, block *btcutil.Block) (int,
 			}
 
 			if !match {
-				return 0, fmt.Errorf("filter for block %v is "+
+				log.Errorf("filter for block %v might be "+
 					"invalid, input %d of tx %v spends "+
 					"pk script %x which wasn't matched by "+
-					"filter", block.Hash(), inIdx,
+					"filter. The input likely spends a "+
+					"taproot output which is not yet"+
+					"supported", block.Hash(), inIdx,
 					tx.Hash(), script.Script())
 			}
 		}

--- a/verification_test.go
+++ b/verification_test.go
@@ -112,21 +112,15 @@ func TestVerifyBlockFilter(t *testing.T) {
 		},
 	}
 
-	// We now create two filters from our block. One that is fully valid and
-	// contains all the entries we require according to BIP-158 and one that
-	// is missing the pk scripts of the _spent_ outputs.
+	// We now create a filter from our block that is fully valid and
+	// contains all the entries we require according to BIP-158.
 	utxoSet := []*wire.MsgTx{prevTx}
 	validFilter := filterFromBlock(t, utxoSet, spendBlock, true)
-	invalidFilter := filterFromBlock(t, utxoSet, spendBlock, false)
 	b := btcutil.NewBlock(spendBlock)
 
 	opReturnValid, err := VerifyBasicBlockFilter(validFilter, b)
 	require.NoError(t, err)
 	require.Equal(t, 1, opReturnValid)
-
-	opReturnInvalid, err := VerifyBasicBlockFilter(invalidFilter, b)
-	require.Error(t, err)
-	require.Equal(t, 0, opReturnInvalid)
 }
 
 func filterFromBlock(t *testing.T, utxoSet []*wire.MsgTx,


### PR DESCRIPTION
In this commit, the checks for input script pub keys is removed since the function used to reconstruct script pub keys from witness data currently does not take taproot outputs into consideration and so is producing the wrong script pubkeys which then causes the verification to fail. This code can be put back once the ComputeScriptPubKey function takes taproot into account. 

off the top of my head, I think that the ComputeScriptPubKey function might need to be changed to return a set of options since i think sometimes we wont be able to tell the difference between a P2WPKH, P2TR key path with annex, P2TR script path.