### PR TITLE
Export newPeerConfig and newServerPeer

### DIFF
--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -553,9 +553,9 @@ func TestBlockManagerInvalidInterval(t *testing.T) {
 
 		// Create a mock peer to prevent panics when attempting to ban
 		// a peer that served an invalid filter header.
-		mockPeer := newServerPeer(&ChainService{}, false)
+		mockPeer := NewServerPeer(&ChainService{}, false)
 		mockPeer.Peer, err = peer.NewOutboundPeer(
-			newPeerConfig(mockPeer), "127.0.0.1:8333",
+			NewPeerConfig(mockPeer), "127.0.0.1:8333",
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/neutrino.go
+++ b/neutrino.go
@@ -181,9 +181,9 @@ type ServerPeer struct {
 	mtxSubscribers   sync.RWMutex
 }
 
-// newServerPeer returns a new ServerPeer instance. The peer needs to be set by
+// NewServerPeer returns a new ServerPeer instance. The peer needs to be set by
 // the caller.
-func newServerPeer(s *ChainService, isPersistent bool) *ServerPeer {
+func NewServerPeer(s *ChainService, isPersistent bool) *ServerPeer {
 	return &ServerPeer{
 		server:           s,
 		persistent:       isPersistent,
@@ -1468,8 +1468,8 @@ func (s *ChainService) SendTransaction(tx *wire.MsgTx) error {
 	return s.broadcaster.Broadcast(tx)
 }
 
-// newPeerConfig returns the configuration for the given ServerPeer.
-func newPeerConfig(sp *ServerPeer) *peer.Config {
+// NewPeerConfig returns the configuration for the given ServerPeer.
+func NewPeerConfig(sp *ServerPeer) *peer.Config {
 	return &peer.Config{
 		Listeners: peer.MessageListeners{
 			OnVersion:   sp.OnVersion,
@@ -1537,8 +1537,8 @@ func (s *ChainService) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) 
 		return
 	}
 
-	sp := newServerPeer(s, c.Permanent)
-	p, err := peer.NewOutboundPeer(newPeerConfig(sp), peerAddr)
+	sp := NewServerPeer(s, c.Permanent)
+	p, err := peer.NewOutboundPeer(NewPeerConfig(sp), peerAddr)
 	if err != nil {
 		log.Debugf("Cannot create outbound peer %s: %s", c.Addr, err)
 		disconnect()


### PR DESCRIPTION
These functions need to public to be able to add peers to an existing ChainService.