### PR TITLE
Add Browser Support

### DIFF
--- a/bamboozle_unit_test.go
+++ b/bamboozle_unit_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightninglabs/neutrino/headerfs"
+	_ "github.com/linden/tempdb"
 )
 
 func decodeHashNoError(str string) *chainhash.Hash {
@@ -525,9 +526,7 @@ func runCheckCFCheckptSanityTestCase(t *testing.T, testCase *cfCheckptTestCase) 
 	}
 	defer os.RemoveAll(tempDir)
 
-	db, err := walletdb.Create(
-		"bdb", tempDir+"/weks.db", true, dbOpenTimeout,
-	)
+	db, err := walletdb.Create("tempdb", "weks.db")
 	if err != nil {
 		t.Fatalf("Error opening DB: %s", err)
 	}

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -59,9 +59,7 @@ func setupBlockManager(t *testing.T) (*blockManager, headerfs.BlockHeaderStore,
 
 	// Set up the block and filter header stores.
 	tempDir := t.TempDir()
-	db, err := walletdb.Create(
-		"bdb", tempDir+"/weks.db", true, dbOpenTimeout,
-	)
+	db, err := walletdb.Create("tempdb", "weks.db")
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error opening DB: %s", err)
 	}

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -873,6 +874,12 @@ func TestBlockManagerDetectBadPeers(t *testing.T) {
 // each other properly).
 func TestHandleHeaders(t *testing.T) {
 	t.Parallel()
+
+	// skip this test because we can't spawn a process in the browser.
+	// https://github.com/linden/wasmexec/issues/2.
+	if runtime.GOOS == "js" {
+		t.Skip("start process is unsupported in the browser, skipping test.")
+	}
 
 	// First, we set up a block manager and a fake peer that will act as the
 	// test's remote peer.

--- a/filterdb/db_test.go
+++ b/filterdb/db_test.go
@@ -3,27 +3,19 @@ package filterdb
 import (
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/btcsuite/btcd/btcutil/gcs"
 	"github.com/btcsuite/btcd/btcutil/gcs/builder"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcwallet/walletdb"
-	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	_ "github.com/linden/tempdb"
 	"github.com/stretchr/testify/require"
 )
 
 func createTestDatabase(t *testing.T) FilterDatabase {
-	tempDir := t.TempDir()
-
-	db, err := walletdb.Create(
-		"bdb", tempDir+"/test.db", true, time.Second*10,
-	)
+	db, err := walletdb.Create("tempdb", "test.db")
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
 
 	filterDB, err := New(db, chaincfg.SimNetParams)
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,12 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.2.3
-	github.com/btcsuite/btcwallet/walletdb v1.3.5
+	github.com/btcsuite/btcwallet/walletdb v1.4.0
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/lightninglabs/neutrino/cache v1.1.0
 	github.com/lightningnetwork/lnd/queue v1.0.1
+	github.com/linden/tempdb v0.0.0-20240218031655-83bc03e79f51
 	github.com/stretchr/testify v1.8.1
 )
 
@@ -28,10 +29,11 @@ require (
 	github.com/lightningnetwork/lnd/clock v1.0.1 // indirect
 	github.com/lightningnetwork/lnd/ticker v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.etcd.io/bbolt v1.3.5-0.20200615073812-232d8fc87f50 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.18
+go 1.21.2
+
+toolchain go1.21.5

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/lightninglabs/neutrino/cache v1.1.0
 	github.com/lightningnetwork/lnd/queue v1.0.1
+	github.com/linden/indexeddb v0.0.0-20240218035359-81389d584a5e
 	github.com/linden/tempdb v0.0.0-20240218031655-83bc03e79f51
 	github.com/stretchr/testify v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/lightningnetwork/lnd/queue v1.0.1 h1:jzJKcTy3Nj5lQrooJ3aaw9Lau3I0IwvQ
 github.com/lightningnetwork/lnd/queue v1.0.1/go.mod h1:vaQwexir73flPW43Mrm7JOgJHmcEFBWWSl9HlyASoms=
 github.com/lightningnetwork/lnd/ticker v1.0.0 h1:S1b60TEGoTtCe2A0yeB+ecoj/kkS4qpwh6l+AkQEZwU=
 github.com/lightningnetwork/lnd/ticker v1.0.0/go.mod h1:iaLXJiVgI1sPANIF2qYYUJXjoksPNvGNYowB8aRbpX0=
-github.com/linden/tempdb v0.0.0-20231124230014-42fe18a60308 h1:3J67IzgcvBcl1UyzMuExSPmq7hejA1Vr1E7ixKqAUds=
-github.com/linden/tempdb v0.0.0-20231124230014-42fe18a60308/go.mod h1:xR9HUmc4girdp/lNzw1jOt53GaCSmctyB8t+Q6EkWp8=
+github.com/linden/indexeddb v0.0.0-20240218035359-81389d584a5e h1:6FTMUiW0wI+my/+7w4CEEYt5zvGmbAjugt2q/fCUyBM=
+github.com/linden/indexeddb v0.0.0-20240218035359-81389d584a5e/go.mod h1:2AP38q2ks+pRwMc2EhmCexlyri456KCewavN30MZQ8Y=
 github.com/linden/tempdb v0.0.0-20240218031655-83bc03e79f51 h1:RfZREkHD3XpItaIN2I1/tb2hCzE2TN5e14OkTH6Sv74=
 github.com/linden/tempdb v0.0.0-20240218031655-83bc03e79f51/go.mod h1:xR9HUmc4girdp/lNzw1jOt53GaCSmctyB8t+Q6EkWp8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,9 @@ github.com/btcsuite/btcwallet/wallet/txrules v1.2.0 h1:BtEN5Empw62/RVnZ0VcJaVtVl
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.0/go.mod h1:AtkqiL7ccKWxuLYtZm8Bu8G6q82w4yIZdgq6riy60z0=
 github.com/btcsuite/btcwallet/wallet/txsizes v1.1.0 h1:wZnOolEAeNOHzHTnznw/wQv+j35ftCIokNrnOTOU5o8=
 github.com/btcsuite/btcwallet/wallet/txsizes v1.1.0/go.mod h1:pauEU8UuMFiThe5PB3EO+gO5kx87Me5NvdQDsTuq6cs=
-github.com/btcsuite/btcwallet/walletdb v1.3.5 h1:SoxUPLgJUkyO1XqON6X7x+rjHJoIpRQov8o8X6gNoz8=
 github.com/btcsuite/btcwallet/walletdb v1.3.5/go.mod h1:oJDxAEUHVtnmIIBaa22wSBPTVcs6hUp5NKWmI8xDwwU=
+github.com/btcsuite/btcwallet/walletdb v1.4.0 h1:/C5JRF+dTuE2CNMCO/or5N8epsrhmSM4710uBQoYPTQ=
+github.com/btcsuite/btcwallet/walletdb v1.4.0/go.mod h1:oJDxAEUHVtnmIIBaa22wSBPTVcs6hUp5NKWmI8xDwwU=
 github.com/btcsuite/btcwallet/wtxmgr v1.5.0 h1:WO0KyN4l6H3JWnlFxfGR7r3gDnlGT7W2cL8vl6av4SU=
 github.com/btcsuite/btcwallet/wtxmgr v1.5.0/go.mod h1:TQVDhFxseiGtZwEPvLgtfyxuNUDsIdaJdshvWzR0HJ4=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=
@@ -83,6 +84,10 @@ github.com/lightningnetwork/lnd/queue v1.0.1 h1:jzJKcTy3Nj5lQrooJ3aaw9Lau3I0IwvQ
 github.com/lightningnetwork/lnd/queue v1.0.1/go.mod h1:vaQwexir73flPW43Mrm7JOgJHmcEFBWWSl9HlyASoms=
 github.com/lightningnetwork/lnd/ticker v1.0.0 h1:S1b60TEGoTtCe2A0yeB+ecoj/kkS4qpwh6l+AkQEZwU=
 github.com/lightningnetwork/lnd/ticker v1.0.0/go.mod h1:iaLXJiVgI1sPANIF2qYYUJXjoksPNvGNYowB8aRbpX0=
+github.com/linden/tempdb v0.0.0-20231124230014-42fe18a60308 h1:3J67IzgcvBcl1UyzMuExSPmq7hejA1Vr1E7ixKqAUds=
+github.com/linden/tempdb v0.0.0-20231124230014-42fe18a60308/go.mod h1:xR9HUmc4girdp/lNzw1jOt53GaCSmctyB8t+Q6EkWp8=
+github.com/linden/tempdb v0.0.0-20240218031655-83bc03e79f51 h1:RfZREkHD3XpItaIN2I1/tb2hCzE2TN5e14OkTH6Sv74=
+github.com/linden/tempdb v0.0.0-20240218031655-83bc03e79f51/go.mod h1:xR9HUmc4girdp/lNzw1jOt53GaCSmctyB8t+Q6EkWp8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/headerfs/file.go
+++ b/headerfs/file.go
@@ -1,18 +1,211 @@
+//go:build !windows && !js && !wasm
+
 package headerfs
 
 import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sync"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/walletdb"
 )
 
-// ErrHeaderNotFound is returned when a target header on disk (flat file) can't
-// be found.
-type ErrHeaderNotFound struct {
-	error
+// headerBufPool is a pool of bytes.Buffer that will be re-used by the various
+// headerStore implementations to batch their header writes to disk. By
+// utilizing this variable we can minimize the total number of allocations when
+// writing headers to disk.
+var headerBufPool = sync.Pool{
+	New: func() interface{} { return new(bytes.Buffer) },
+}
+
+// headerStore combines a on-disk set of headers within a flat file in addition
+// to a database which indexes that flat file. Together, these two abstractions
+// can be used in order to build an indexed header store for any type of
+// "header" as it deals only with raw bytes, and leaves it to a higher layer to
+// interpret those raw bytes accordingly.
+//
+// TODO(roasbeef): quickcheck coverage.
+type headerStore struct {
+	mtx sync.RWMutex // nolint:structcheck // false positive because used as embedded struct only
+
+	fileName string
+
+	file *os.File
+
+	hType HeaderType
+
+	*headerIndex
+}
+
+// newHeaderStore creates a new headerStore given an already open database, a
+// target file path for the flat-file and a particular header type. The target
+// file will be created as necessary.
+func newHeaderStore(db walletdb.DB, filePath string,
+	hType HeaderType) (*headerStore, error) {
+
+	var flatFileName string
+	switch hType {
+	case Block:
+		flatFileName = "block_headers.bin"
+	case RegularFilter:
+		flatFileName = "reg_filter_headers.bin"
+	default:
+		return nil, fmt.Errorf("unrecognized filter type: %v", hType)
+	}
+
+	flatFileName = filepath.Join(filePath, flatFileName)
+
+	// We'll open the file, creating it if necessary and ensuring that all
+	// writes are actually appends to the end of the file.
+	fileFlags := os.O_RDWR | os.O_APPEND | os.O_CREATE
+	headerFile, err := os.OpenFile(flatFileName, fileFlags, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	// With the file open, we'll then create the header index so we can
+	// have random access into the flat files.
+	index, err := newHeaderIndex(db, hType)
+	if err != nil {
+		return nil, err
+	}
+
+	return &headerStore{
+		fileName:    flatFileName,
+		file:        headerFile,
+		hType:       hType,
+		headerIndex: index,
+	}, nil
+}
+
+// WriteHeaders writes a set of headers to disk and updates the index in a
+// single atomic transaction.
+//
+// NOTE: Part of the BlockHeaderStore interface.
+func (h *blockHeaderStore) WriteHeaders(hdrs ...BlockHeader) error {
+	// Lock store for write.
+	h.mtx.Lock()
+	defer h.mtx.Unlock()
+
+	// First, we'll grab a buffer from the write buffer pool so we an
+	// reduce our total number of allocations, and also write the headers
+	// in a single swoop.
+	headerBuf := headerBufPool.Get().(*bytes.Buffer)
+	headerBuf.Reset()
+	defer headerBufPool.Put(headerBuf)
+
+	// Next, we'll write out all the passed headers in series into the
+	// buffer we just extracted from the pool.
+	for _, header := range hdrs {
+		if err := header.Serialize(headerBuf); err != nil {
+			return err
+		}
+	}
+
+	// With all the headers written to the buffer, we'll now write out the
+	// entire batch in a single write call.
+	if err := h.appendRaw(headerBuf.Bytes()); err != nil {
+		return err
+	}
+
+	// Once those are written, we'll then collate all the headers into
+	// headerEntry instances so we can write them all into the index in a
+	// single atomic batch.
+	headerLocs := make([]headerEntry, len(hdrs))
+	for i, header := range hdrs {
+		headerLocs[i] = header.toIndexEntry()
+	}
+
+	return h.addHeaders(headerLocs)
+}
+
+// WriteHeaders writes a batch of filter headers to persistent storage. The
+// headers themselves are appended to the flat file, and then the index updated
+// to reflect the new entires.
+func (f *FilterHeaderStore) WriteHeaders(hdrs ...FilterHeader) error {
+	// Lock store for write.
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	// If there are 0 headers to be written, return immediately. This
+	// prevents the newTip assignment from panicking because of an index
+	// of -1.
+	if len(hdrs) == 0 {
+		return nil
+	}
+
+	// First, we'll grab a buffer from the write buffer pool so we an
+	// reduce our total number of allocations, and also write the headers
+	// in a single swoop.
+	headerBuf := headerBufPool.Get().(*bytes.Buffer)
+	headerBuf.Reset()
+	defer headerBufPool.Put(headerBuf)
+
+	// Next, we'll write out all the passed headers in series into the
+	// buffer we just extracted from the pool.
+	for _, header := range hdrs {
+		if _, err := headerBuf.Write(header.FilterHash[:]); err != nil {
+			return err
+		}
+	}
+
+	// With all the headers written to the buffer, we'll now write out the
+	// entire batch in a single write call.
+	if err := f.appendRaw(headerBuf.Bytes()); err != nil {
+		return err
+	}
+
+	// As the block headers should already be written, we only need to
+	// update the tip pointer for this particular header type.
+	newTip := hdrs[len(hdrs)-1].toIndexEntry().hash
+	return f.truncateIndex(&newTip, false)
+}
+
+// Remove the file.
+func (h *headerStore) Remove() error {
+	// Close the file before removing it. This is required by some
+	// OS, e.g., Windows.
+	if err := h.file.Close(); err != nil {
+		return err
+	}
+	if err := os.Remove(h.fileName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Calculate the current height.
+func (h *headerStore) height() (uint32, bool, error) {
+	fileInfo, err := h.file.Stat()
+	if err != nil {
+		return 0, false, err
+	}
+
+	size := fileInfo.Size()
+
+	// Check if the file is empty. Fallback to a height of zero.
+	if size == 0 {
+		return 0, true, nil
+	}
+
+	var fileHeight uint32
+
+	// Compute the size of the current file so we can
+	// calculate the latest header written to disk.
+	switch h.hType {
+	case Block:
+		fileHeight = uint32(size/80) - 1
+
+	case RegularFilter:
+		fileHeight = uint32(size/32) - 1
+	}
+
+	return fileHeight, false, nil
 }
 
 // appendRaw appends a new raw header to the end of the flat file.

--- a/headerfs/index_test.go
+++ b/headerfs/index_test.go
@@ -173,12 +173,18 @@ func TestHeaderStorageFallback(t *testing.T) {
 		t.Fatalf("error setting new tip: %v", err)
 	}
 	for _, header := range newHeaderEntries {
-		if err := hIndex.truncateIndex(&header.hash, true); err != nil {
+		// Copy the header hash so we can create a iteration-specific pointer.
+		// https://github.com/golang/go/discussions/56010#discussion-4441437.
+		hash := header.hash
+
+		if err := hIndex.truncateIndex(&hash, true); err != nil {
 			t.Fatalf("error truncating tip: %v", err)
 		}
 	}
 	for _, header := range oldHeaderEntries {
-		if err := hIndex.truncateIndex(&header.hash, true); err != nil {
+		hash := header.hash
+
+		if err := hIndex.truncateIndex(&hash, true); err != nil {
 			t.Fatalf("error truncating tip: %v", err)
 		}
 	}

--- a/headerfs/js.go
+++ b/headerfs/js.go
@@ -1,0 +1,402 @@
+//go:build js && wasm
+
+package headerfs
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall/js"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/linden/indexeddb"
+)
+
+const headersStore = "headers"
+
+// headerStore combines a IndexedDB store of headers within a flat file in addition
+// to a database which indexes that flat file. Together, these two abstractions
+// can be used in order to build an indexed header store for any type of
+// "header" as it deals only with raw bytes, and leaves it to a higher layer to
+// interpret those raw bytes accordingly.
+//
+// TODO(roasbeef): quickcheck coverage.
+type headerStore struct {
+	mtx sync.RWMutex // nolint:structcheck // false positive because used as embedded struct only
+
+	idb *indexeddb.DB
+
+	*headerIndex
+}
+
+// readHeader reads a full block header from the flat-file. The header read is
+// determined by the hight value.
+func (h *headerStore) readHeader(height uint32) (wire.BlockHeader, error) {
+	// Create a new read/write transaction, scoped to headers.
+	tx, err := h.idb.NewTransaction([]string{headersStore}, indexeddb.ReadWriteMode)
+	if err != nil {
+		return wire.BlockHeader{}, err
+	}
+
+	// Get the headers store.
+	hdrs := tx.Store(headersStore)
+
+	// Get the raw header.
+	val, err := hdrs.Get(height)
+
+	// check if the value was not found as that case is handled differently.
+	if errors.Is(err, indexeddb.ErrValueNotFound) {
+		return wire.BlockHeader{}, &ErrHeaderNotFound{err}
+	}
+
+	if err != nil {
+		return wire.BlockHeader{}, err
+	}
+
+	// Ensure the value is a string.
+	if val.Type() != js.TypeString {
+		return wire.BlockHeader{}, fmt.Errorf("unexpected type: %s", val.Type())
+	}
+
+	var header wire.BlockHeader
+
+	// Unquote the value.
+	unquote, err := strconv.Unquote(val.String())
+	if err != nil {
+		return wire.BlockHeader{}, err
+	}
+
+	// Create a new reader from the raw header.
+	reader := strings.NewReader(unquote)
+
+	// Finally, decode the  bytes into a proper bitcoin header.
+	err = header.Deserialize(reader)
+
+	return header, err
+}
+
+func (h *headerStore) height() (uint32, bool, error) {
+	// Create a new read-only transaction. Scoped to headers.
+	tx, err := h.idb.NewTransaction([]string{headersStore}, indexeddb.ReadMode)
+	if err != nil {
+		return 0, false, err
+	}
+
+	// Get the headers store.
+	hdrs := tx.Store(headersStore)
+
+	// Count the amount of headers.
+	count, err := hdrs.Count()
+
+	// Fallback to the zero value if no value is found.
+	if errors.Is(err, indexeddb.ErrValueNotFound) || count == 0 {
+		return 0, true, nil
+	}
+
+	if err != nil {
+		return 0, false, err
+	}
+
+	// Subtract one as the block height does not include the genesis block.
+	return uint32(count - 1), false, nil
+}
+
+func (h *headerStore) singleTruncate() error {
+	// Get the current height.
+	height, genesis, err := h.height()
+	if err != nil {
+		return err
+	}
+
+	// Create a write transaction. Scoped to height.
+	tx, err := h.idb.NewTransaction([]string{headersStore}, indexeddb.ReadWriteMode)
+	if err != nil {
+		return err
+	}
+
+	// Get the height store.
+	hdrs := tx.Store(headersStore)
+
+	// Delete the genesis block.
+	if genesis {
+		return hdrs.Delete("genesis")
+	}
+
+	// Delete the header.
+	return hdrs.Delete(height + 1)
+}
+
+// Remove every key/value and set the height to 0.
+func (h *headerStore) Remove() error {
+	// Create a write transaction. Scoped to headers.
+	tx, err := h.idb.NewTransaction([]string{headersStore}, indexeddb.ReadWriteMode)
+	if err != nil {
+		return err
+	}
+
+	// Get the headers store.
+	hdrs := tx.Store(headersStore)
+
+	// Clear all the headers.
+	return hdrs.Clear()
+}
+
+// newHeaderStore creates a new headerStore given an already open database, a
+// target file path for the flat-file and a particular header type. The target
+// file will be created as necessary.
+func newHeaderStore(db walletdb.DB, filePath string, hType HeaderType) (*headerStore, error) {
+	var prefix string
+	switch hType {
+	case Block:
+		prefix = "blocks"
+	case RegularFilter:
+		prefix = "filters"
+	default:
+		return nil, fmt.Errorf("unrecognized filter type: %v", hType)
+	}
+
+	// Prefix with the file path to prevent collisions.
+	prefix = filePath + "-" + prefix
+
+	// Create the database.
+	idb, err := indexeddb.New(prefix, 1, func(up *indexeddb.Upgrade) error {
+		// Create the headers store.
+		up.CreateStore(headersStore)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// With the file open, we'll then create the header index so we can
+	// have random access into the flat files.
+	index, err := newHeaderIndex(db, hType)
+	if err != nil {
+		return nil, err
+	}
+
+	return &headerStore{
+		idb:         idb,
+		headerIndex: index,
+	}, nil
+}
+
+// readHeaderRange will attempt to fetch a series of block headers within the
+// target height range.
+//
+// NOTE: The end height is _inclusive_ so we'll fetch all headers from the
+// startHeight up to the end height, including the final header.
+func (h *blockHeaderStore) readHeaderRange(startHeight uint32,
+	endHeight uint32) ([]wire.BlockHeader, error) {
+	var headers []wire.BlockHeader
+
+	// Add headers from start height to end height.
+	for height := startHeight; height <= endHeight; height++ {
+		// Read the header.
+		header, err := h.readHeader(height)
+		if err != nil {
+			return nil, err
+		}
+
+		// Append the header to the slice.
+		headers = append(headers, header)
+	}
+
+	return headers, nil
+}
+
+// WriteHeaders writes a set of headers to disk and updates the index in a
+// single atomic transaction.
+//
+// NOTE: Part of the BlockHeaderStore interface.
+func (h *blockHeaderStore) WriteHeaders(hdrs ...BlockHeader) error {
+	// Lock store for write.
+	h.mtx.Lock()
+	defer h.mtx.Unlock()
+
+	height, genesis, err := h.height()
+	if err != nil {
+		return err
+	}
+
+	tx, err := h.idb.NewTransaction([]string{headersStore}, indexeddb.ReadWriteMode)
+	if err != nil {
+		return err
+	}
+
+	str := tx.Store(headersStore)
+
+	// Next, we'll write out all the passed headers in series.
+	for _, header := range hdrs {
+		buf := new(bytes.Buffer)
+
+		// Serialize the header.
+		if err := header.Serialize(buf); err != nil {
+			return err
+		}
+
+		var key any
+
+		if genesis {
+			key = height
+			genesis = false
+		} else {
+			// Add space for the genesis block.
+			key = height + 1
+		}
+
+		// Put the block header.
+		err = str.Put(
+			key,
+			// Quote the string so it is UTF-8 safe.
+			strconv.Quote(buf.String()),
+		)
+		if err != nil {
+			return err
+		}
+
+		height++
+
+	}
+
+	// Once those are written, we'll then collate all the headers into
+	// headerEntry instances so we can write them all into the index in a
+	// single atomic batch.
+	headerLocs := make([]headerEntry, len(hdrs))
+	for i, header := range hdrs {
+		headerLocs[i] = header.toIndexEntry()
+	}
+
+	return h.addHeaders(headerLocs)
+}
+
+// readHeader reads a single filter header at the specified height from the
+// flat files on disk.
+func (f *FilterHeaderStore) readHeader(height uint32) (*chainhash.Hash, error) {
+	// Create a new read-only transaction.
+	tx, err := f.idb.NewTransaction([]string{headersStore}, indexeddb.ReadMode)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the headers store.
+	hdrs := tx.Store(headersStore)
+
+	// Get the header.
+	val, err := hdrs.Get(height)
+
+	// check if the value was not found as that case is handled differently.
+	if errors.Is(err, indexeddb.ErrValueNotFound) {
+		return nil, &ErrHeaderNotFound{err}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure the value is a string.
+	if val.Type() != js.TypeString {
+		return nil, fmt.Errorf("unexpected type: %s", val.Type())
+	}
+
+	// Unquote the value.
+	unquote, err := strconv.Unquote(val.String())
+	if err != nil {
+		return nil, err
+	}
+
+	// Cast the hash to a chainhash.
+	return (*chainhash.Hash)([]byte(unquote)), nil
+}
+
+// readHeaderRange will attempt to fetch a series of filter headers within the
+// target height range. This method batches a set of reads into a single system
+// call thereby increasing performance when reading a set of contiguous
+// headers.
+//
+// NOTE: The end height is _inclusive_ so we'll fetch all headers from the
+// startHeight up to the end height, including the final header.
+func (f *FilterHeaderStore) readHeaderRange(startHeight uint32,
+	endHeight uint32) ([]chainhash.Hash, error) {
+	var headers []chainhash.Hash
+
+	// Add headers from start height to end height.
+	for height := startHeight; height <= endHeight; height++ {
+		// Read the header.
+		header, err := f.readHeader(height)
+		if err != nil {
+			return nil, err
+		}
+
+		// Append the header to the slice.
+		headers = append(headers, *header)
+	}
+
+	return headers, nil
+}
+
+// WriteHeaders writes a batch of filter headers to persistent storage. The
+// headers themselves are appended to the flat file, and then the index updated
+// to reflect the new entires.
+func (f *FilterHeaderStore) WriteHeaders(hdrs ...FilterHeader) error {
+	// Lock store for write.
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	// If there are 0 headers to be written, return immediately. This
+	// prevents the newTip assignment from panicking because of an index
+	// of -1.
+	if len(hdrs) == 0 {
+		return nil
+	}
+
+	height, genesis, err := f.height()
+	if err != nil {
+		return err
+	}
+
+	// Create a new transaction.
+	tx, err := f.idb.NewTransaction([]string{headersStore}, indexeddb.ReadWriteMode)
+	if err != nil {
+		return err
+	}
+
+	str := tx.Store(headersStore)
+
+	// Next, we'll write out all the passed headers in series into the
+	// buffer we just extracted from the pool.
+	for _, header := range hdrs {
+		var key any
+
+		if genesis {
+			key = height
+			genesis = false
+		} else {
+			// Add space for the genesis block.
+			key = height + 1
+		}
+
+		// Put the filter header.
+		err = str.Put(
+			key,
+			// Encode the filter hash.
+			strconv.Quote(string(header.FilterHash[:])),
+		)
+		if err != nil {
+			return err
+		}
+
+		height++
+	}
+
+	// As the block headers should already be written, we only need to
+	// update the tip pointer for this particular header type.
+	newTip := hdrs[len(hdrs)-1].toIndexEntry().hash
+	return f.truncateIndex(&newTip, false)
+}

--- a/headerfs/store_test.go
+++ b/headerfs/store_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/davecgh/go-spew/spew"
+	_ "github.com/linden/tempdb"
 )
 
 func createTestBlockHeaderStore() (func(), walletdb.DB, string,
@@ -26,10 +26,7 @@ func createTestBlockHeaderStore() (func(), walletdb.DB, string,
 		return nil, nil, "", nil, err
 	}
 
-	dbPath := filepath.Join(tempDir, "test.db")
-	db, err := walletdb.Create(
-		"bdb", dbPath, true, time.Second*10,
-	)
+	db, err := walletdb.Create("tempdb", "test.db")
 	if err != nil {
 		return nil, nil, "", nil, err
 	}
@@ -41,7 +38,6 @@ func createTestBlockHeaderStore() (func(), walletdb.DB, string,
 
 	cleanUp := func() {
 		os.RemoveAll(tempDir)
-		db.Close()
 	}
 
 	return cleanUp, db, tempDir, hStore.(*blockHeaderStore), nil
@@ -231,8 +227,7 @@ func createTestFilterHeaderStore() (func(), walletdb.DB, string, *FilterHeaderSt
 		return nil, nil, "", nil, err
 	}
 
-	dbPath := filepath.Join(tempDir, "test.db")
-	db, err := walletdb.Create("bdb", dbPath, true, time.Second*10)
+	db, err := walletdb.Create("tempdb", "test.db")
 	if err != nil {
 		return nil, nil, "", nil, err
 	}

--- a/headerfs/truncate.go
+++ b/headerfs/truncate.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !js && !wasm
+// +build !windows,!js,!wasm
 
 package headerfs
 

--- a/mock_store.go
+++ b/mock_store.go
@@ -82,3 +82,7 @@ func (m *mockBlockHeaderStore) WriteHeaders(headers ...headerfs.BlockHeader) err
 
 	return nil
 }
+
+func (m *mockBlockHeaderStore) Remove() error {
+	return nil
+}

--- a/sync_test.go
+++ b/sync_test.go
@@ -1035,6 +1035,12 @@ func testRandomBlocks(harness *neutrinoHarness, t *testing.T) {
 }
 
 func TestNeutrinoSync(t *testing.T) {
+	// skip this test because we can't spawn a process in the browser.
+	// https://github.com/linden/wasmexec/issues/2.
+	if runtime.GOOS == "js" {
+		t.Skip("start process is unsupported in the browser, skipping test.")
+	}
+
 	// Set up logging.
 	logger := btclog.NewBackend(os.Stdout)
 	chainLogger := logger.Logger("CHAIN")

--- a/sync_test.go
+++ b/sync_test.go
@@ -27,10 +27,10 @@ import (
 	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/walletdb"
-	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
 	"github.com/lightninglabs/neutrino"
 	"github.com/lightninglabs/neutrino/banman"
 	"github.com/lightninglabs/neutrino/headerfs"
+	_ "github.com/linden/tempdb"
 )
 
 var (
@@ -1140,9 +1140,7 @@ func TestNeutrinoSync(t *testing.T) {
 		t.Fatalf("Failed to create temporary directory: %s", err)
 	}
 	defer os.RemoveAll(tempDir)
-	db, err := walletdb.Create(
-		"bdb", tempDir+"/weks.db", true, dbOpenTimeout,
-	)
+	db, err := walletdb.Create("tempdb", "weks.db")
 	if err != nil {
 		t.Fatalf("Error opening DB: %s\n", err)
 	}


### PR DESCRIPTION
This PR adds support for the browser using [indexeddb](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) as a storage backend for `headerfs` instead of the file system.

## Why IndexedDB?
I'd initially chosen to go with [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) for simplicity but due to recent rate limiting changes it made syncing past a couple 100 blocks freeze, indexddb does not have share these limitations. I'd also looked into emulating the file system but it turned out to add a lot of complexity with a performance loss over just using indexeddb directly. 

## Browser Testing.
Since Go only provides an executor for your native platform testing needs to be done via a custom executor targeting the browser. I've written my own called [`wasmexec`](https://github.com/linden/wasmexec) which also provides file system access for ease of testing, you can run tests via the following:
```sh
# install wasmexec from the add-file-system branch while #1 is in progress.
go install github.com/linden/wasmexec@add-file-system

# target javascript/wasm and execute via wasmexec.
GOOS=js GOARCH=wasm go test -exec wasmexec ./...
```
I'm planning on provider this as part of a Github Action in the future.

## `btcd` Changes.
Running this in the browser without `wasmexec`'s file system access requires a couple of changes to `btcd`'s `addrmgr` & `btcutil` as they require a file system. Changes made in https://github.com/btcsuite/btcd/pull/2124.