### PR TITLE
neutrino: remove deprecated method `OnAlert`

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -1505,12 +1505,6 @@ func NewPeerConfig(sp *ServerPeer) *peer.Config {
 			OnAddrV2:    sp.OnAddrV2,
 			OnRead:      sp.OnRead,
 			OnWrite:     sp.OnWrite,
-
-			// Note: The reference client currently bans peers that send alerts
-			// not signed with its key.  We could verify against their key, but
-			// since the reference client is currently unwilling to support
-			// other implementations' alert messages, we will not relay theirs.
-			OnAlert: nil,
 		},
 		NewestBlock:      sp.newestBlock,
 		HostToNetAddress: sp.server.addrManager.HostToNetAddress,


### PR DESCRIPTION
This method is removed in this PR: https://github.com/btcsuite/btcd/pull/2396