### PR TITLE
blockmanager: recover from WriteHeaders failure to prevent permanent sync stall

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2694,6 +2694,26 @@ func (b *blockManager) handleHeadersMsg(hmsg *headersMsg) {
 		err := b.cfg.BlockHeaders.WriteHeaders(headerWriteBatch...)
 		if err != nil {
 			log.Errorf("Unable to write block headers: %v", err)
+
+			// Roll back the in-memory header list to match the
+			// on-disk state, since headers were already appended
+			// to headerList before the write attempt.
+			header, height, err := b.cfg.BlockHeaders.ChainTip()
+			if err != nil {
+				log.Errorf("Unable to fetch chain tip for "+
+					"header list rollback: %v", err)
+			} else {
+				b.headerList.ResetHeaderState(headerlist.Node{
+					Header: *header,
+					Height: int32(height),
+				})
+			}
+
+			// Disconnect the sync peer to trigger the recovery
+			// path in handleDonePeerMsg, which will reset state
+			// and start a new sync.
+			hmsg.peer.Disconnect()
+
 			return
 		}
 	}

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2734,6 +2734,9 @@ func (b *blockManager) handleHeadersMsg(hmsg *headersMsg) {
 		if err != nil {
 			log.Warnf("Failed to send getheaders message to "+
 				"peer %s: %s", hmsg.peer.Addr(), err)
+
+			hmsg.peer.Disconnect()
+
 			return
 		}
 	}

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2628,9 +2628,29 @@ func (b *blockManager) handleHeadersMsg(hmsg *headersMsg) {
 			}
 			err = b.cfg.BlockHeaders.WriteHeaders(hdrs)
 			if err != nil {
-				log.Criticalf("Couldn't write block to "+
-					"database: %s", err)
-				// Should we panic here?
+				log.Errorf("Couldn't write reorg block "+
+					"header to database: %s", err)
+
+				// Reset in-memory state to match the
+				// on-disk chain tip after the rollback.
+				header, height, err :=
+					b.cfg.BlockHeaders.ChainTip()
+				if err != nil {
+					log.Errorf("Unable to fetch chain "+
+						"tip for header list "+
+						"rollback: %v", err)
+				} else {
+					b.headerList.ResetHeaderState(
+						headerlist.Node{
+							Header: *header,
+							Height: int32(height),
+						},
+					)
+				}
+
+				hmsg.peer.Disconnect()
+
+				return
 			}
 
 			b.headerList.ResetHeaderState(headerlist.Node{

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2157,7 +2157,15 @@ func (b *blockManager) startSync(peers *list.List) {
 
 		// With our stop hash selected, we'll kick off the sync from
 		// this peer with an initial GetHeaders message.
-		_ = b.SyncPeer().PushGetHeadersMsg(locator, stopHash)
+		err = b.SyncPeer().PushGetHeadersMsg(locator, stopHash)
+		if err != nil {
+			log.Warnf("Failed to send initial getheaders to "+
+				"peer %s: %v", bestPeer.Addr(), err)
+
+			b.syncPeerMutex.Lock()
+			b.syncPeer = nil
+			b.syncPeerMutex.Unlock()
+		}
 	} else {
 		log.Warnf("No sync peer candidates available")
 	}

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1973,6 +1973,13 @@ func (b *blockManager) blockHandler() {
 	defer b.wg.Done()
 
 	candidatePeers := list.New()
+
+	// stallTicker periodically retries header sync when we have no sync
+	// peer. This prevents the node from getting stuck when a sync peer
+	// disconnects and no new peers connect immediately.
+	stallTicker := time.NewTicker(retryTimeout)
+	defer stallTicker.Stop()
+
 out:
 	for {
 		// Now check peer messages and quit channels.
@@ -1994,6 +2001,11 @@ out:
 			default:
 				log.Warnf("Invalid message type in block "+
 					"handler: %T", msg)
+			}
+
+		case <-stallTicker.C:
+			if !b.BlockHeadersSynced() && b.SyncPeer() == nil {
+				b.startSync(candidatePeers)
 			}
 
 		case <-b.quit:

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -439,16 +439,7 @@ func (b *blockManager) handleDonePeerMsg(peers *list.List, sp *ServerPeer) {
 		b.syncPeerMutex.Lock()
 		b.syncPeer = nil
 		b.syncPeerMutex.Unlock()
-		header, height, err := b.cfg.BlockHeaders.ChainTip()
-		if err != nil {
-			log.Errorf("Unable to fetch chain tip for header "+
-				"list reset: %v", err)
-			return
-		}
-		b.headerList.ResetHeaderState(headerlist.Node{
-			Header: *header,
-			Height: int32(height),
-		})
+		b.resetHeaderListFromDisk()
 		b.startSync(peers)
 	}
 }
@@ -2635,20 +2626,7 @@ func (b *blockManager) handleHeadersMsg(hmsg *headersMsg) {
 
 				// Reset in-memory state to match the
 				// on-disk chain tip after the rollback.
-				header, height, err :=
-					b.cfg.BlockHeaders.ChainTip()
-				if err != nil {
-					log.Errorf("Unable to fetch chain "+
-						"tip for header list "+
-						"rollback: %v", err)
-				} else {
-					b.headerList.ResetHeaderState(
-						headerlist.Node{
-							Header: *header,
-							Height: int32(height),
-						},
-					)
-				}
+				b.resetHeaderListFromDisk()
 
 				hmsg.peer.Disconnect()
 
@@ -2720,16 +2698,7 @@ func (b *blockManager) handleHeadersMsg(hmsg *headersMsg) {
 			// Roll back the in-memory header list to match the
 			// on-disk state, since headers were already appended
 			// to headerList before the write attempt.
-			header, height, err := b.cfg.BlockHeaders.ChainTip()
-			if err != nil {
-				log.Errorf("Unable to fetch chain tip for "+
-					"header list rollback: %v", err)
-			} else {
-				b.headerList.ResetHeaderState(headerlist.Node{
-					Header: *header,
-					Height: int32(height),
-				})
-			}
+			b.resetHeaderListFromDisk()
 
 			// Disconnect the sync peer to trigger the recovery
 			// path in handleDonePeerMsg, which will reset state
@@ -2769,6 +2738,23 @@ func (b *blockManager) handleHeadersMsg(hmsg *headersMsg) {
 	b.headerTipHash = *finalHash
 	b.newHeadersMtx.Unlock()
 	b.newHeadersSignal.Broadcast()
+}
+
+// resetHeaderListFromDisk resets the in-memory header list to match the
+// on-disk chain tip. This is used to restore consistency when a write to the
+// block header store fails after the in-memory list was already advanced.
+func (b *blockManager) resetHeaderListFromDisk() {
+	header, height, err := b.cfg.BlockHeaders.ChainTip()
+	if err != nil {
+		log.Errorf("Unable to fetch chain tip for header list "+
+			"rollback: %v", err)
+		return
+	}
+
+	b.headerList.ResetHeaderState(headerlist.Node{
+		Header: *header,
+		Height: int32(height),
+	})
 }
 
 // areHeadersConnected returns true if the passed block headers are connected to

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -441,6 +441,8 @@ func (b *blockManager) handleDonePeerMsg(peers *list.List, sp *ServerPeer) {
 		b.syncPeerMutex.Unlock()
 		header, height, err := b.cfg.BlockHeaders.ChainTip()
 		if err != nil {
+			log.Errorf("Unable to fetch chain tip for header "+
+				"list reset: %v", err)
 			return
 		}
 		b.headerList.ResetHeaderState(headerlist.Node{

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -2,6 +2,7 @@ package neutrino
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -945,4 +946,104 @@ func TestHandleHeaders(t *testing.T) {
 	})
 	bm.handleHeadersMsg(hmsg)
 	assertPeerDisconnected(true)
+}
+
+// failingBlockHeaderStore wraps a real BlockHeaderStore and returns an error
+// from WriteHeaders when configured to do so.
+type failingBlockHeaderStore struct {
+	headerfs.BlockHeaderStore
+
+	shouldFail bool
+}
+
+func (f *failingBlockHeaderStore) WriteHeaders(
+	hdrs ...headerfs.BlockHeader) error {
+
+	if f.shouldFail {
+		return errors.New("simulated write failure")
+	}
+
+	return f.BlockHeaderStore.WriteHeaders(hdrs...)
+}
+
+// TestHandleHeadersWriteFailure tests that when WriteHeaders fails, the block
+// manager properly recovers by resetting the in-memory header list to match
+// the on-disk chain tip and disconnecting the sync peer.
+func TestHandleHeadersWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	bm, hdrStore, _, err := setupBlockManager(t)
+	require.NoError(t, err)
+
+	// Wrap the real header store so we can inject WriteHeaders failures.
+	failStore := &failingBlockHeaderStore{
+		BlockHeaderStore: hdrStore,
+	}
+	bm.cfg.BlockHeaders = failStore
+
+	fakePeer, err := peer.NewOutboundPeer(&peer.Config{}, "fake:123")
+	require.NoError(t, err)
+
+	assertPeerDisconnected := func(shouldBeDisconnected bool) {
+		refValue := reflect.ValueOf(fakePeer).Elem()
+		disconnected := refValue.FieldByName("disconnect").Int()
+
+		if shouldBeDisconnected {
+			require.EqualValues(t, 1, disconnected)
+		} else {
+			require.EqualValues(t, 0, disconnected)
+		}
+	}
+
+	harness, err := rpctest.New(
+		&chaincfg.SimNetParams, nil, []string{"--txindex"}, "",
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, harness.TearDown())
+	})
+
+	err = harness.SetUp(false, 0)
+	require.NoError(t, err)
+
+	blockHashes, err := harness.Client.Generate(200)
+	require.NoError(t, err)
+
+	hmsg := &headersMsg{
+		headers: &wire.MsgHeaders{
+			Headers: make([]*wire.BlockHeader, len(blockHashes)),
+		},
+		peer: &ServerPeer{
+			Peer: fakePeer,
+		},
+	}
+
+	for i := range blockHashes {
+		header, err := harness.Client.GetBlockHeader(blockHashes[i])
+		require.NoError(t, err)
+
+		hmsg.headers.Headers[i] = header
+	}
+
+	// Record the chain tip before feeding headers.
+	_, tipHeightBefore, err := hdrStore.ChainTip()
+	require.NoError(t, err)
+
+	// Enable write failures and feed the valid headers.
+	failStore.shouldFail = true
+	bm.handleHeadersMsg(hmsg)
+
+	// The peer should be disconnected due to the write failure.
+	assertPeerDisconnected(true)
+
+	// The in-memory header list should be rolled back to the on-disk
+	// chain tip (genesis at height 0).
+	backNode := bm.headerList.Back()
+	require.NotNil(t, backNode)
+	require.Equal(t, int32(tipHeightBefore), backNode.Height)
+
+	// The on-disk chain tip should be unchanged (still at genesis).
+	_, tipHeightAfter, err := hdrStore.ChainTip()
+	require.NoError(t, err)
+	require.Equal(t, tipHeightBefore, tipHeightAfter)
 }


### PR DESCRIPTION
## Summary

- When `WriteHeaders` fails in `handleHeadersMsg`, the block manager enters a permanently stuck state: the in-memory `headerList` diverges from disk, no `getheaders` is sent, `cfHandler` blocks forever on `newHeadersSignal.Wait()`, and the sync peer stays connected preventing automatic recovery.
- Fix both the main header sync path and the reorg path by resetting `headerList` from the on-disk chain tip and disconnecting the sync peer, which triggers the existing recovery flow in `handleDonePeerMsg`.
- Add logging to the silent `ChainTip` failure in `handleDonePeerMsg` so recovery failures are observable.

## Test plan

- [x] `TestHandleHeadersWriteFailure` verifies that on `WriteHeaders` failure the peer is disconnected and `headerList` is rolled back to the on-disk chain tip.
- [x] Verify existing tests still pass (`go test ./...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)