### PR TITLE
Don't hammer disconnecting peers

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -874,6 +874,11 @@ func NewChainService(cfg Config) (*ChainService, error) {
 					continue
 				}
 
+				// Don't hammer.
+				if time.Since(addr.LastAttempt()) < ConnectionRetryInterval {
+					continue
+				}
+
 				// only allow recent nodes (10mins) after we failed 30
 				// times
 				if tries < 30 && time.Since(addr.LastAttempt()) < 10*time.Minute {


### PR DESCRIPTION
A peer disconnect can trigger immediate reconnects to the same peer regardless of the nature of the disconnect.

Starting at `(*Peer).Disconnect`, closing the `quit` channel causes `WaitForDisconnect` to return in `peerDoneHandler`, which sends a message to `handleDonePeerMsg`. For non-persistent peers, this can cause two simultanous calls to `GetNewAddress`. Once more directly via `NewConnReq`, and once via `(*ConnManager).Remove` sending a `handleDisconnected` to the `(*ConnManager).connHandler` and `(*ConnManager).handleFailedConn`, which calls `NewConnReq` again. So a disconnecting peer can trigger two new connection requests immediately, and there's nothing preventing the same address from being used.

The `newAddressFunc` used by `*server` in **btcd** may also benefit from this change. I think it might be the reason for [the `// TODO: duplicate oneshots?` comment](https://github.com/btcsuite/btcd/blob/6b197d38d745048c5fe2a895010c9c0a4d9ab2a6/server.go#L2009).

