### PR TITLE
verification: fix log line

### DIFF
--- a/verification.go
+++ b/verification.go
@@ -145,7 +145,7 @@ func VerifyBasicBlockFilter(filter *gcs.Filter, block *btcutil.Block) (int,
 					"invalid, input %d of tx %v spends "+
 					"pk script %x which wasn't matched by "+
 					"filter. The input likely spends a "+
-					"taproot output which is not yet"+
+					"taproot output which is not yet "+
 					"supported", block.Hash(), inIdx,
 					tx.Hash(), script.Script())
 			}


### PR DESCRIPTION
There was a missing space between words:
"The input likely spends a taproot output which is not yetsupported"