### PR TITLE
neutrino+query+rescan: improve rescan speed

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -597,6 +597,7 @@ type ChainService struct { // nolint:maligned
 	utxoScanner          *UtxoScanner
 	broadcaster          *pushtx.Broadcaster
 	banStore             banman.Store
+	queryDispatcher      query.Dispatcher
 	workManager          *query.WorkManager
 
 	// peerSubscribers is a slice of active peer subscriptions, that we
@@ -678,6 +679,8 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		NewWorker:      query.NewWorker,
 		Ranking:        query.NewPeerRanking(),
 	})
+
+	s.queryDispatcher = s.workManager
 
 	// We set the queryPeers method to point to queryChainServicePeers,
 	// passing a reference to the newly created ChainService.

--- a/neutrino.go
+++ b/neutrino.go
@@ -575,11 +575,6 @@ type ChainService struct { // nolint:maligned
 	FilterCache *lru.Cache
 	BlockCache  *lru.Cache
 
-	// queryPeers will be called to send messages to one or more peers,
-	// expecting a response.
-	queryPeers func(wire.Message, func(*ServerPeer, wire.Message,
-		chan<- struct{}), ...QueryOption)
-
 	chainParams          chaincfg.Params
 	addrManager          *addrmgr.AddrManager
 	connManager          *connmgr.ConnManager
@@ -681,13 +676,6 @@ func NewChainService(cfg Config) (*ChainService, error) {
 	})
 
 	s.queryDispatcher = s.workManager
-
-	// We set the queryPeers method to point to queryChainServicePeers,
-	// passing a reference to the newly created ChainService.
-	s.queryPeers = func(msg wire.Message, f func(*ServerPeer,
-		wire.Message, chan<- struct{}), qo ...QueryOption) {
-		queryChainServicePeers(&s, msg, f, qo...)
-	}
 
 	var err error
 

--- a/query.go
+++ b/query.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lightninglabs/neutrino/query"
+
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -947,75 +949,96 @@ func (s *ChainService) GetBlock(blockHash chainhash.Hash,
 	getData := wire.NewMsgGetData()
 	_ = getData.AddInvVect(inv)
 
-	// The block is only updated from the checkResponse function argument,
-	// which is always called single-threadedly. We don't check the block
-	// until after the query is finished, so we can just write to it
-	// naively.
 	var foundBlock *btcutil.Block
-	s.queryPeers(
-		// Send a wire.GetDataMsg
-		getData,
+	request := &query.Request{
+		Req: getData,
+		HandleResp: func(req, resp wire.Message, peer string) query.Progress {
+			// The request must have been a "getdata" msg.
+			_, ok := req.(*wire.MsgGetData)
+			if !ok {
+				return query.Progress{
+					Finished:   false,
+					Progressed: false,
+				}
+			}
 
-		// Check responses and if we get one that matches, end the
-		// query early.
-		func(sp *ServerPeer, resp wire.Message,
-			quit chan<- struct{}) {
-			switch response := resp.(type) {
 			// We're only interested in "block" messages.
-			case *wire.MsgBlock:
-				// Only keep this going if we haven't already
-				// found a block, or we risk closing an already
-				// closed channel.
-				if foundBlock != nil {
-					return
+			response, ok := resp.(*wire.MsgBlock)
+			if !ok {
+				return query.Progress{
+					Finished:   false,
+					Progressed: false,
 				}
+			}
 
-				// If this isn't our block, ignore it.
-				if response.BlockHash() != blockHash {
-					return
+			// If this isn't the block we asked for, ignore it.
+			if response.BlockHash() != blockHash {
+				return query.Progress{
+					Finished:   false,
+					Progressed: false,
 				}
-				block := btcutil.NewBlock(response)
+			}
 
-				// Only set height if btcutil hasn't
-				// automagically put one in.
-				if block.Height() == btcutil.BlockHeightUnknown {
-					block.SetHeight(int32(height))
+			block := btcutil.NewBlock(response)
+
+			// Only set height if btcutil hasn't
+			// automagically put one in.
+			if block.Height() == btcutil.BlockHeightUnknown {
+				block.SetHeight(int32(height))
+			}
+
+			// If this claims our block but doesn't pass
+			// the sanity check, the peer is trying to
+			// bamboozle us.
+			if err := blockchain.CheckBlockSanity(
+				block,
+				// We don't need to check PoW because
+				// by the time we get here, it's been
+				// checked during header
+				// synchronization
+				s.chainParams.PowLimit,
+				s.timeSource,
+			); err != nil {
+				log.Warnf("Invalid block for %s "+
+					"received from %s -- ",
+					blockHash, peer)
+				fmt.Println(err)
+
+				return query.Progress{
+					Finished:   false,
+					Progressed: false,
 				}
+			}
 
-				// If this claims our block but doesn't pass
-				// the sanity check, the peer is trying to
-				// bamboozle us. Disconnect it.
-				if err := blockchain.CheckBlockSanity(
-					block,
-					// We don't need to check PoW because
-					// by the time we get here, it's been
-					// checked during header
-					// synchronization
-					s.chainParams.PowLimit,
-					s.timeSource,
-				); err != nil {
-					log.Warnf("Invalid block for %s "+
-						"received from %s -- "+
-						"disconnecting peer", blockHash,
-						sp.Addr())
-					sp.Disconnect()
-					return
-				}
+			// TODO(roasbeef): modify CheckBlockSanity to
+			// also check witness commitment
 
-				// TODO(roasbeef): modify CheckBlockSanity to
-				// also check witness commitment
-
-				// At this point, the block matches what we
-				// know about it and we declare it sane. We can
-				// kill the query and pass the response back to
-				// the caller.
-				foundBlock = block
-				close(quit)
-			default:
+			// At this point, the block matches what we
+			// know about it and we declare it sane. We can
+			// kill the query and pass the response back to
+			// the caller.
+			foundBlock = block
+			return query.Progress{
+				Finished:   true,
+				Progressed: true,
 			}
 		},
-		options...,
+	}
+
+	errChan := s.queryDispatcher.Query(
+		[]*query.Request{request}, query.Encoding(qo.encoding),
+		query.Cancel(s.quit),
 	)
+
+	select {
+	case err := <-errChan:
+		if err != nil {
+			return nil, err
+		}
+	case <-s.quit:
+		return nil, ErrShuttingDown
+	}
+
 	if foundBlock == nil {
 		return nil, fmt.Errorf("couldn't retrieve block %s from "+
 			"network", blockHash)


### PR DESCRIPTION
This PR should probably be split into 3 PR's. Doing it in 1 for now just to get some initial feedback and to better show the progression. The three sections are as follows:

1. The first 2 commits alter the `GetBlock` and `GetCFilter` functions to use the work dispatcher for their queries instead of using the old `queryPeers` function. The function is now removed bringing us one step closer to removing all query logic from the main package. 
2. The 3rd commit isolates the bottleneck of the `GetCFilter` function which is persisting filters to the DB. In this commit, this operation is spun off into a goroutine thus allowing the `GetCFilter` function to return as soon as all the filters are written to the cache. 
3. Finally, the 4th commit ensures that `rescan` can make use of batch filter fetching by waiting until the header chain is either current or until it is ahead of the specified end height. Before this commit, if rescan is started before the chain is current, then the filters are fetched one by one instead which is what makes things super slow. For example, on local regtest: before this commit it would take 7 seconds to sync 3000 blocks but with this commit, it takes 900ms. (full testnet rescan from local testnet bitcoind took like 5 mins)