### PR TITLE
headerfs: fail gracefully on header write

### DIFF
--- a/headerfs/file.go
+++ b/headerfs/file.go
@@ -3,6 +3,7 @@ package headerfs
 import (
 	"bytes"
 	"fmt"
+	"io"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -16,7 +17,25 @@ type ErrHeaderNotFound struct {
 
 // appendRaw appends a new raw header to the end of the flat file.
 func (h *headerStore) appendRaw(header []byte) error {
-	if _, err := h.file.Write(header); err != nil {
+	// Get current file position before writing. We'll use this position to
+	// revert to if the write fails partially.
+	currentPos, err := h.file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return err
+	}
+
+	n, err := h.file.Write(header)
+	if err != nil {
+		// If we wrote some bytes but not all (partial write),
+		// truncate the file back to its original size to maintain consistency.
+		// This removes the partial/corrupt header.
+		if n > 0 {
+			truncErr := h.file.Truncate(currentPos)
+			if truncErr != nil {
+				return fmt.Errorf("write failed with %w and recovery "+
+					"failed with: %v", err, truncErr)
+			}
+		}
 		return err
 	}
 

--- a/headerfs/file.go
+++ b/headerfs/file.go
@@ -3,7 +3,6 @@ package headerfs
 import (
 	"bytes"
 	"fmt"
-	"os"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -166,7 +165,7 @@ func (f *FilterHeaderStore) readHeaderRange(startHeight uint32,
 
 // readHeadersFromFile reads a chunk of headers, each of size headerSize, from
 // the given file, from startHeight to endHeight.
-func readHeadersFromFile(f *os.File, headerSize, startHeight,
+func readHeadersFromFile(f FileInterface, headerSize, startHeight,
 	endHeight uint32) (*bytes.Reader, error) {
 
 	// Each header is headerSize bytes, so using this information, we'll

--- a/headerfs/file_test.go
+++ b/headerfs/file_test.go
@@ -1,0 +1,179 @@
+package headerfs
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestAppendRow(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialData   []byte
+		headerToWrite []byte
+		writeFn       func([]byte, FileInterface) (int, error)
+		truncFn       func(size int64) error
+		expected      []byte
+		wantErr       bool
+		errMsg        string
+	}{
+		{
+			name:          "NormalWrite_ValidHeader_DataAppendedSuccessfully",
+			initialData:   []byte{0x01, 0x02, 0x03},
+			headerToWrite: []byte{0x04, 0x05, 0x06},
+			expected:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+		},
+		{
+			name:          "WriteError_ZeroBytesWritten_OriginalDataPreserved",
+			initialData:   []byte{0x01, 0x02, 0x03},
+			headerToWrite: []byte{0x04, 0x05, 0x06},
+			writeFn: func(p []byte, _ FileInterface) (int, error) {
+				return 0, errors.New("simulated write failure")
+			},
+			expected: []byte{0x01, 0x02, 0x03},
+			wantErr:  true,
+			errMsg:   "simulated write failure",
+		},
+		{
+			name:          "PartialWrite_WriteErrorMidway_RollsBackToOriginal",
+			initialData:   []byte{0x01, 0x02, 0x03},
+			headerToWrite: []byte{0x04, 0x05, 0x06},
+			writeFn: func(p []byte, file FileInterface) (int, error) {
+				// Mock a partial write - write the first two bytes.
+				n, _ := file.Write(p[:2])
+				return n, errors.New("simulated partial write failure")
+			},
+			expected: []byte{0x01, 0x02, 0x03},
+			wantErr:  true,
+			errMsg:   "simulated partial write failure",
+		},
+		{
+			name:          "PartialWrite_TruncateFailure_ReportsCompoundError",
+			initialData:   []byte{0x01, 0x02, 0x03},
+			headerToWrite: []byte{0x04, 0x05, 0x06},
+			writeFn: func(p []byte, file FileInterface) (int, error) {
+				// Mock a partial write - write just the first byte.
+				n, _ := file.Write(p[:1])
+				return n, errors.New("simulated partial write failure")
+			},
+			truncFn: func(size int64) error {
+				return errors.New("simulated truncate failure")
+			},
+			expected: []byte{0x01, 0x02, 0x03, 0x04},
+			wantErr:  true,
+			errMsg: "write failed with simulated partial write failure and " +
+				"recovery failed with: simulated truncate failure",
+		},
+		{
+			name:          "NormalWrite_ValidHeader_DataAppendedSuccessfully",
+			initialData:   []byte{},
+			headerToWrite: []byte{0x01, 0x02, 0x03},
+			expected:      []byte{0x01, 0x02, 0x03},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a temporary file for testing.
+			tmpFile, err := os.CreateTemp(t.TempDir(), "header_store_test")
+			if err != nil {
+				t.Fatalf("Failed to create temp file: %v", err)
+			}
+			defer os.Remove(tmpFile.Name())
+
+			// Write initial data.
+			if _, err := tmpFile.Write(test.initialData); err != nil {
+				t.Fatalf("Failed to write initial data: %v", err)
+			}
+
+			// Reset the file position to the end of initial data.
+			_, err = tmpFile.Seek(int64(len(test.initialData)), io.SeekStart)
+			if err != nil {
+				t.Fatalf("Failed to seek: %v", err)
+			}
+
+			// Create a mock file that wraps the real file.
+			mockFile := &mockFile{
+				File:    tmpFile,
+				writeFn: test.writeFn,
+				truncFn: test.truncFn,
+			}
+
+			// Create a header store with our mock file.
+			h := &headerStore{
+				file: mockFile,
+			}
+
+			// Call the function being tested.
+			err = h.appendRaw(test.headerToWrite)
+			if err == nil && test.wantErr {
+				t.Fatal("expected an error, but got none")
+			}
+			if err != nil && !test.wantErr {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err != nil && test.wantErr &&
+				!strings.Contains(err.Error(), test.errMsg) {
+
+				t.Errorf("expected error message %q to be "+
+					"in %q", test.errMsg, err.Error())
+			}
+
+			// Reset file position to start for reading.
+			if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
+				t.Fatalf("Failed to seek to start: %v", err)
+			}
+
+			// Read the file contents.
+			actualData, err := io.ReadAll(tmpFile)
+			if err != nil {
+				t.Fatalf("Failed to read file: %v", err)
+			}
+
+			// Compare expected vs. actual file contents.
+			if !bytes.Equal(actualData, test.expected) {
+				t.Fatalf("Expected file data: %v, "+
+					"got: %v", test.expected, actualData)
+			}
+		})
+	}
+}
+
+// mockFile wraps a real file but allows us to override the Write and
+// Sync methods.
+type mockFile struct {
+	*os.File
+	writeFn func([]byte, FileInterface) (int, error)
+	syncFn  func() error
+	truncFn func(size int64) error
+}
+
+// Write implements the Write method for FileInterface.
+func (m *mockFile) Write(p []byte) (int, error) {
+	if m.writeFn != nil {
+		return m.writeFn(p, m.File)
+	}
+	return m.File.Write(p)
+}
+
+// Sync implements the Sync method for FileInterface.
+func (m *mockFile) Sync() error {
+	if m.syncFn != nil {
+		return m.syncFn()
+	}
+	return m.File.Sync()
+}
+
+// Truncate implements the Truncate method for FileInterface.
+func (m *mockFile) Truncate(size int64) error {
+	if m.truncFn != nil {
+		return m.truncFn(size)
+	}
+	return m.File.Truncate(size)
+}
+
+// Ensure mockFile implements necessary interfaces.
+var _ io.Writer = &mockFile{}

--- a/headerfs/store.go
+++ b/headerfs/store.go
@@ -3,6 +3,7 @@ package headerfs
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -84,6 +85,23 @@ var headerBufPool = sync.Pool{
 	New: func() interface{} { return new(bytes.Buffer) },
 }
 
+// FileInterface defines the minimum file operations needed by headerStore.
+type FileInterface interface {
+	// Basic I/O operations.
+	io.Reader
+	io.Writer
+	io.Closer
+
+	// Extended I/O positioning.
+	io.Seeker
+	io.ReaderAt
+
+	// File-specific operations.
+	Stat() (os.FileInfo, error)
+	Sync() error
+	Truncate(size int64) error
+}
+
 // headerStore combines a on-disk set of headers within a flat file in addition
 // to a database which indexes that flat file. Together, these two abstractions
 // can be used in order to build an indexed header store for any type of
@@ -96,7 +114,7 @@ type headerStore struct {
 
 	fileName string
 
-	file *os.File
+	file FileInterface
 
 	*headerIndex
 }


### PR DESCRIPTION
## Description

This PR improves error handling by failing gracefully when header writes fail. This helps prevent unexpected `EOF` errors during the process.