### PR TITLE
set headerfs.BlockStamp.Timestamp

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1278,8 +1278,9 @@ func (b *blockManager) rollBackToHeight(height uint32) (*headerfs.BlockStamp, er
 		return nil, err
 	}
 	bs := &headerfs.BlockStamp{
-		Height: int32(headerHeight),
-		Hash:   header.BlockHash(),
+		Height:    int32(headerHeight),
+		Hash:      header.BlockHash(),
+		Timestamp: header.Timestamp,
 	}
 
 	_, regHeight, err := b.cfg.RegFilterHeaders.ChainTip()

--- a/headerfs/store.go
+++ b/headerfs/store.go
@@ -330,14 +330,15 @@ func (h *blockHeaderStore) RollbackLastBlock() (*BlockStamp, error) {
 		return nil, err
 	}
 
-	// With this height obtained, we'll use it to read the latest header
+	// With this height obtained, we'll use it to read the previous header
 	// from disk, so we can populate our return value which requires the
 	// prev header hash.
-	bestHeader, err := h.readHeader(chainTipHeight)
+	prevHeader, err := h.readHeader(chainTipHeight - 1)
 	if err != nil {
 		return nil, err
 	}
-	prevHeaderHash := bestHeader.PrevBlock
+
+	prevHeaderHash := prevHeader.BlockHash()
 
 	// Now that we have the information we need to return from this
 	// function, we can now truncate the header file, and then use the hash
@@ -350,8 +351,9 @@ func (h *blockHeaderStore) RollbackLastBlock() (*BlockStamp, error) {
 	}
 
 	return &BlockStamp{
-		Height: int32(chainTipHeight) - 1,
-		Hash:   prevHeaderHash,
+		Height:    int32(chainTipHeight) - 1,
+		Hash:      prevHeaderHash,
+		Timestamp: prevHeader.Timestamp,
 	}, nil
 }
 

--- a/neutrino.go
+++ b/neutrino.go
@@ -949,8 +949,9 @@ func (s *ChainService) BestBlock() (*headerfs.BlockStamp, error) {
 	}
 
 	return &headerfs.BlockStamp{
-		Height: int32(bestHeight),
-		Hash:   bestHeader.BlockHash(),
+		Height:    int32(bestHeight),
+		Hash:      bestHeader.BlockHash(),
+		Timestamp: bestHeader.Timestamp,
 	}, nil
 }
 

--- a/rescan.go
+++ b/rescan.go
@@ -539,8 +539,9 @@ func rescan(chain ChainSource, options ...RescanOption) error {
 		}
 
 		newStamp := headerfs.BlockStamp{
-			Hash:   header.BlockHash(),
-			Height: int32(nextBlockHeight),
+			Hash:      header.BlockHash(),
+			Height:    int32(nextBlockHeight),
+			Timestamp: header.Timestamp,
 		}
 
 		log.Tracef("Rescan got block %d (%s)", newStamp.Height,


### PR DESCRIPTION
The `headerfs.BlockStamp` returned from `(*ChainService).BestBlock` had a zero `Timestamp`.
This change sets the `Timestamp` field from the block header if available.

Internally it does not seem to matter that `Timestamp` is the zero `time.Time`, but for `ChainService` consumers it is helpful to have the block's timestamp.  For example, one may compare the timestamp from the current best block from `ChainService` to the wallet `Manager`'s birthday time.