### PR TITLE
Headerfs: add error msg

### DIFF
--- a/headerfs/index.go
+++ b/headerfs/index.go
@@ -266,6 +266,12 @@ func (h *headerIndex) chainTipWithTx(tx walletdb.ReadTx) (*chainhash.Hash,
 	// fetch the hash for this tip, then using that we'll fetch the height
 	// that corresponds to that hash.
 	tipHashBytes := rootBucket.Get(tipKey)
+	if tipHashBytes == nil {
+		return nil, 0, fmt.Errorf(
+			"the key %s does not exist in bucket %s",
+			tipKey, indexBucket,
+		)
+	}
 	tipHeight, err := getHeaderEntry(rootBucket, tipHashBytes)
 	if err != nil {
 		return nil, 0, ErrHeightNotFound


### PR DESCRIPTION
Adds an error message when there is a missing key (happens if neutrino.db is deleted for example).