### PR TITLE
neutrino: improve perf in high latency networks

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -753,7 +753,7 @@ func NewChainService(cfg Config) (*ChainService, error) {
 	if s.persistToDisk {
 		cfg := &chanutils.BatchWriterConfig[*filterdb.FilterData]{
 			QueueBufferSize:        chanutils.DefaultQueueSize,
-			MaxBatch:               1000,
+			MaxBatch:               10,
 			DBWritesTickerDuration: time.Millisecond * 500,
 			PutItems:               s.FilterDB.PutFilters,
 		}

--- a/query.go
+++ b/query.go
@@ -49,7 +49,7 @@ var (
 	// each peer before we've concluded we aren't going to get a valid
 	// response. This allows to make up for missed messages in some
 	// instances.
-	QueryNumRetries = 2
+	QueryNumRetries = 8
 
 	// QueryPeerConnectTimeout specifies how long to wait for the
 	// underlying chain service to connect to a peer before giving up

--- a/rescan.go
+++ b/rescan.go
@@ -956,7 +956,7 @@ func (rs *rescanState) handleBlockConnected(ntfn *blockntfns.Connected) error {
 
 	// Otherwise, we'll attempt to fetch the filter to retrieve the relevant
 	// transactions and notify them.
-	queryOptions := NumRetries(0)
+	queryOptions := NumRetries(2)
 	blockFilter, err := chain.GetCFilter(
 		newStamp.Hash, wire.GCSFilterRegular, queryOptions,
 	)


### PR DESCRIPTION
After working with @hsjoberg and @niteshbalusu11 to troubleshoot Blixt performance we realized two things were consistently going wrong in networks with > around 300ms latency:

1. Retries would be exhausted quickly
2. Due to that --^ timeouts being doubled did not help much

After investigating, we decided to experiment with changing some constants in neutrino to work better.

This PR addresses both issues by:
- Decreasing maxBatch to 10
- Increasing query retries from 2 to 8
- Increasing rescan retries from 1 to 2
- Increasing broadcast query retries from 1 to 8

The result is that we can now use Blixt with networks that we could not previously.