### PR TITLE
blockmanager: reset header state after chainimport

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -282,6 +282,49 @@ func newBlockManager(cfg *blockManagerCfg) (*blockManager, error) {
 	return &bm, nil
 }
 
+// ResetHeaderState re-reads the chain tips from the header stores and
+// reinitializes the block manager's internal tracking state. This must be
+// called after headers have been imported into the stores outside of the
+// block manager (e.g., via chainimport) but before the block manager is
+// started, so that it begins syncing from the correct chain tip rather
+// than the stale state captured at construction time.
+func (b *blockManager) ResetHeaderState() error {
+	// Re-read the block header chain tip from the store.
+	header, height, err := b.cfg.BlockHeaders.ChainTip()
+	if err != nil {
+		return fmt.Errorf("failed to read block header chain "+
+			"tip: %w", err)
+	}
+	b.nextCheckpoint = b.findNextHeaderCheckpoint(int32(height))
+	b.headerList.ResetHeaderState(headerlist.Node{
+		Header: *header,
+		Height: int32(height),
+	})
+	b.headerTip = height
+	b.headerTipHash = header.BlockHash()
+
+	// Re-read the filter header chain tip from the store.
+	_, b.filterHeaderTip, err = b.cfg.RegFilterHeaders.ChainTip()
+	if err != nil {
+		return fmt.Errorf("failed to read filter header chain "+
+			"tip: %w", err)
+	}
+
+	// Ensure the filter header tip hash is set to the block hash at the
+	// filter tip height.
+	fh, err := b.cfg.BlockHeaders.FetchHeaderByHeight(b.filterHeaderTip)
+	if err != nil {
+		return fmt.Errorf("failed to fetch block header at filter "+
+			"tip height %d: %w", b.filterHeaderTip, err)
+	}
+	b.filterHeaderTipHash = fh.BlockHash()
+
+	log.Infof("Block manager header state reset: block tip=%d, "+
+		"filter tip=%d", height, b.filterHeaderTip)
+
+	return nil
+}
+
 // Start begins the core block handler which processes block and inv messages.
 func (b *blockManager) Start() {
 	// Already started?

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2989,6 +2989,12 @@ type lightHeaderCtx struct {
 
 	store      headerfs.BlockHeaderStore
 	headerList headerlist.Chain
+
+	// node, if non-nil, is the headerList node corresponding to this
+	// header. When set, RelativeAncestorCtx will use the node's skip-list
+	// pointer for O(log n) ancestor lookups instead of walking back from
+	// the chain tip on every call.
+	node *headerlist.Node
 }
 
 // newLightHeaderCtx returns an instance of a lightHeaderCtx to be used when
@@ -3053,26 +3059,27 @@ func (l *lightHeaderCtx) RelativeAncestorCtx(
 		err      error
 	)
 
-	// We'll first consult the headerList to see if the ancestor can be
-	// found there. If that fails, we'll look up the header in the header
-	// store.
-	iterNode := l.headerList.Back()
-
-	// Keep looping until iterNode is nil or the ancestor height is
-	// encountered.
-	for iterNode != nil {
-		if iterNode.Height == ancestorHeight {
-			// We've found the ancestor.
-			ancestor = &iterNode.Header
-			break
+	// We'll first attempt to resolve the ancestor through the headerList's
+	// skip-list. When we already know the current node, we can jump
+	// straight from it; otherwise we anchor on the chain tip and let
+	// Ancestor short-circuit if the target is in range.
+	var ancestorNode *headerlist.Node
+	if l.node != nil {
+		ancestorNode = l.node.Ancestor(ancestorHeight)
+	} else if l.headerList != nil {
+		backNode := l.headerList.Back()
+		if backNode != nil {
+			ancestorNode = backNode.Ancestor(ancestorHeight)
 		}
-
-		// We haven't hit the ancestor header yet, so we'll go back one.
-		iterNode = iterNode.Prev()
 	}
 
+	if ancestorNode != nil {
+		ancestor = &ancestorNode.Header
+	}
+
+	// If the ancestor has already aged out of the in-memory headerList,
+	// fall back to the on-disk header store.
 	if ancestor == nil {
-		// Lookup the ancestor in the header store.
 		ancestor, err = l.store.FetchHeaderByHeight(
 			uint32(ancestorHeight),
 		)
@@ -3081,7 +3088,13 @@ func (l *lightHeaderCtx) RelativeAncestorCtx(
 		}
 	}
 
-	return newLightHeaderCtx(
+	// Carry the resolved headerList node into the returned context so
+	// that any further ancestor walks from it can keep using the
+	// skip-list rather than walking from the tip again.
+	ancestorCtx := newLightHeaderCtx(
 		ancestorHeight, ancestor, l.store, l.headerList,
 	)
+	ancestorCtx.node = ancestorNode
+
+	return ancestorCtx
 }

--- a/blockmanager_lightheaderctx_test.go
+++ b/blockmanager_lightheaderctx_test.go
@@ -1,0 +1,145 @@
+package neutrino
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/neutrino/headerfs"
+	"github.com/lightninglabs/neutrino/headerlist"
+	"github.com/stretchr/testify/require"
+)
+
+// buildSkipListHeaderChain populates a BoundedMemoryChain with nHeaders
+// sequential, distinct headers and returns the chain. Headers are constructed
+// with monotonically increasing timestamps and difficulty bits so each node is
+// easily distinguishable when asserting on ancestor results.
+func buildSkipListHeaderChain(maxNodes,
+	nHeaders uint32) *headerlist.BoundedMemoryChain {
+
+	chain := headerlist.NewBoundedMemoryChain(maxNodes)
+	for i := uint32(0); i < nHeaders; i++ {
+		chain.PushBack(headerlist.Node{
+			Height: int32(i),
+			Header: wire.BlockHeader{
+				Version:   1,
+				Timestamp: time.Unix(int64(1_700_000_000+i), 0),
+				Bits:      0x1d00ffff + i,
+			},
+		})
+	}
+
+	return chain
+}
+
+// TestLightHeaderCtxRelativeAncestorSkipList ensures that
+// lightHeaderCtx.RelativeAncestorCtx satisfies ancestor lookups through the
+// in-memory headerList skip-list when the target is in range, and that the
+// returned context carries the resolved headerList node so further ancestor
+// walks can keep amortizing along the skip-list. The block header store is
+// configured to fail the test if it is consulted on this path.
+func TestLightHeaderCtxRelativeAncestorSkipList(t *testing.T) {
+	t.Parallel()
+
+	const nHeaders = 256
+	chain := buildSkipListHeaderChain(nHeaders, nHeaders)
+	tip := chain.Back()
+	require.NotNil(t, tip)
+	require.Equal(t, int32(nHeaders-1), tip.Height)
+
+	store := &headerfs.MockBlockHeaderStore{}
+
+	ctx := newLightHeaderCtx(tip.Height, &tip.Header, store, chain)
+
+	// Walking back one step at a time from the tip must reach height 0
+	// without ever touching the store, and every returned context must
+	// carry a non-nil headerList node so the skip-list inheritance from
+	// the original tip is preserved across the chain of Parent calls.
+	cur := ctx
+	for h := int32(nHeaders - 2); h >= 0; h-- {
+		expectedHeight := h
+		parent := cur.RelativeAncestorCtx(1)
+		require.NotNil(t, parent, "no parent at expected height %d",
+			expectedHeight)
+		require.Equal(t, expectedHeight, parent.Height())
+
+		lhc, ok := parent.(*lightHeaderCtx)
+		require.True(t, ok, "RelativeAncestorCtx returned a "+
+			"non-lightHeaderCtx value")
+		require.NotNil(t, lhc.node, "skip-list node not propagated "+
+			"into ancestor at height %d", expectedHeight)
+		require.Equal(t, expectedHeight, lhc.node.Height)
+
+		cur = lhc
+	}
+
+	// A single deep skip from the tip must also resolve through the
+	// skip-list and carry the resolved node.
+	deep := ctx.RelativeAncestorCtx(int32(nHeaders - 1))
+	require.NotNil(t, deep)
+	require.Equal(t, int32(0), deep.Height())
+
+	deepLhc, ok := deep.(*lightHeaderCtx)
+	require.True(t, ok)
+	require.NotNil(t, deepLhc.node)
+	require.Equal(t, int32(0), deepLhc.node.Height)
+
+	// At no point above did we need the store; FetchHeaderByHeight must
+	// not have been called.
+	store.AssertNotCalled(t, "FetchHeaderByHeight")
+}
+
+// TestLightHeaderCtxRelativeAncestorStoreFallback ensures that when the
+// requested ancestor has aged out of the bounded in-memory headerList,
+// lightHeaderCtx.RelativeAncestorCtx falls back to the block header store and
+// returns a context whose node is nil (since there is no in-memory node to
+// thread through). This locks in the documented degradation path: results
+// are still correct, but subsequent ancestor walks from that context will
+// re-anchor on the chain tip rather than skipping from the resolved node.
+func TestLightHeaderCtxRelativeAncestorStoreFallback(t *testing.T) {
+	t.Parallel()
+
+	// Build a chain that wraps: 256 headers pushed into a 32-slot
+	// BoundedMemoryChain. Only heights 224..255 remain reachable in
+	// memory; anything below 224 must come from the store.
+	const (
+		capacity = 32
+		nHeaders = 256
+	)
+	chain := buildSkipListHeaderChain(capacity, nHeaders)
+	tip := chain.Back()
+	require.NotNil(t, tip)
+	require.Equal(t, int32(nHeaders-1), tip.Height)
+
+	// The ancestor we'll ask for is height 100, which is far below the
+	// in-memory window. The store must be consulted to satisfy the
+	// request.
+	const targetHeight = uint32(100)
+	storedHeader := &wire.BlockHeader{
+		Version:   1,
+		Timestamp: time.Unix(int64(1_700_000_000+targetHeight), 0),
+		Bits:      0x1d00ffff + targetHeight,
+	}
+
+	store := &headerfs.MockBlockHeaderStore{}
+	store.On("FetchHeaderByHeight", targetHeight).Return(storedHeader, nil)
+
+	ctx := newLightHeaderCtx(tip.Height, &tip.Header, store, chain)
+
+	// Distance from the tip down to targetHeight pushes us through the
+	// store-fallback path. The resulting context describes the correct
+	// height and header, but its skip-list node must be nil because the
+	// header is not reachable in the bounded in-memory chain.
+	distance := tip.Height - int32(targetHeight)
+	ancestor := ctx.RelativeAncestorCtx(distance)
+	require.NotNil(t, ancestor)
+	require.Equal(t, int32(targetHeight), ancestor.Height())
+	require.Equal(t, storedHeader.Bits, ancestor.Bits())
+
+	lhc, ok := ancestor.(*lightHeaderCtx)
+	require.True(t, ok)
+	require.Nil(t, lhc.node, "expected nil skip-list node on store-"+
+		"fallback path")
+
+	store.AssertExpectations(t)
+}

--- a/chainimport/headers_import.go
+++ b/chainimport/headers_import.go
@@ -16,7 +16,7 @@ import (
 const (
 	// defaultWriteBatchSizePerRegion defines the default number of headers
 	// to process in a single batch when no specific batch size is provided.
-	defaultWriteBatchSizePerRegion = 16384
+	defaultWriteBatchSizePerRegion = 65536
 )
 
 // processingRegions contains regions to process. The divergence and new headers

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/lightningnetwork/lnd/queue v1.0.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20250811191247-51f88131bc50
+	pgregory.net/rapid v1.2.0
 )
 
 require (

--- a/headerfs/index.go
+++ b/headerfs/index.go
@@ -27,6 +27,12 @@ var (
 	// current block hash of the best known chain that the headers for
 	// regular filter are synced to.
 	regFilterTip = []byte("regular")
+
+	// indexSubBucketsReady is the marker key stored in the header index
+	// root bucket once all hash-prefix sub-buckets have been
+	// pre-created. Its presence lets newHeaderIndex skip the bulk
+	// sub-bucket creation step on subsequent process starts.
+	indexSubBucketsReady = []byte("index-sub-buckets-ready")
 )
 
 var (
@@ -137,10 +143,16 @@ func newHeaderIndex(db walletdb.DB, indexType HeaderType) (*headerIndex, error) 
 	// necessary for functioning of the index. If these buckets has already
 	// been created, then we can exit early.
 	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
-		_, err := tx.CreateTopLevelBucket(indexBucket)
-		return err
+		rootBucket, err := tx.CreateTopLevelBucket(indexBucket)
+		if err == walletdb.ErrBucketExists {
+			rootBucket = tx.ReadWriteBucket(indexBucket)
+		} else if err != nil {
+			return err
+		}
+
+		return ensureIndexSubBuckets(rootBucket)
 	})
-	if err != nil && err != walletdb.ErrBucketExists {
+	if err != nil {
 		return nil, err
 	}
 
@@ -148,6 +160,30 @@ func newHeaderIndex(db walletdb.DB, indexType HeaderType) (*headerIndex, error) 
 		db:        db,
 		indexType: indexType,
 	}, nil
+}
+
+// ensureIndexSubBuckets pre-creates the full set of hash-prefix sub-buckets
+// used by the header index. The index sharding scheme stores each header
+// under a sub-bucket keyed by the first numSubBucketBytes of its hash, so
+// creating all 2^(8*numSubBucketBytes) buckets up-front lets the hot
+// addHeaders path do a cheap lookup instead of a CreateBucketIfNotExists call
+// per header. The marker key indexSubBucketsReady gates re-running this loop
+// on subsequent startups.
+func ensureIndexSubBuckets(rootBucket walletdb.ReadWriteBucket) error {
+	if rootBucket.Get(indexSubBucketsReady) != nil {
+		return nil
+	}
+
+	var prefix [numSubBucketBytes]byte
+	for i := 0; i <= 0xffff; i++ {
+		binary.BigEndian.PutUint16(prefix[:], uint16(i))
+		_, err := rootBucket.CreateBucketIfNotExists(prefix[:])
+		if err != nil {
+			return err
+		}
+	}
+
+	return rootBucket.Put(indexSubBucketsReady, []byte{1})
 }
 
 // headerEntry is an internal type that's used to quickly map a (height, hash)
@@ -217,8 +253,37 @@ func (h *headerIndex) addHeaders(batch headerBatch) error {
 			chainTipHeight uint32
 		)
 
+		// Since the batch is sorted by hash, consecutive entries tend
+		// to share the same sub-bucket prefix. We cache the last
+		// resolved sub-bucket and prefix so that we only re-resolve
+		// when the prefix changes, avoiding a NestedReadWriteBucket
+		// call per header. The required sub-buckets are pre-created in
+		// newHeaderIndex via ensureIndexSubBuckets, so a missing
+		// sub-bucket here is a hard error.
+		var (
+			subBucket        walletdb.ReadWriteBucket
+			currentSubPrefix []byte
+		)
+
 		for _, header := range batch {
-			if err := putHeaderEntry(rootBucket, header); err != nil {
+			prefix := header.hash[0:numSubBucketBytes]
+			if !bytes.Equal(currentSubPrefix, prefix) {
+				subBucket = rootBucket.NestedReadWriteBucket(
+					prefix,
+				)
+				if subBucket == nil {
+					return fmt.Errorf("missing header "+
+						"index sub-bucket %x", prefix)
+				}
+
+				currentSubPrefix = append(
+					currentSubPrefix[:0], prefix...,
+				)
+			}
+
+			if err := putHeaderEntryInBucket(
+				subBucket, header,
+			); err != nil {
 				return err
 			}
 
@@ -384,6 +449,15 @@ func putHeaderEntry(rootBucket walletdb.ReadWriteBucket,
 	if err != nil {
 		return err
 	}
+
+	return putHeaderEntryInBucket(subBucket, header)
+}
+
+// putHeaderEntryInBucket writes a single header entry into an already
+// resolved sub-bucket. It is the inner half of putHeaderEntry and lets hot
+// callers (like addHeaders) reuse a cached sub-bucket across many entries.
+func putHeaderEntryInBucket(subBucket walletdb.ReadWriteBucket,
+	header headerEntry) error {
 
 	var heightBytes [4]byte
 	binary.BigEndian.PutUint32(heightBytes[:], header.height)

--- a/headerlist/bounded_header_list.go
+++ b/headerlist/bounded_header_list.go
@@ -95,6 +95,15 @@ func (b *BoundedMemoryChain) PushBack(n Node) *Node {
 		prevElem = &b.chain[b.tailPtr]
 	}
 
+	// With a maxSize of one, the only slot in the backing array is the
+	// same slot we're about to overwrite. Leaving prevElem pointing at it
+	// would make the new node's prev pointer reference itself, creating a
+	// cycle that any backwards traversal (Prev, Ancestor) would follow
+	// indefinitely. Force prev to nil in that case.
+	if b.maxSize == 1 {
+		prevElem = nil
+	}
+
 	// As we're adding to the chain, we'll increment the tail pointer and
 	// clamp it down to the max size.
 	b.tailPtr++
@@ -123,8 +132,11 @@ func (b *BoundedMemoryChain) PushBack(n Node) *Node {
 
 	// Now that we've inserted this new element, we'll set the prev pointer
 	// to the prior element. If this is the first element, then we'll just
-	// set the nil value again.
+	// set the nil value again. We also reset any stale skip-list ancestor
+	// from a wrapped-over slot before rebuilding it from prev.
 	b.chain[chainIndex].prev = prevElem
+	b.chain[chainIndex].ancestor = nil
+	b.chain[chainIndex].buildAncestor()
 
 	// Finally, we'll increment the length of the chain, and clamp down the
 	// size if needed to the max possible length.

--- a/headerlist/bounded_header_list_test.go
+++ b/headerlist/bounded_header_list_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"pgregory.net/rapid"
 )
 
 // TestBoundedMemoryChainEmptyList tests the expected functionality of an empty
@@ -179,6 +180,213 @@ func TestBoundedMemoryChainPrevIteration(t *testing.T) {
 			t.Fatalf("expected %v, got %v",
 				spew.Sdump(nextNode.Prev()),
 				spew.Sdump(iterNode))
+		}
+	}
+}
+
+// TestBoundedMemoryChainAncestor ensures that skip-list ancestor lookups return
+// the expected nodes, including after the bounded chain wraps.
+func TestBoundedMemoryChainAncestor(t *testing.T) {
+	t.Parallel()
+
+	memChain := NewBoundedMemoryChain(100)
+	for i := 0; i < 100; i++ {
+		memChain.PushBack(Node{
+			Height: int32(i),
+		})
+	}
+
+	tip := memChain.Back()
+	for i := 0; i < 100; i++ {
+		ancestor := tip.Ancestor(int32(i))
+		if ancestor == nil {
+			t.Fatalf("expected ancestor at height %v", i)
+		}
+		if ancestor.Height != int32(i) {
+			t.Fatalf("expected ancestor height %v, got %v",
+				i, ancestor.Height)
+		}
+	}
+
+	wrappedChain := NewBoundedMemoryChain(5)
+	for i := 0; i < 20; i++ {
+		wrappedChain.PushBack(Node{
+			Height: int32(i),
+		})
+	}
+
+	tip = wrappedChain.Back()
+	for i := 15; i < 20; i++ {
+		ancestor := tip.Ancestor(int32(i))
+		if ancestor == nil {
+			t.Fatalf("expected ancestor at height %v", i)
+		}
+		if ancestor.Height != int32(i) {
+			t.Fatalf("expected ancestor height %v, got %v",
+				i, ancestor.Height)
+		}
+	}
+
+	if ancestor := tip.Ancestor(14); ancestor != nil {
+		t.Fatalf("unexpected pruned ancestor: %v", ancestor.Height)
+	}
+}
+
+// TestBoundedMemoryChainAncestorRapid uses property-based testing to confirm
+// that skip-list ancestor lookups agree with a naive linear walk across many
+// random chain shapes, including wrap-around configurations.
+func TestBoundedMemoryChainAncestorRapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		capacity := rapid.IntRange(1, 512).Draw(t, "capacity")
+		startHeight := rapid.IntRange(0, 100000).Draw(t, "start_height")
+		appendCount := rapid.IntRange(1, 2048).Draw(t, "append_count")
+
+		memChain := NewBoundedMemoryChain(uint32(capacity))
+		for i := 0; i < appendCount; i++ {
+			memChain.PushBack(Node{
+				Height: int32(startHeight + i),
+			})
+		}
+
+		assertAncestorsMatchLinearWalk(t, memChain)
+	})
+}
+
+// TestBoundedMemoryChainAncestorResetRapid is a property-based test that
+// covers the post-reset path: after ResetHeaderState the chain seeds a new
+// genesis at an arbitrary height, and subsequent PushBacks must still produce
+// ancestor pointers that agree with a linear prev walk.
+func TestBoundedMemoryChainAncestorResetRapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		capacity := rapid.IntRange(1, 512).Draw(t, "capacity")
+		beforeReset := rapid.IntRange(1, 2048).Draw(t, "before_reset")
+		resetHeight := rapid.IntRange(0, 100000).Draw(t, "reset_height")
+		afterReset := rapid.IntRange(0, 2048).Draw(t, "after_reset")
+
+		memChain := NewBoundedMemoryChain(uint32(capacity))
+		for i := 0; i < beforeReset; i++ {
+			memChain.PushBack(Node{
+				Height: int32(i),
+			})
+		}
+
+		memChain.ResetHeaderState(Node{
+			Height: int32(resetHeight),
+		})
+		for i := 1; i <= afterReset; i++ {
+			memChain.PushBack(Node{
+				Height: int32(resetHeight + i),
+			})
+		}
+
+		assertAncestorsMatchLinearWalk(t, memChain)
+	})
+}
+
+// assertAncestorsMatchLinearWalk fails the test if Node.Ancestor disagrees
+// with a linear walk along prev pointers for any target height in or near the
+// current chain bounds.
+func assertAncestorsMatchLinearWalk(t rapid.TB, chain *BoundedMemoryChain) {
+	t.Helper()
+
+	tip := chain.Back()
+	if tip == nil {
+		return
+	}
+
+	front := chain.Front()
+	minHeight := front.Height - 2
+	maxHeight := tip.Height + 2
+	for h := minHeight; h <= maxHeight; h++ {
+		targetHeight := h
+		expected := linearAncestor(tip, targetHeight)
+		actual := tip.Ancestor(targetHeight)
+
+		if expected == nil {
+			if actual != nil {
+				t.Fatalf("expected no ancestor at height %v, "+
+					"got %v", targetHeight, actual.Height)
+			}
+
+			continue
+		}
+
+		if actual == nil {
+			t.Fatalf("expected ancestor at height %v", targetHeight)
+		}
+		if actual.Height != expected.Height {
+			t.Fatalf("expected ancestor height %v, got %v",
+				expected.Height, actual.Height)
+		}
+	}
+}
+
+// linearAncestor returns the ancestor at the given height by walking prev
+// pointers from tip one node at a time. It serves as the reference oracle
+// against which the skip-list implementation is compared.
+func linearAncestor(tip *Node, height int32) *Node {
+	for tip != nil && tip.Height != height {
+		tip = tip.Prev()
+	}
+
+	return tip
+}
+
+// BenchmarkBoundedMemoryChainAncestor measures skip-list ancestor lookup cost
+// over a fixed spread of target heights, including small, mid-range, and tip
+// targets that exercise different skip patterns.
+func BenchmarkBoundedMemoryChainAncestor(b *testing.B) {
+	memChain := NewBoundedMemoryChain(10000)
+	for i := 0; i < 10000; i++ {
+		memChain.PushBack(Node{
+			Height: int32(i),
+		})
+	}
+
+	tip := memChain.Back()
+	targets := []int32{0, 1, 17, 499, 999, 2016, 4096, 8191, 9999}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, target := range targets {
+			ancestor := tip.Ancestor(target)
+			if ancestor == nil || ancestor.Height != target {
+				b.Fatalf("unexpected ancestor at "+
+					"height %v", target)
+			}
+		}
+	}
+}
+
+// BenchmarkBoundedMemoryChainPrevWalk is the baseline counterpart to
+// BenchmarkBoundedMemoryChainAncestor: it answers the same lookups using only
+// the prev pointer so the two can be compared head-to-head.
+func BenchmarkBoundedMemoryChainPrevWalk(b *testing.B) {
+	memChain := NewBoundedMemoryChain(10000)
+	for i := 0; i < 10000; i++ {
+		memChain.PushBack(Node{
+			Height: int32(i),
+		})
+	}
+
+	tip := memChain.Back()
+	targets := []int32{0, 1, 17, 499, 999, 2016, 4096, 8191, 9999}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, target := range targets {
+			iter := tip
+			for iter != nil && iter.Height != target {
+				iter = iter.Prev()
+			}
+			if iter == nil || iter.Height != target {
+				b.Fatalf("unexpected ancestor at "+
+					"height %v", target)
+			}
 		}
 	}
 }

