### PR TITLE
Disable retargeting on regtest to preserve compatibility with bitcoind

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2736,6 +2736,11 @@ func (b *blockManager) checkHeaderSanity(blockHeader *wire.BlockHeader,
 func (b *blockManager) calcNextRequiredDifficulty(newBlockTime time.Time,
 	reorgAttempt bool) (uint32, error) {
 
+	// Some networks don't support difficulty retargeting.
+	if b.cfg.ChainParams.PoWNoRetargeting {
+		return b.cfg.ChainParams.PowLimitBits, nil
+	}
+
 	hList := b.headerList
 	if reorgAttempt {
 		hList = b.reorgList

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/lightninglabs/neutrino
 
 require (
-	github.com/btcsuite/btcd v0.23.3
+	github.com/btcsuite/btcd v0.23.5-0.20230622075109-7fd5c1e92cfa
 	github.com/btcsuite/btcd/btcec/v2 v2.1.3
 	github.com/btcsuite/btcd/btcutil v1.1.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13P
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220204213055-eaf0459ff879/go.mod h1:osu7EoKiL36UThEgzYPqdRaxeo0NU8VoXqgcnwpey0g=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220316175102-8d5c75c28923/go.mod h1:taIcYprAW2g6Z9S0gGUxyR+zDwimyDMK5ePOX+iJ2ds=
-github.com/btcsuite/btcd v0.23.3 h1:4KH/JKy9WiCd+iUS9Mu0Zp7Dnj17TGdKrg9xc/FGj24=
-github.com/btcsuite/btcd v0.23.3/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
+github.com/btcsuite/btcd v0.23.5-0.20230622075109-7fd5c1e92cfa h1:ZsImW58WIGcCbdRMKZiFWFPcqQnSv/3OI0+SxcVzVIA=
+github.com/btcsuite/btcd v0.23.5-0.20230622075109-7fd5c1e92cfa/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.1/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3 h1:xM/n3yIhHAhHy04z4i43C8p4ehixJZMsnrVJkgl+MTE=


### PR DESCRIPTION
Replaces https://github.com/lightninglabs/neutrino/pull/256/, now that https://github.com/btcsuite/btcd/pull/1985 was merged.

Fixes https://github.com/lightninglabs/neutrino/issues/255.

cc @chappjc, @amanzag 
