### PR TITLE
fix(query/worker): replace ineffective break with continue in job can…

### DIFF
--- a/query/worker.go
+++ b/query/worker.go
@@ -124,20 +124,16 @@ func (w *worker) Run(results chan<- *jobResult, quit <-chan struct{}) {
 			log.Tracef("Worker %v found job with index %v "+
 				"already canceled", peer.Addr(), job.Index())
 
-			// We break to the below loop, where we'll check the
-			// cancel channel again and the ErrJobCanceled
-			// result will be sent back.
-			break
+			// Use continue to skip sending a canceled job to the peer and proceed to the next iteration of the outer loop.
+			continue
 
 		case <-job.internalCancelChan:
 			log.Tracef("Worker %v found job with index %v "+
 				"already internally canceled (batch timed out)",
 				peer.Addr(), job.Index())
 
-			// We break to the below loop, where we'll check the
-			// internal cancel channel again and the ErrJobCanceled
-			// result will be sent back.
-			break
+			// Use continue to skip sending a canceled job to the peer and proceed to the next iteration of the outer loop.
+			continue
 
 		// We received a non-canceled query job, send it to the peer.
 		default:


### PR DESCRIPTION
…cel check


Replaced inefficient break statements with continue statements inside the first select block in the worker's Run function. Now, when a job is canceled (job.cancelChan or job.internalCancelChan), execution correctly moves to the next iteration of the outer loop, which prevents possible logical errors.