### PR TITLE
support parsing .onion peer addresses

### DIFF
--- a/banman/util.go
+++ b/banman/util.go
@@ -1,7 +1,10 @@
 package banman
 
 import (
+	"crypto/sha256"
+	"encoding/base32"
 	"net"
+	"strings"
 )
 
 var (
@@ -14,6 +17,12 @@ var (
 	// networks from an address. This ensures that the IP network only
 	// contains *one* IP address -- the one specified.
 	defaultIPv6Mask = net.CIDRMask(128, 128)
+
+	// onionCatPrefix is the IPv6 prefix used for OnionCat/Tor addresses.
+	onionCatPrefix = [6]byte{0xfd, 0x87, 0xd8, 0x7e, 0xeb, 0x43}
+
+	// noPaddingBase32 is used for decoding unpadded .onion labels.
+	noPaddingBase32 = base32.StdEncoding.WithPadding(base32.NoPadding)
 )
 
 // ParseIPNet parses the IP network that contains the given address. An optional
@@ -31,6 +40,10 @@ func ParseIPNet(addr string, mask net.IPMask) (*net.IPNet, error) {
 
 	// Parse the IP from the host to ensure it is supported.
 	ip := net.ParseIP(host)
+	if ip == nil {
+		ip = parseOnionHost(host)
+	}
+
 	switch {
 	case ip.To4() != nil:
 		if mask == nil {
@@ -45,4 +58,41 @@ func ParseIPNet(addr string, mask net.IPMask) (*net.IPNet, error) {
 	}
 
 	return &net.IPNet{IP: ip.Mask(mask), Mask: mask}, nil
+}
+
+func parseOnionHost(host string) net.IP {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if !strings.HasSuffix(host, ".onion") {
+		return nil
+	}
+
+	label := strings.ToUpper(strings.TrimSuffix(host, ".onion"))
+	switch len(label) {
+	case 16:
+		decoded, err := noPaddingBase32.DecodeString(label)
+		if err != nil || len(decoded) != 10 {
+			return nil
+		}
+
+		return onionCatIP(decoded)
+
+	case 56:
+		decoded, err := noPaddingBase32.DecodeString(label)
+		if err != nil || len(decoded) != 35 || decoded[34] != 0x03 {
+			return nil
+		}
+
+		sum := sha256.Sum256(decoded[:32])
+		return onionCatIP(sum[:10])
+
+	default:
+		return nil
+	}
+}
+
+func onionCatIP(suffix []byte) net.IP {
+	ip := make(net.IP, net.IPv6len)
+	copy(ip[:6], onionCatPrefix[:])
+	copy(ip[6:], suffix[:10])
+	return ip
 }

--- a/banman/util_test.go
+++ b/banman/util_test.go
@@ -87,3 +87,56 @@ func TestParseIPNet(t *testing.T) {
 		}
 	}
 }
+
+func TestParseIPNetOnionV3(t *testing.T) {
+	t.Parallel()
+
+	host := "yov4edh4vgbgywplxuxv4esroksz2brb64fdtjbryc5wbo43wtlbsiad.onion"
+
+	ipNet, err := ParseIPNet(
+		net.JoinHostPort(host, "38333"), nil,
+	)
+	if err != nil {
+		t.Fatalf("unable to parse onion v3 address: %v", err)
+	}
+
+	if ipNet == nil || ipNet.IP == nil || ipNet.IP.To16() == nil {
+		t.Fatalf("expected ipv6 network for onion v3, got: %#v", ipNet)
+	}
+
+	if !reflect.DeepEqual(ipNet.Mask, defaultIPv6Mask) {
+		t.Fatalf("expected mask %#v, got %#v",
+			defaultIPv6Mask, ipNet.Mask)
+	}
+}
+
+func TestParseIPNetOnionStableAcrossPortVariants(t *testing.T) {
+	t.Parallel()
+
+	host := "yov4edh4vgbgywplxuxv4esroksz2brb64fdtjbryc5wbo43wtlbsiad.onion"
+
+	withPort, err := ParseIPNet(net.JoinHostPort(host, "38333"), nil)
+	if err != nil {
+		t.Fatalf("unable to parse onion host with port: %v", err)
+	}
+
+	withoutPort, err := ParseIPNet(host, nil)
+	if err != nil {
+		t.Fatalf("unable to parse onion host without port: %v", err)
+	}
+
+	if withPort.String() != withoutPort.String() {
+		t.Fatalf("expected stable onion mapping: "+
+			"withPort=%s withoutPort=%s",
+			withPort.String(), withoutPort.String())
+	}
+}
+
+func TestParseIPNetRejectsInvalidOnion(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseIPNet("invalid.onion:8333", nil)
+	if err == nil {
+		t.Fatal("expected invalid onion hostname to fail")
+	}
+}


### PR DESCRIPTION
Neutrino already supports `.onion` peers in connection flow; this patch fixes ban subsystem parsing so Tor peers discovered from the network no longer trigger `unsupported IP type` errors.

## Tests
Added/updated tests in `banman/util_test.go` for:
- parsing onion v3 successfully,
- stable mapping with/without port,
- rejecting invalid onion hostnames.