### PR TITLE
rescan: use batch filter fetching

### DIFF
--- a/rescan.go
+++ b/rescan.go
@@ -74,6 +74,10 @@ type ChainSource interface {
 	//
 	// TODO(wilmer): extend with best hash as well.
 	Subscribe(bestHeight uint32) (*blockntfns.Subscription, error)
+
+	// IsCurrent returns true if the backend chain thinks that its view of
+	// the network is current.
+	IsCurrent() bool
 }
 
 // ScanProgressHandler is used in rescanOptions to update the caller with the

--- a/rescan_test.go
+++ b/rescan_test.go
@@ -272,6 +272,12 @@ func (c *mockChainSource) setFailGetFilter(b bool) {
 	c.failGetFilter = b
 }
 
+// IsCurrent returns true if the backend chain thinks that its view of
+// the network is current.
+func (c *mockChainSource) IsCurrent() bool {
+	return true
+}
+
 // GetCFilter returns the filter of the given type for the block with the given
 // hash.
 func (c *mockChainSource) GetCFilter(hash chainhash.Hash,


### PR DESCRIPTION
With this PR, we ensure that `rescan` can make use of batch filter fetching by 
waiting until the header chain is either current or until it is ahead of the specified 
end height before starting the scan. This greatly improves the speed of a rescan 
because before this commit, the filters would be fetched one-by-one. 

The first few commits of this PR are just refactor commits that clean-up the `rescan`
function and then the actual behaviour change is added in the final commit. 

Fixes https://github.com/lightninglabs/neutrino/issues/68
Replaces https://github.com/lightninglabs/neutrino/pull/236

## Performance Improvement

On current master branch, syncing 3200 filters on my local regtest network takes 4m25s
With this PR, syncing the same number of filters takes 653ms

## LND CI

https://github.com/lightningnetwork/lnd/pull/7788