### PR TITLE
blockmanager: validate BIP 157 stop hashes to prevent peer disconnects during reorgs

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -5,6 +5,7 @@ package neutrino
 import (
 	"bytes"
 	"container/list"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -47,6 +48,11 @@ const (
 
 // zeroHash is the zero value hash (all zeros).  It is defined as a convenience.
 var zeroHash chainhash.Hash
+
+// errReorgDetected is returned when a chain reorg is detected during a
+// filter-related query, indicating the caller should retry with updated chain
+// state.
+var errReorgDetected = errors.New("reorg detected during filter query")
 
 // newPeerMsg signifies a newly connected peer to the block handler.
 type newPeerMsg struct {
@@ -569,7 +575,29 @@ waitForHeaders:
 
 			log.Debugf("Getting filter checkpoints up to "+
 				"height=%v, hash=%v", bestHeight, bestHash)
-			allCFCheckpoints = b.getCheckpts(&bestHash, fType)
+
+			var checkptsErr error
+			allCFCheckpoints, checkptsErr = b.getCheckpts(
+				&bestHash, fType,
+			)
+			if checkptsErr != nil {
+				log.Warnf("Error fetching checkpoints: "+
+					"%v, trying again...", checkptsErr)
+
+				// If a reorg was detected, we need to
+				// re-snapshot the chain state since our
+				// bestHash may reference a rolled-back block.
+				if errors.Is(checkptsErr, errReorgDetected) {
+					goto waitForHeaders
+				}
+
+				select {
+				case <-time.After(retryTimeout):
+				case <-b.quit:
+					return
+				}
+				continue
+			}
 			if len(allCFCheckpoints) == 0 {
 				log.Warnf("Unable to fetch set of " +
 					"candidate checkpoints, trying again...")
@@ -616,9 +644,27 @@ waitForHeaders:
 	}
 
 	// Get all the headers up to the last known good checkpoint.
-	b.getCheckpointedCFHeaders(
+	if err = b.getCheckpointedCFHeaders(
 		goodCheckpoints, store, fType,
-	)
+	); err != nil {
+		log.Warnf("Failed to get checkpointed cfheaders: %v", err)
+
+		select {
+		case <-time.After(retryTimeout):
+		case <-b.quit:
+			return
+		}
+
+		// If a reorg was detected, we need to clear stale
+		// checkpoints and re-snapshot chain state from scratch.
+		// For other errors (query failures, store issues), we
+		// can retry with the same checkpoints.
+		if errors.Is(err, errReorgDetected) {
+			allCFCheckpoints = nil
+			goto waitForHeaders
+		}
+		goto waitForHeaders
+	}
 
 	// Now we check the headers again. If the block headers are not yet
 	// current, then we go back to the loop waiting for them to finish.
@@ -682,6 +728,14 @@ waitForHeaders:
 			log.Debugf("couldn't get uncheckpointed headers for "+
 				"%v: %v", fType, err)
 
+			// If a reorg was detected, we need to go back to
+			// waiting for headers to re-snapshot the chain
+			// state, as our current view may reference blocks
+			// that no longer exist.
+			if errors.Is(err, errReorgDetected) {
+				goto waitForHeaders
+			}
+
 			select {
 			case <-time.After(retryTimeout):
 			case <-b.quit:
@@ -735,7 +789,12 @@ func (b *blockManager) getUncheckpointedCFHeaders(
 
 	// Query all peers for the responses.
 	startHeight := filtHeight + 1
-	headers, numHeaders := b.getCFHeadersForAllPeers(startHeight, fType)
+	headers, numHeaders, err := b.getCFHeadersForAllPeers(
+		startHeight, fType,
+	)
+	if err != nil {
+		return err
+	}
 
 	// Ban any peer that responds with the wrong prev filter header.
 	for peer, msg := range headers {
@@ -926,16 +985,22 @@ func (c *checkpointedCFHeadersQuery) handleResponse(req, resp wire.Message,
 
 // getCheckpointedCFHeaders catches a filter header store up with the
 // checkpoints we got from the network. It assumes that the filter header store
-// matches the checkpoints up to the tip of the store.
-func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
-	store headerfs.FilterHeaderStore, fType wire.FilterType) {
+// matches the checkpoints up to the tip of the store. If a reorg is detected
+// (e.g., a block header at a checkpoint height is no longer available),
+// errReorgDetected is returned.
+//
+//nolint:unparam
+func (b *blockManager) getCheckpointedCFHeaders(
+	checkpoints []*chainhash.Hash,
+	store headerfs.FilterHeaderStore,
+	fType wire.FilterType) error {
 
 	// We keep going until we've caught up the filter header store with the
 	// latest known checkpoint.
 	curHeader, curHeight, err := store.ChainTip()
 	if err != nil {
-		panic(fmt.Sprintf("failed getting chaintip from filter "+
-			"store: %v", err))
+		return fmt.Errorf("failed getting chaintip from filter "+
+			"store: %w", err)
 	}
 
 	initialFilterHeader := curHeader
@@ -997,8 +1062,12 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 			endHeightRange,
 		)
 		if err != nil {
-			panic(fmt.Sprintf("failed getting block header at "+
-				"height %v: %v", endHeightRange, err))
+			// If we can't fetch the header at this height, the
+			// chain was likely rolled back due to a reorg.
+			log.Infof("Failed to get block header at height "+
+				"%v (reorg likely): %v", endHeightRange, err)
+
+			return errReorgDetected
 		}
 		stopHash := stopHeader.BlockHash()
 
@@ -1020,7 +1089,7 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 
 	batchesCount := len(queryMsgs)
 	if batchesCount == 0 {
-		return
+		return nil
 	}
 
 	log.Infof("Attempting to query for %v cfheader batches", batchesCount)
@@ -1056,11 +1125,11 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 		case err := <-errChan:
 			switch {
 			case err == query.ErrWorkManagerShuttingDown:
-				return
+				return nil
 			case err != nil:
 				log.Errorf("Query finished with error before "+
 					"all responses received: %v", err)
-				return
+				return err
 			}
 
 			// The query did finish successfully, but continue to
@@ -1069,7 +1138,7 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 			continue
 
 		case <-b.quit:
-			return
+			return nil
 		}
 
 		checkPointIndex := stopHashes[r.StopHash]
@@ -1165,6 +1234,8 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 			break
 		}
 	}
+
+	return nil
 }
 
 // writeCFHeadersMsg writes a cfheaders message to the specified store. It
@@ -1432,7 +1503,12 @@ func (b *blockManager) resolveConflict(
 	// which ones are valid.
 	// TODO(halseth): check if peer serves headers that matches its checkpoints
 	startHeight := uint32(heightDiff) * wire.CFCheckptInterval
-	headers, numHeaders := b.getCFHeadersForAllPeers(startHeight, fType)
+	headers, numHeaders, err := b.getCFHeadersForAllPeers(
+		startHeight, fType,
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	// Make sure we're working off the same baseline. Otherwise, we want to
 	// go back and get checkpoints again.
@@ -1558,9 +1634,12 @@ func (b *blockManager) detectBadPeers(headers map[string]*wire.MsgCFHeaders,
 
 	// Fetch filters from the peers in question.
 	// TODO(halseth): query only peers from headers map.
-	filtersFromPeers := b.fetchFilterFromAllPeers(
+	filtersFromPeers, err := b.fetchFilterFromAllPeers(
 		targetHeight, header.BlockHash(), fType,
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	var badPeers []string
 	for peer, msg := range headers {
@@ -1767,26 +1846,30 @@ func resolveFilterMismatchFromBlock(block *wire.MsgBlock,
 
 // getCFHeadersForAllPeers runs a query for cfheaders at a specific height and
 // returns a map of responses from all peers. The second return value is the
-// number for cfheaders in each response.
+// number for cfheaders in each response. If a reorg is detected during the
+// query, errReorgDetected is returned.
 func (b *blockManager) getCFHeadersForAllPeers(height uint32,
-	fType wire.FilterType) (map[string]*wire.MsgCFHeaders, int) {
+	fType wire.FilterType) (map[string]*wire.MsgCFHeaders, int, error) {
 
 	// Create the map we're returning.
 	headers := make(map[string]*wire.MsgCFHeaders)
 
 	// Get the header we expect at either the tip of the block header store
 	// or at the end of the maximum-size response message, whichever is
-	// larger.
+	// larger. We snapshot the chain tip hash so we can detect reorgs after
+	// the query completes.
 	stopHeader, stopHeight, err := b.cfg.BlockHeaders.ChainTip()
 	if err != nil {
-		return nil, 0
+		return nil, 0, err
 	}
+	tipHash := stopHeader.BlockHash()
+
 	if stopHeight-height >= wire.MaxCFHeadersPerMsg {
 		stopHeader, err = b.cfg.BlockHeaders.FetchHeaderByHeight(
 			height + wire.MaxCFHeadersPerMsg - 1,
 		)
 		if err != nil {
-			return nil, 0
+			return nil, 0, err
 		}
 
 		// We'll make sure we also update our stopHeight so we know how
@@ -1821,16 +1904,44 @@ func (b *blockManager) getCFHeadersForAllPeers(height uint32,
 		},
 	)
 
-	return headers, numHeaders
+	// After the query, check if the chain tip changed (indicating a reorg
+	// occurred while we were querying). If so, our stopHash may reference
+	// a block the peer no longer has, which would cause them to disconnect
+	// us per BIP 157.
+	currentTip, _, err := b.cfg.BlockHeaders.ChainTip()
+	if err != nil {
+		return nil, 0, err
+	}
+	if currentTip.BlockHash() != tipHash {
+		log.Infof("Reorg detected during cfheaders query, retrying "+
+			"with updated chain state (old_tip=%v, new_tip=%v)",
+			tipHash, currentTip.BlockHash())
+
+		return nil, 0, errReorgDetected
+	}
+
+	return headers, numHeaders, nil
 }
 
 // fetchFilterFromAllPeers attempts to fetch a filter for the target filter
 // type and blocks from all peers connected to the block manager. This method
 // returns a map which allows the caller to match a peer to the filter it
-// responded with.
+// responded with. If the target block has been rolled back due to a reorg,
+// errReorgDetected is returned.
 func (b *blockManager) fetchFilterFromAllPeers(
 	height uint32, blockHash chainhash.Hash,
-	filterType wire.FilterType) map[string]*gcs.Filter {
+	filterType wire.FilterType) (map[string]*gcs.Filter, error) {
+
+	// Before querying peers, verify the block hash still exists in our
+	// header store. If it was rolled back during a reorg, we must not
+	// send this hash to peers as they will disconnect us per BIP 157.
+	_, _, err := b.cfg.BlockHeaders.FetchHeader(&blockHash)
+	if err != nil {
+		log.Infof("Block hash %v no longer in header store, "+
+			"reorg likely occurred", blockHash)
+
+		return nil, fmt.Errorf("%w: %v", errReorgDetected, err)
+	}
 
 	// We'll use this map to collate all responses we receive from each
 	// peer.
@@ -1878,13 +1989,25 @@ func (b *blockManager) fetchFilterFromAllPeers(
 		},
 	)
 
-	return filterResponses
+	return filterResponses, nil
 }
 
 // getCheckpts runs a query for cfcheckpts against all peers and returns a map
-// of responses.
+// of responses. If the target block has been rolled back due to a reorg,
+// errReorgDetected is returned.
 func (b *blockManager) getCheckpts(lastHash *chainhash.Hash,
-	fType wire.FilterType) map[string][]*chainhash.Hash {
+	fType wire.FilterType) (map[string][]*chainhash.Hash, error) {
+
+	// Before querying peers, verify the lastHash block still exists in our
+	// header store. If it was rolled back during a reorg, we must not send
+	// this hash to peers as they will disconnect us per BIP 157.
+	_, _, err := b.cfg.BlockHeaders.FetchHeader(lastHash)
+	if err != nil {
+		log.Infof("Checkpoint stop hash %v no longer in header "+
+			"store, reorg likely occurred", lastHash)
+
+		return nil, fmt.Errorf("%w: %v", errReorgDetected, err)
+	}
 
 	checkpoints := make(map[string][]*chainhash.Hash)
 	getCheckptMsg := wire.NewMsgGetCFCheckpt(fType, lastHash)
@@ -1904,7 +2027,7 @@ func (b *blockManager) getCheckpts(lastHash *chainhash.Hash,
 			}
 		},
 	)
-	return checkpoints
+	return checkpoints, nil
 }
 
 // checkCFCheckptSanity checks whether all peers which have responded agree.

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1217,8 +1217,8 @@ func (b *blockManager) getCheckpointedCFHeaders(
 			// the next message.
 			curHeader, curHeight, err = b.writeCFHeadersMsg(r, store)
 			if err != nil {
-				panic(fmt.Sprintf("couldn't write "+
-					"cfheaders msg: %v", err))
+				return fmt.Errorf("couldn't write "+
+					"cfheaders msg: %w", err)
 			}
 
 			// Update the next interval to write to reflect our

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightninglabs/neutrino/blockntfns"
 	"github.com/lightninglabs/neutrino/headerfs"
 	"github.com/lightninglabs/neutrino/query"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1207,4 +1208,165 @@ func TestDetectBadPeersReorgRecovery(t *testing.T) {
 	require.Error(t, err)
 
 	mBlockHeaderStore.AssertExpectations(t)
+}
+
+// TestWriteCFHeadersMsgErrorNoPanic tests that writeCFHeadersMsg returns an
+// error to the caller instead of panicking when the underlying filter header
+// store fails. We verify that this error propagates through
+// getCheckpointedCFHeaders, which previously panicked on write failures. The
+// caller (cfHandler) handles this by retrying via goto waitForHeaders.
+func TestWriteCFHeadersMsgErrorNoPanic(t *testing.T) {
+	t.Parallel()
+
+	// We'll test writeCFHeadersMsg directly with a mock store that fails
+	// on WriteHeaders.
+	errStoreFailed := fmt.Errorf("simulated store write failure")
+
+	// Create a filter header with the expected tip matching the
+	// PrevFilterHeader in our message.
+	prevHeader := chainhash.Hash{0x01}
+
+	// Set up a mock filter header store. ChainTip returns the prev header
+	// (so the alignment check passes), then WriteHeaders fails.
+	mFilterStore := &headerfs.MockFilterHeaderStore{}
+	mFilterStore.On("ChainTip").Return(
+		&prevHeader, uint32(1000), nil,
+	)
+	mFilterStore.On(
+		"WriteHeaders",
+		mock.AnythingOfType("[]headerfs.FilterHeader"),
+	).Return(errStoreFailed)
+
+	// Set up a mock block header store for FetchHeaderAncestors (needed
+	// by writeCFHeadersMsg to match filter headers to block headers).
+	blockHeader := wire.BlockHeader{Nonce: 0x42}
+	blockHash := blockHeader.BlockHash()
+	mBlockStore := &headerfs.MockBlockHeaderStore{}
+	mBlockStore.On(
+		"FetchHeaderAncestors", uint32(0), &blockHash,
+	).Return(
+		[]wire.BlockHeader{blockHeader}, uint32(1001), nil,
+	)
+
+	bm := &blockManager{
+		cfg: &blockManagerCfg{
+			BlockHeaders: mBlockStore,
+		},
+	}
+
+	// Construct a minimal CFHeaders message with one filter hash.
+	filterHash := chainhash.Hash{0x02}
+	msg := &wire.MsgCFHeaders{
+		FilterType:       wire.GCSFilterRegular,
+		StopHash:         blockHash,
+		PrevFilterHeader: prevHeader,
+		FilterHashes:     []*chainhash.Hash{&filterHash},
+	}
+
+	// writeCFHeadersMsg should return the store error, not panic.
+	_, _, err := bm.writeCFHeadersMsg(msg, mFilterStore)
+	require.ErrorIs(t, err, errStoreFailed)
+
+	mFilterStore.AssertExpectations(t)
+	mBlockStore.AssertExpectations(t)
+}
+
+// TestGetCheckpointedCFHeadersWriteError tests that getCheckpointedCFHeaders
+// returns an error (instead of panicking) when writeCFHeadersMsg encounters a
+// store write failure mid-sync. The caller (cfHandler) can then retry by
+// jumping back to waitForHeaders. This is a regression test that verifies the
+// panic in the write path has been replaced with proper error propagation.
+func TestGetCheckpointedCFHeadersWriteError(t *testing.T) {
+	t.Parallel()
+
+	// Use the real stores so we get the full query pipeline.
+	bm, hdrStore, cfStore, err := setupBlockManager(t)
+	require.NoError(t, err)
+
+	// Generate headers and write block headers.
+	genesisBlockHeader, _, err := hdrStore.ChainTip()
+	require.NoError(t, err)
+	genesisFilterHeader, _, err := cfStore.ChainTip()
+	require.NoError(t, err)
+
+	hdrs, err := generateHeaders(
+		genesisBlockHeader, genesisFilterHeader, nil,
+	)
+	require.NoError(t, err)
+
+	err = hdrStore.WriteHeaders(hdrs.blockHeaders[1:]...)
+	require.NoError(t, err)
+
+	// Set up the query dispatcher to deliver valid responses, but advance
+	// the filter header store's tip before the write happens. We do this
+	// by writing a mismatched filter header to the store in between the
+	// response being validated and being written, which causes
+	// writeCFHeadersMsg's alignment check to fail.
+	firstCall := true
+	bm.cfg.QueryDispatcher.(*mockDispatcher).query = func(
+		requests []*query.Request,
+		options ...query.QueryOption) chan error {
+
+		var msgs []wire.Message
+		for _, q := range requests {
+			msgs = append(msgs, q.Req)
+		}
+
+		responses, genErr := generateResponses(msgs, hdrs)
+		if genErr != nil {
+			errChan := make(chan error, 1)
+			errChan <- genErr
+			return errChan
+		}
+
+		errChan := make(chan error, 1)
+		go func() {
+			for i := range responses {
+				resp := *responses[i]
+
+				// On the first query invocation, write a bogus
+				// filter header to the store so that the
+				// alignment check in writeCFHeadersMsg fails.
+				// This simulates a store corruption or
+				// concurrent modification.
+				if firstCall {
+					firstCall = false
+					bh := hdrs.blockHeaders[1]
+					fh := chainhash.Hash{0xff}
+					bogus := headerfs.FilterHeader{
+						HeaderHash: bh.BlockHash(),
+						FilterHash: fh,
+						Height:     1,
+					}
+					_ = cfStore.WriteHeaders(bogus)
+				}
+
+				requests[i].HandleResp(
+					msgs[i], &resp, "",
+				)
+			}
+			errChan <- nil
+		}()
+
+		return errChan
+	}
+
+	// Drain block notifications so we don't block.
+	go func() {
+		for {
+			select {
+			case <-bm.blockNtfnChan:
+			case <-bm.quit:
+				return
+			}
+		}
+	}()
+
+	// getCheckpointedCFHeaders should return an error from the
+	// writeCFHeadersMsg path rather than panicking.
+	err = bm.getCheckpointedCFHeaders(
+		hdrs.checkpoints, cfStore, wire.GCSFilterRegular,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cfheaders")
 }

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -434,9 +434,10 @@ func TestBlockManagerInitialInterval(t *testing.T) {
 
 		// Call the get checkpointed cf headers method with the
 		// checkpoints we created to start the test.
-		bm.getCheckpointedCFHeaders(
+		err = bm.getCheckpointedCFHeaders(
 			headers.checkpoints, cfStore, wire.GCSFilterRegular,
 		)
+		require.NoError(t, err)
 
 		// Finally make sure the filter header tip is what we expect.
 		tip, tipHeight, err := cfStore.ChainTip()
@@ -660,8 +661,10 @@ func TestBlockManagerInvalidInterval(t *testing.T) {
 		}()
 
 		// Start the test by calling the get checkpointed cf headers
-		// method with the checkpoints we created.
-		bm.getCheckpointedCFHeaders(
+		// method with the checkpoints we created. This test
+		// deliberately sends invalid intervals, so the function may
+		// return an error from the query dispatcher.
+		_ = bm.getCheckpointedCFHeaders(
 			headers.checkpoints, cfStore, wire.GCSFilterRegular,
 		)
 	}
@@ -802,6 +805,13 @@ func TestBlockManagerDetectBadPeers(t *testing.T) {
 
 		mBlockHeaderStore.On("FetchHeaderByHeight", targetIndex).Return(
 			&blockHeader, nil,
+		)
+
+		// fetchFilterFromAllPeers now validates that the block hash
+		// still exists in the header store before querying peers.
+		targetHash := blockHeader.BlockHash()
+		mBlockHeaderStore.On("FetchHeader", &targetHash).Return(
+			&blockHeader, targetIndex, nil,
 		)
 
 		// We set up the mock queryAllPeers to only respond according to
@@ -945,4 +955,256 @@ func TestHandleHeaders(t *testing.T) {
 	})
 	bm.handleHeadersMsg(hmsg)
 	assertPeerDisconnected(true)
+}
+
+// TestGetCFHeadersReorgRecovery tests that getCFHeadersForAllPeers returns
+// errReorgDetected when the chain tip changes during the query, which happens
+// when a reorg occurs while filter headers are being fetched. This is a
+// regression test for https://github.com/lightninglabs/neutrino/issues/338.
+func TestGetCFHeadersReorgRecovery(t *testing.T) {
+	t.Parallel()
+
+	// Create two different chain tips to simulate a reorg.
+	chainATip := &wire.BlockHeader{
+		Nonce: 0xaa,
+	}
+	chainBTip := &wire.BlockHeader{
+		Nonce: 0xbb,
+	}
+
+	fType := wire.GCSFilterRegular
+	startHeight := uint32(100)
+
+	// Set up mock block header store that returns chain A tip first, then
+	// chain B tip on the second call (simulating a reorg mid-query).
+	mBlockHeaderStore := &headerfs.MockBlockHeaderStore{}
+
+	// First ChainTip call returns chain A (used to construct the query).
+	mBlockHeaderStore.On("ChainTip").Return(
+		chainATip, startHeight, nil,
+	).Once()
+
+	// Second ChainTip call returns chain B (post-query validation detects
+	// the reorg).
+	mBlockHeaderStore.On("ChainTip").Return(
+		chainBTip, startHeight, nil,
+	).Once()
+
+	// Track whether queryAllPeers was called with a stale hash.
+	queryCalled := false
+	queryAllPeers := func(
+		queryMsg wire.Message,
+		checkResponse func(sp *ServerPeer, resp wire.Message,
+			quit chan<- struct{}, peerQuit chan<- struct{}),
+		options ...QueryOption) {
+
+		queryCalled = true
+	}
+
+	bm := &blockManager{
+		cfg: &blockManagerCfg{
+			BlockHeaders:  mBlockHeaderStore,
+			queryAllPeers: queryAllPeers,
+		},
+	}
+
+	// Call getCFHeadersForAllPeers — it should detect the reorg and
+	// return errReorgDetected.
+	_, _, err := bm.getCFHeadersForAllPeers(startHeight, fType)
+	require.ErrorIs(t, err, errReorgDetected)
+
+	// The query should have been issued (we detect the reorg after).
+	require.True(t, queryCalled)
+
+	mBlockHeaderStore.AssertExpectations(t)
+}
+
+// TestFetchFilterReorgRecovery tests that fetchFilterFromAllPeers returns
+// errReorgDetected when the target block hash has been rolled back due to a
+// reorg. This is a regression test for
+// https://github.com/lightninglabs/neutrino/issues/338.
+func TestFetchFilterReorgRecovery(t *testing.T) {
+	t.Parallel()
+
+	// Create a block hash that will be "reorged away".
+	reorgedBlock := wire.BlockHeader{
+		Nonce: 0xdead,
+	}
+	reorgedHash := reorgedBlock.BlockHash()
+
+	fType := wire.GCSFilterRegular
+	targetHeight := uint32(100)
+
+	// Set up mock that returns an error for FetchHeader, simulating the
+	// block being rolled back.
+	mBlockHeaderStore := &headerfs.MockBlockHeaderStore{}
+	mBlockHeaderStore.On("FetchHeader", &reorgedHash).Return(
+		nil, uint32(0), fmt.Errorf("header not found"),
+	)
+
+	// queryAllPeers should NOT be called since we detect the reorg before
+	// sending any queries.
+	queryCalled := false
+	queryAllPeers := func(
+		queryMsg wire.Message,
+		checkResponse func(sp *ServerPeer, resp wire.Message,
+			quit chan<- struct{}, peerQuit chan<- struct{}),
+		options ...QueryOption) {
+
+		queryCalled = true
+	}
+
+	bm := &blockManager{
+		cfg: &blockManagerCfg{
+			BlockHeaders:  mBlockHeaderStore,
+			queryAllPeers: queryAllPeers,
+		},
+	}
+
+	_, err := bm.fetchFilterFromAllPeers(
+		targetHeight, reorgedHash, fType,
+	)
+	require.ErrorIs(t, err, errReorgDetected)
+
+	// The query should NOT have been issued since we detected the reorg
+	// before sending.
+	require.False(t, queryCalled)
+
+	mBlockHeaderStore.AssertExpectations(t)
+}
+
+// TestGetCheckptsReorgRecovery tests that getCheckpts returns errReorgDetected
+// when the checkpoint stop hash has been rolled back due to a reorg. This is a
+// regression test for https://github.com/lightninglabs/neutrino/issues/338.
+func TestGetCheckptsReorgRecovery(t *testing.T) {
+	t.Parallel()
+
+	// Create a block hash that will be "reorged away".
+	reorgedBlock := wire.BlockHeader{
+		Nonce: 0xbeef,
+	}
+	reorgedHash := reorgedBlock.BlockHash()
+
+	fType := wire.GCSFilterRegular
+
+	// Set up mock that returns an error for FetchHeader, simulating the
+	// block being rolled back.
+	mBlockHeaderStore := &headerfs.MockBlockHeaderStore{}
+	mBlockHeaderStore.On("FetchHeader", &reorgedHash).Return(
+		nil, uint32(0), fmt.Errorf("header not found"),
+	)
+
+	// queryAllPeers should NOT be called.
+	queryCalled := false
+	queryAllPeers := func(
+		queryMsg wire.Message,
+		checkResponse func(sp *ServerPeer, resp wire.Message,
+			quit chan<- struct{}, peerQuit chan<- struct{}),
+		options ...QueryOption) {
+
+		queryCalled = true
+	}
+
+	bm := &blockManager{
+		cfg: &blockManagerCfg{
+			BlockHeaders:  mBlockHeaderStore,
+			queryAllPeers: queryAllPeers,
+		},
+	}
+
+	_, err := bm.getCheckpts(&reorgedHash, fType)
+	require.ErrorIs(t, err, errReorgDetected)
+
+	// The query should NOT have been issued.
+	require.False(t, queryCalled)
+
+	mBlockHeaderStore.AssertExpectations(t)
+}
+
+// TestGetCheckpointedCFHeadersReorgNoPanic tests that
+// getCheckpointedCFHeaders returns an error instead of panicking when the block
+// header store can't serve a header at a checkpoint height because it was
+// rolled back during a reorg. This is a regression test for
+// https://github.com/lightninglabs/neutrino/issues/338.
+func TestGetCheckpointedCFHeadersReorgNoPanic(t *testing.T) {
+	t.Parallel()
+
+	fType := wire.GCSFilterRegular
+
+	// Set up a filter header store mock with a tip at height 0.
+	filterTip := chainhash.Hash{}
+	mFilterHeaderStore := &headerfs.MockFilterHeaderStore{}
+	mFilterHeaderStore.On("ChainTip").Return(
+		&filterTip, uint32(0), nil,
+	)
+
+	// Create checkpoints. We need at least one checkpoint so the function
+	// tries to fetch headers.
+	checkpoints := make([]*chainhash.Hash, 2)
+	for i := range checkpoints {
+		h := chainhash.Hash{}
+		h[0] = byte(i + 1)
+		checkpoints[i] = &h
+	}
+
+	// Set up block header store mock. The function will try to fetch a
+	// block header at the end of the checkpoint range. With 2 checkpoints
+	// and maxCFCheckptsPerQuery=2, the first (and only) query requests
+	// endHeightRange = 2 * wire.CFCheckptInterval = 2000.
+	endHeightRange := uint32(len(checkpoints)) * wire.CFCheckptInterval
+	mBlockHeaderStore := &headerfs.MockBlockHeaderStore{}
+	mBlockHeaderStore.On(
+		"FetchHeaderByHeight", endHeightRange,
+	).Return(
+		nil, fmt.Errorf("header not found: chain rolled back"),
+	)
+
+	bm := &blockManager{
+		cfg: &blockManagerCfg{
+			BlockHeaders:     mBlockHeaderStore,
+			RegFilterHeaders: mFilterHeaderStore,
+		},
+	}
+
+	// This should return errReorgDetected instead of panicking.
+	err := bm.getCheckpointedCFHeaders(
+		checkpoints, mFilterHeaderStore, fType,
+	)
+	require.ErrorIs(t, err, errReorgDetected)
+
+	mBlockHeaderStore.AssertExpectations(t)
+	mFilterHeaderStore.AssertExpectations(t)
+}
+
+// TestDetectBadPeersReorgRecovery tests that detectBadPeers propagates
+// errReorgDetected when the target block has been rolled back. This is a
+// regression test for https://github.com/lightninglabs/neutrino/issues/338.
+func TestDetectBadPeersReorgRecovery(t *testing.T) {
+	t.Parallel()
+
+	fType := wire.GCSFilterRegular
+	targetHeight := uint32(100)
+
+	// The block at targetHeight has been rolled back.
+	mBlockHeaderStore := &headerfs.MockBlockHeaderStore{}
+	mBlockHeaderStore.On(
+		"FetchHeaderByHeight", targetHeight,
+	).Return(
+		nil, fmt.Errorf("header not found"),
+	)
+
+	bm := &blockManager{
+		cfg: &blockManagerCfg{
+			BlockHeaders: mBlockHeaderStore,
+		},
+	}
+
+	// detectBadPeers should propagate the error from FetchHeaderByHeight.
+	headers := map[string]*wire.MsgCFHeaders{
+		"peer1:1": {},
+	}
+	_, err := bm.detectBadPeers(headers, targetHeight, 0, fType)
+	require.Error(t, err)
+
+	mBlockHeaderStore.AssertExpectations(t)
 }


### PR DESCRIPTION
In this PR, we fix a bug where neutrino could enter a tight
disconnect/reconnect loop with bitcoind peers during a chain reorg
(#338). The root cause is a race between `blockHandler` (which
processes reorg headers via `handleHeadersMsg` → `rollBackToHeight`)
and `cfHandler` which reads from the header store concurrently to
construct filter queries. When `cfHandler` captures a block hash for
use as a `StopHash` in `GetCFilters`/`GetCFHeaders`/`GetCFCheckpt`
messages, that hash can become stale if `blockHandler` rolls back
the chain in between.

Per BIP 157, the `StopHash` MUST be known to the receiving peer.
bitcoind's `PrepareBlockFilterRequest` enforces this strictly: if the
stop hash isn't in the active chain (i.e.
`!stop_index || !BlockRequestAllowed`), it sets `fDisconnect = true`.
So sending a stale hash from a reorged-out block causes an immediate
disconnect, and since neutrino retries with the same stale state, we
get a tight reconnect loop. This was observed in the wild during the
recent Foundry reorg.

We introduce `errReorgDetected` as a sentinel error and add validation
to all four query construction paths. `getCFHeadersForAllPeers`
snapshots the chain tip hash before the query and re-checks after; if
the tip changed mid-query, we return `errReorgDetected` so the caller
retries with fresh state. `fetchFilterFromAllPeers` and `getCheckpts`
both validate their target block hash still exists in the header store
via `FetchHeader` before sending any query to peers.
`getCheckpointedCFHeaders` replaces a `panic` on
`FetchHeaderByHeight` failure with a graceful `errReorgDetected`
return, since a rolled-back chain makes previously valid heights
unreachable. We also change the signature from `void` to `error` so
callers can react.

All callers in `cfHandler`, `getUncheckpointedCFHeaders`,
`resolveConflict`, and `detectBadPeers` are updated to propagate the
new error. The existing retry loops in `cfHandler` (with
`retryTimeout` backoff and `goto waitForHeaders`) handle the recovery
naturally. When `getCheckpts` returns `errReorgDetected` specifically,
we go to `waitForHeaders` to re-snapshot chain state rather than
retrying with the same potentially stale `bestHash`. Similarly,
`getCheckpointedCFHeaders` failures clear `allCFCheckpoints` and
apply a retry backoff before going back to `waitForHeaders` to prevent
tight loops on persistent store errors.

As a secondary fix, we also replace the remaining `panic` in the
`writeCFHeadersMsg` error path with a proper error return, so store
write failures (DB errors, alignment mismatches from concurrent
reorgs) are recoverable rather than crashing the process.

See each commit message for a detailed description w.r.t the
incremental changes.

Fixes #338.