### PR TITLE
rescan: Retry transient errors during catchup.

### DIFF
--- a/rescan.go
+++ b/rescan.go
@@ -507,6 +507,13 @@ func (rs *rescanState) rescan() error {
 		// TODO(roasbeef): add exponential back-off
 		blockRetryInterval = time.Millisecond * 100
 		blockRetryQueue    = newBlockRetryQueue()
+
+		// catchupRetryInterval is the interval used to retry block
+		// processing errors during catchup mode (e.g. timeouts
+		// fetching blocks or filters from peers). This uses a longer
+		// interval than blockRetryInterval since it typically
+		// indicates broader network issues.
+		catchupRetryInterval = 5 * time.Second
 	)
 
 	// We'll need to keep track of whether we are current with the chain in
@@ -751,8 +758,23 @@ rescanLoop:
 				uint32(nextHeight),
 			)
 			if err != nil {
-				return err
+				log.Errorf("Failed to get header for "+
+					"height %v, retrying in %v: %v",
+					nextHeight, catchupRetryInterval,
+					err)
+
+				select {
+				case <-time.After(catchupRetryInterval):
+				case <-ro.quit:
+					return ErrRescanExit
+				}
+				continue rescanLoop
 			}
+
+			// Save the current state so we can restore it
+			// if notifying the block fails.
+			prevHeader := rs.curHeader
+			prevStamp := rs.curStamp
 
 			rs.curHeader = *header
 			rs.curStamp.Height++
@@ -766,7 +788,26 @@ rescanLoop:
 
 			err = rs.notifyBlock()
 			if err != nil {
-				return err
+				// Restore the state to before we
+				// attempted to process this block so
+				// that it will be retried on the next
+				// iteration.
+				rs.curHeader = prevHeader
+				rs.curStamp = prevStamp
+
+				log.Errorf("Failed to process block "+
+					"%d (%s) during catchup, "+
+					"retrying in %v: %v",
+					nextHeight,
+					header.BlockHash(),
+					catchupRetryInterval, err)
+
+				select {
+				case <-time.After(catchupRetryInterval):
+				case <-ro.quit:
+					return ErrRescanExit
+				}
+				continue rescanLoop
 			}
 		}
 	}


### PR DESCRIPTION
When the rescan is in catchup mode (not current with the chain tip), errors from GetBlockHeaderByHeight and notifyBlock were fatal — they caused the rescan goroutine to return the error and exit. This meant that a transient issue like a peer timeout fetching a block would permanently kill the rescan. The btcwallet notification handler would log "Neutrino rescan ended with error" and cancel the block subscription, after which the wallet would never process another block until a manual rescan was triggered.

This was observed on mainnet where a peer timeout during block processing caused the wallet to stall for 15+ hours until the user manually initiated a rescan.

Fix this by retrying both GetBlockHeaderByHeight and notifyBlock errors with a 5-second delay instead of returning them. For notifyBlock failures, the rescan state is rolled back so the same block is retried on the next iteration. Both retry paths respect the quit channel for clean shutdown.