--- a/headerlist/header_list.go
+++ b/headerlist/header_list.go
@@ -35,7 +35,14 @@ type Node struct {
 	// Header is the header that this node represents.
 	Header wire.BlockHeader
 
+	// prev is the node immediately before this one within the chain. The
+	// genesis or "head" node has a nil prev pointer.
 	prev *Node
+
+	// ancestor is a skip-list pointer that may jump several heights back
+	// in a single step, enabling O(log n) ancestor lookups. Skipping is
+	// optional: callers may always fall back to walking prev.
+	ancestor *Node
 }
 
 // Prev attempts to access the prior node within the header chain relative to
@@ -43,4 +50,71 @@ type Node struct {
 // nil.
 func (n *Node) Prev() *Node {
 	return n.prev
+}
+
+// invertLowestOne clears the lowest set bit in the binary representation of n.
+// It is a small helper used to derive skip-list ancestor heights.
+func invertLowestOne(n int32) int32 {
+	return n & (n - 1)
+}
+
+// getAncestorHeight returns the skip-list ancestor height for a node at the
+// given height. The result is chosen so that following ancestor pointers
+// produces an O(log n) traversal, in the spirit of Bitcoin Core's CBlockIndex
+// skip-list. Heights at or below zero have no meaningful ancestor and are
+// clamped to zero.
+func getAncestorHeight(height int32) int32 {
+	if height <= 0 {
+		return 0
+	}
+
+	return invertLowestOne(invertLowestOne(height))
+}
+
+// buildAncestor populates the skip-list ancestor pointer for this node by
+// hopping back through the prior node's own skip-list. This must be called
+// once, immediately after the prev pointer is set, so the skip-list stays
+// consistent with the chain.
+func (n *Node) buildAncestor() {
+	if n.prev == nil {
+		return
+	}
+
+	n.ancestor = n.prev.Ancestor(getAncestorHeight(n.Height))
+}
+
+// Ancestor returns the ancestor node at the target height. It uses the
+// skip-list pointer to jump multiple heights when that pointer still lands at
+// or above the target, and falls back to walking the prev pointer one node at
+// a time when the skip would overshoot. The skip pointer is treated as an
+// optimization: callers always get the same result they would have obtained by
+// repeatedly calling Prev, just in fewer steps.
+//
+// If height is greater than n.Height, or the requested height is no longer in
+// the chain (e.g. it was pruned out of a BoundedMemoryChain), nil is returned.
+func (n *Node) Ancestor(height int32) *Node {
+	if n == nil || height > n.Height {
+		return nil
+	}
+
+	for n != nil && n.Height != height {
+		// Take the skip-list shortcut only when it still lands at or
+		// above the target and actually makes progress (the ancestor
+		// height must be strictly less than the current height). The
+		// height-vs-target check on the ancestor itself guards against
+		// stale skip pointers in a wrapped BoundedMemoryChain where the
+		// pointed-to slot may have been overwritten.
+		ancestorHeight := getAncestorHeight(n.Height)
+		if n.ancestor != nil && ancestorHeight >= height &&
+			n.ancestor.Height >= height &&
+			n.ancestor.Height < n.Height {
+
+			n = n.ancestor
+			continue
+		}
+
+		n = n.prev
+	}
+
+	return n
 }

--- a/neutrino.go
+++ b/neutrino.go
@@ -1680,6 +1680,17 @@ func (s *ChainService) Start(ctx context.Context) error {
 		if _, err := importer.Import(ctx); err != nil {
 			return err
 		}
+
+		// The block manager was constructed before the import ran,
+		// so its internal header tracking state (headerList,
+		// headerTip, filterHeaderTip, etc.) reflects the
+		// pre-import chain tips. Re-read the now-updated stores
+		// so the block manager starts syncing from the correct
+		// height rather than from genesis.
+		if err := s.blockManager.ResetHeaderState(); err != nil {
+			return fmt.Errorf("failed to reset block manager "+
+				"state after headers import: %w", err)
+		}
 	}
 
 	// Start the address manager and block manager, both of which are

--- a/sync_test.go
+++ b/sync_test.go
@@ -1249,6 +1249,139 @@ func TestNeutrinoSyncWithHeadersImport(t *testing.T) {
 	testInitialSync(testHarness, t)
 }
 
+// TestNeutrinoImportThenP2PSync verifies that a single ChainService that
+// imports headers from files can also continue syncing new blocks via P2P
+// in the same session. This exercises the ResetHeaderState path: the block
+// manager is constructed (with an empty store) before Start() runs the
+// import, so its internal tracking state must be refreshed after import to
+// build correct P2P locators for the remaining chain.
+func TestNeutrinoImportThenP2PSync(t *testing.T) {
+	rootCtx := context.Background()
+
+	// Create a btcd SimNet node and generate an initial chain.
+	h1, err := rpctest.New(
+		&chaincfg.SimNetParams, nil, []string{"--txindex"}, "",
+	)
+	require.NoError(t, err)
+	defer h1.TearDown()
+
+	err = h1.SetUp(false, 0)
+	require.NoError(t, err)
+
+	const initialBlocks = 800
+	_, err = h1.Client.Generate(initialBlocks)
+	require.NoError(t, err)
+
+	// Sync an export service to obtain header files.
+	exportDir := t.TempDir()
+	defer os.RemoveAll(exportDir)
+
+	exportDB, err := walletdb.Create(
+		"bdb", exportDir+"/filters.db", true, dbOpenTimeout,
+	)
+	require.NoError(t, err)
+
+	neutrino.MaxPeers = 1
+	neutrino.BanDuration = 5 * time.Second
+	neutrino.QueryPeerConnectTimeout = 10 * time.Second
+
+	exportSvc, err := neutrino.NewChainService(neutrino.Config{
+		DataDir:     exportDir,
+		Database:    exportDB,
+		ChainParams: chaincfg.SimNetParams,
+		AddPeers:    []string{h1.P2PAddress()},
+	})
+	require.NoError(t, err)
+	exportSvc.Start(rootCtx)
+
+	err = waitForSync(t, exportSvc, h1)
+	require.NoError(t, err, "export service failed to sync")
+
+	// Copy the header files and add import metadata.
+	importDir := t.TempDir()
+	defer os.RemoveAll(importDir)
+
+	blockSrc := filepath.Join(exportDir, "block_headers.bin")
+	filterSrc := filepath.Join(exportDir, "reg_filter_headers.bin")
+	blockDst := filepath.Join(importDir, "block_headers.bin")
+	filterDst := filepath.Join(importDir, "reg_filter_headers.bin")
+
+	err = copyFile(blockSrc, blockDst)
+	require.NoError(t, err)
+	err = copyFile(filterSrc, filterDst)
+	require.NoError(t, err)
+
+	err = chainimport.AddHeadersImportMetadata(
+		blockDst, chaincfg.SimNetParams.Net, 0,
+		headerfs.Block, 0,
+	)
+	require.NoError(t, err)
+	err = chainimport.AddHeadersImportMetadata(
+		filterDst, chaincfg.SimNetParams.Net, 0,
+		headerfs.RegularFilter, 0,
+	)
+	require.NoError(t, err)
+
+	exportSvc.Stop()
+	require.NoError(t, exportDB.Close())
+
+	// Mine additional blocks AFTER the export, so the import files only
+	// cover [0, initialBlocks]. The service must fetch the rest via P2P.
+	const extraBlocks = 50
+	_, err = h1.Client.Generate(extraBlocks)
+	require.NoError(t, err)
+
+	// Create a fresh service with BOTH headers import AND a peer
+	// connection. This is the critical setup: the block manager is
+	// constructed in NewChainService (reading the empty store), then
+	// Start() runs the import (populating the store), then the block
+	// manager begins P2P sync. Without ResetHeaderState, the block
+	// manager would use a genesis locator and fail to fetch the
+	// remaining blocks.
+	svcDir := t.TempDir()
+	defer os.RemoveAll(svcDir)
+
+	svcDB, err := walletdb.Create(
+		"bdb", svcDir+"/filters.db", true, dbOpenTimeout,
+	)
+	require.NoError(t, err)
+	defer svcDB.Close()
+
+	svc, err := neutrino.NewChainService(neutrino.Config{
+		DataDir:     svcDir,
+		Database:    svcDB,
+		ChainParams: chaincfg.SimNetParams,
+		AddPeers:    []string{h1.P2PAddress()},
+		HeadersImport: &neutrino.HeadersImportConfig{
+			BlockHeadersSource:      blockDst,
+			FilterHeadersSource:     filterDst,
+			ValidationFlags:         blockchain.BFFastAdd,
+			WriteBatchSizePerRegion: 64,
+		},
+	})
+	require.NoError(t, err)
+
+	svc.Start(rootCtx)
+	defer svc.Stop()
+
+	// The service should sync all the way to initialBlocks + extraBlocks
+	// by importing the first batch from file and fetching the rest via
+	// P2P.
+	err = waitForSync(t, svc, h1)
+	require.NoError(t, err, "service failed to sync after import + P2P")
+
+	// Verify the service reached the expected height.
+	best, err := svc.BestBlock()
+	require.NoError(t, err)
+
+	_, expectedHeight, err := h1.Client.GetBestBlock()
+	require.NoError(t, err)
+	require.Equal(
+		t, expectedHeight, best.Height,
+		"service height should match btcd tip",
+	)
+}
+
 // TestNeutrinoSyncWithoutHeadersImport tests the standard synchronization
 // behavior of Neutrino without using the headers import feature.
 func TestNeutrinoSyncWithoutHeadersImport(t *testing.T) {

--- a/sync_test.go
+++ b/sync_test.go
@@ -1568,6 +1568,7 @@ func BenchmarkHeadersImport(b *testing.B) {
 				BlockHeadersSource:      blockHeadersPath,
 				FilterHeadersSource:     filterHeadersPath,
 				WriteBatchSizePerRegion: batch,
+				ValidationFlags:         blockchain.BFFastAdd,
 			}
 
 			// Get initial CPU time for measuring CPU usage during


### PR DESCRIPTION
When headers are imported via `chainimport` in `ChainService.Start()`, the block manager's internal state (`headerList`, `headerTip`, `headerTipHash`, `filterHeaderTip`, `filterHeaderTipHash`) still reflects the pre-import chain tips from when it was constructed in `NewChainService()`. Since the block manager is created before `Start()` runs the import, its in-memory tracking state becomes stale once the import writes headers to the stores. This causes the block manager to build P2P getheaders locators using the genesis hash, preventing it from fetching any remaining blocks via P2P after import completes.

This was discovered while wiring the `chainimport` feature into lnd's integration tests. A fresh neutrino node configured with both `HeadersImport` and peer connections would successfully import headers from file but then fail to sync any additional blocks mined after the import snapshot. The neutrino logs showed `getheaders` requests with a genesis locator and `cfheaders` fetch failures, confirming the block manager was unaware of the imported headers.

The fix adds `ResetHeaderState()` to the block manager, which re-reads the block and filter header chain tips from the stores and reinitializes all internal tracking fields (`headerList`, `headerTip`, `headerTipHash`, `nextCheckpoint`, `filterHeaderTip`, `filterHeaderTipHash`). This method is called in `Start()` immediately after a successful import, before the block manager begins its P2P sync loop.

A new test `TestNeutrinoImportThenP2PSync` exercises this exact scenario: a single `ChainService` with both `HeadersImport` and `AddPeers` configured imports 800 blocks from file, then must sync 50 additional blocks via P2P. Without the fix, the test times out waiting for sync; with the fix, the service correctly builds locators from the imported tip and catches up via P2P.

Depends on the `headerlist.ResetHeaderState()` method added in the chainimport PRs (#317, #320, #324).

---

## Follow-on import performance work

While testing the reset-state fix end-to-end against an lnd local-replace build on mainnet and testnet3, profiling surfaced two hotspots that dominated the import-plus-catch-up wall time well after the locator bug was fixed:

1. The bbolt-backed header-index spent most of its write time creating and re-resolving per-hash sub-buckets, one `CreateBucketIfNotExists` call per imported header.
2. Once the import completed, `lightHeaderCtx.RelativeAncestorCtx` ran a linear walk back from the chain tip for every header validated. On testnet that meant a 2016-step scan per block in every difficulty-adjustment window, and the profile pinned `findPrevTestNetDifficulty` and `checkHeaderSanity` at roughly 10s of cumulative CPU each.

The five commits stacked on top of the original fix address both:

- **`chainimport: bump default header import batch size to 65536`** — 4× the import write batch size.
- **`headerfs: pre-create header index sub-buckets`** — eagerly create all 65 536 two-byte hash-prefix sub-buckets once per database (gated by a new `index-sub-buckets-ready` marker key), then specialize the hot `addHeaders` loop to cache the resolved sub-bucket across consecutive sorted entries.
- **`headerlist: add skip-list ancestor lookups to Node`** — add a single skip pointer to `headerlist.Node` and a matching `Ancestor(height int32)` method in the style of Bitcoin Core's `CBlockIndex`, with the wrap-around-safe staleness checks needed for `BoundedMemoryChain`. Covered by deterministic plus `rapid` property tests and head-to-head skip-vs-prev benchmarks. Also fixes a latent `maxSize == 1` self-cycle in `PushBack` that the property test exposed.
- **`blockmanager: use skip-list ancestor in lightHeaderCtx`** — rewrite `RelativeAncestorCtx` to traverse the new skip-list, threading the resolved `headerlist.Node` into the returned context so subsequent ancestor walks keep amortizing along the skip-list instead of restarting from the tip.
- **`blockmanager: test lightHeaderCtx skip-list and store-fallback paths`** — unit tests that lock down the skip-list path (in-memory only, store never touched, node propagated) and the documented store-fallback path (store consulted, node `nil`).
- **`sync_test: align headers-import benchmark to fast-add validation`** — pass `blockchain.BFFastAdd` in the headers-import benchmark so the measured path matches the block-dn flow chainimport actually runs.

### Measured impact

**Header-import write path** — `BenchmarkHeadersImport` on the bundled 100k mainnet fixture, with `BFFastAdd` validation:

| Batch size | Baseline (no eager buckets) | Eager sub-buckets |
| ---: | ---: | ---: |
| 16 384 | 195 940 hdrs/s | 193 031 hdrs/s |
| 32 768 | 220 237 hdrs/s | 235 562 hdrs/s |
| **65 536** | 213 697 hdrs/s | **260 131 hdrs/s** |
| 131 072 | 203 261 hdrs/s | 279 914 hdrs/s |

Eager sub-bucket pre-creation is what unlocks the larger batch: at 16 384 it is roughly neutral, but at 65 536 it lifts throughput by ~22% over the same batch without the change. 65 536 captures most of the win at roughly half the working set of 131 072.

**Skip-list ancestor lookup** — focused micro-benchmark over a 10 000-node `BoundedMemoryChain` with a spread of target heights:

| Path | ns/op | allocs/op |
| --- | ---: | ---: |
| `Node.Ancestor` (skip-list) | ~1 200 | 0 |
| `Node.Prev()` linear walk | ~96 000 | 0 |

About 80× faster with zero allocations on either path.

**End-to-end CPU profile (lnd, testnet3 → block-dn 4 700 000 source, skip-list + 65 536 batch + eager sub-buckets)**:

| Function | Pre-skip cum CPU | Post-skip cum CPU |
| --- | ---: | ---: |
| `lightHeaderCtx.RelativeAncestorCtx` | 10.52 s | 0.08 s |
| `findPrevTestNetDifficulty` | ~10.47 s | 0.09 s |
| `blockManager.checkHeaderSanity` | ~10.73 s | 0.09 s |

The remaining CPU is back in the bbolt write path inside `headerfs.(*blockHeaderStore).WriteHeaders`.

**End-to-end lnd time-to-synced** (HTTP source `block-dn.org`, local-file source after caching):

| Scenario | Before* | After |
| --- | ---: | ---: |
| Mainnet, 900k headers (HTTP) | 54 s | 41 s |
| Mainnet, 900k headers (local file) | n/a | 17 s |
| Testnet3, 4.7M headers (HTTP) | 5 m 17 s | 3 m 11 s |
| Testnet3, 4.7M headers (local file) | n/a | 2 m 39 s |

*"Before" is the same branch with the original 16 384 batch size and no skip-list. Local-file numbers remove HTTP variance and isolate the write/validation path.

### Verification

- `go test ./headerlist ./headerfs ./chainimport`
- `go test . -run '^TestNeutrinoImportThenP2PSync$' -count=1`
- `go test . -run '^TestLightHeaderCtxRelativeAncestor' -count=1`
- `go test ./...`
- `golangci-lint run --new-from-rev=master --timeout=10m ./...` (clean against the pinned `v1.64.6` from `tools/go.mod`)
- lnd sanity with local neutrino replace: `go test . ./lncfg` and `go test -tags=integration ./itest -run '^$'`
