### PR TITLE
verification: mute taproot related err to dbg

### DIFF
--- a/verification.go
+++ b/verification.go
@@ -141,7 +141,7 @@ func VerifyBasicBlockFilter(filter *gcs.Filter, block *btcutil.Block) (int,
 			}
 
 			if !match {
-				log.Errorf("filter for block %v might be "+
+				log.Debugf("filter for block %v might be "+
 					"invalid, input %d of tx %v spends "+
 					"pk script %x which wasn't matched by "+
 					"filter. The input likely spends a "+


### PR DESCRIPTION
We can't re-create the pkScript from a keyspend p2tr witness, as we're missing the public key. So this warning will trigger for each block that contains a p2tr key spend, which isn't really useful and confuses users. So we're downgrading the error to a debug message.