### PR TITLE
query: end completed queries in sendTransaction before timeout

### DIFF
--- a/sync_test.go
+++ b/sync_test.go
@@ -474,6 +474,29 @@ func testStartRescan(harness *neutrinoHarness, t *testing.T) {
 		}
 	}
 
+	// waitTx will poll for a transaction to appear on given node for up to
+	// 5 seconds.
+	waitTx := func(node *rpcclient.Client, hash chainhash.Hash) {
+		t.Helper()
+		exitTimer := time.NewTimer(5 * time.Second)
+		defer exitTimer.Stop()
+		for {
+			<-time.After(200 * time.Millisecond)
+
+			select {
+			case <-exitTimer.C:
+				t.Fatalf("Timeout waiting to see transaction.")
+			default:
+			}
+
+			if _, err := node.GetRawTransaction(&hash); err != nil {
+				continue
+			}
+
+			return
+		}
+	}
+
 	// Create another address to send to so we don't trip the rescan with
 	// the old address and we can test monitoring both OutPoint usage and
 	// receipt by addresses.
@@ -520,6 +543,9 @@ func testStartRescan(harness *neutrinoHarness, t *testing.T) {
 	if err != nil && !strings.Contains(err.Error(), "already have") {
 		t.Fatalf("Unable to send transaction to network: %s", err)
 	}
+	// SendTransaction does not know when the MsgTx was actually sent, only
+	// that a getdata request was received and a MsgTx queued to send.
+	waitTx(harness.h1.Client, authTx1.Tx.TxHash())
 	_, err = harness.h1.Client.Generate(1)
 	if err != nil {
 		t.Fatalf("Couldn't generate/submit block: %s", err)
@@ -565,6 +591,7 @@ func testStartRescan(harness *neutrinoHarness, t *testing.T) {
 	if err != nil && !strings.Contains(err.Error(), "already have") {
 		t.Fatalf("Unable to send transaction to network: %s", err)
 	}
+	waitTx(harness.h1.Client, authTx2.Tx.TxHash())
 	_, err = harness.h1.Client.Generate(1)
 	if err != nil {
 		t.Fatalf("Couldn't generate/submit block: %s", err)


### PR DESCRIPTION
`(*ChainService).sendTransaction`  always times out even if each peer does respond.  This is because after receiving a `getdata` message in response to the outgoing `inv`, the `checkResponse` closure provided to `queryAllPeers` neglects to close the `peerQuit` channel.  As a result, `sendTransaction` always blocks for the full configured `BroadcastTimeout`.

This change adds the missing `close(peerQuit)` when a matching response (either a getdata or reject) is received.  I have tested this fix in our app, and sends no longer always time out when all peers respond with a getdata.

This change also makes a note in the `sendTransaction` function that the `if numReplied == len(rejections) {` test at the end is currently impossible to hit since `numReplied` would also need to be incremented when _rejections_ are recorded.  I did not fix this however since it would potentially start returning non-nil errors for harmless rejections, such as "already-in-mempool", "already have transaction", and "transaction already exists" (`pushtx.Mempool` and `pushtx.Confirmed`).  There are existing TODO comments from @wpaulino (wilmer) to this effect.  I did add a debug log though to help characterize what rejection messages are actually received in the wild.

Finally, this adds a comment in `(*blockManager).fetchFilterFromAllPeers`, which also appears to be lacking a `close(peerQuit)` in it's `queryAllPeers` check closure.  I added a debug log instead.  I'm pretty certain this fix is needed here too, but this code is only called from `(*blockManager).detectBadPeers`, and I haven't hit that in my tests yet today.