### PR TITLE
feat: Allow custom HTTP client in chainimport

### DIFF
--- a/chainimport/headers_import.go
+++ b/chainimport/headers_import.go
@@ -19,6 +19,8 @@ const (
 	defaultWriteBatchSizePerRegion = 16384
 )
 
+var defaultHTTPClient = newHTTPClient()
+
 // processingRegions contains regions to process. The divergence and new headers
 // regions are detected and processed.
 type processingRegions struct {
@@ -1124,6 +1126,12 @@ type ImportOptions struct {
 	// ValidationFlags specifies the behavior flags used during header
 	// validation. It defaults to BFNone.
 	ValidationFlags blockchain.BehaviorFlags
+
+	// HttpClient is an optional HTTP client to use for downloading headers
+	// from HTTP(s) sources. When set, this client is used instead of the
+	// default http.Client. This allows consumers to inject a
+	// proxy-configured client (e.g., SOCKS5 for Tor).
+	HttpClient HttpClient
 }
 
 // validate checks that all required fields in import options are properly set
@@ -1148,8 +1156,9 @@ func (options *ImportOptions) createBlockHeaderImportSrc() HeaderImportSource {
 		// The empty string ("") URI passed will be replaced by the
 		// temporary file name once the file has been downloaded from
 		// the HTTP source.
+		httpClient := options.httpClient()
 		return newHTTPHeaderImportSource(
-			options.BlockHeadersSource, newHTTPClient(),
+			options.BlockHeadersSource, httpClient,
 			newFileHeaderImportSource("", newBlockHeader),
 		)
 	}
@@ -1165,8 +1174,9 @@ func (options *ImportOptions) createBlockHeaderImportSrc() HeaderImportSource {
 func (options *ImportOptions) createFilterHeaderImportSrc() HeaderImportSource {
 	// Check if the filter headers source is a HTTP(s) URI.
 	if strings.HasPrefix(options.FilterHeadersSource, "http") {
+		httpClient := options.httpClient()
 		return newHTTPHeaderImportSource(
-			options.FilterHeadersSource, newHTTPClient(),
+			options.FilterHeadersSource, httpClient,
 			newFileHeaderImportSource("", newFilterHeader),
 		)
 	}
@@ -1192,6 +1202,15 @@ func (options *ImportOptions) createBlockHeaderValidator(
 // headers.
 func (options *ImportOptions) createFilterHeaderValidator() HeadersValidator {
 	return newFilterHeadersImportSourceValidator(options.TargetChainParams)
+}
+
+// httpClient returns the configured HttpClient or falls back to a shared
+// default one.
+func (options *ImportOptions) httpClient() HttpClient {
+	if options.HttpClient != nil {
+		return options.HttpClient
+	}
+	return defaultHTTPClient
 }
 
 // ImportResult contains statistics about a header import operation.

--- a/chainimport/headers_import_test.go
+++ b/chainimport/headers_import_test.go
@@ -7778,3 +7778,58 @@ func constructFilterHdr(filterHeaderHex string,
 
 	return fH, nil
 }
+
+// TestImportOptionsHttpClient verifies that ImportOptions.httpClient() returns
+// the injected client when set, and falls back to a default client otherwise.
+func TestImportOptionsHttpClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ReturnsInjectedClient", func(t *testing.T) {
+		customClient := &mockHTTPClient{}
+		opts := &ImportOptions{
+			HttpClient: customClient,
+		}
+		got := opts.httpClient()
+		require.Equal(t, customClient, got,
+			"httpClient() should return the injected client")
+	})
+
+	t.Run("FallsBackToDefault", func(t *testing.T) {
+		opts := &ImportOptions{}
+		got := opts.httpClient()
+		gotAgain := opts.httpClient()
+
+		require.NotNil(t, got,
+			"httpClient() should return a non-nil default client")
+		_, ok := got.(*http.Client)
+		require.True(t, ok,
+			"default client should be *http.Client")
+		require.Same(t, got, gotAgain,
+			"httpClient() should return a shared default client")
+	})
+
+	t.Run("HTTPSourceUsesInjectedClient", func(t *testing.T) {
+		customClient := &mockHTTPClient{}
+		blockHeadersURL := "https://example.com/block-headers"
+		filterHeadersURL := "https://example.com/filter-headers"
+		opts := &ImportOptions{
+			BlockHeadersSource:  blockHeadersURL,
+			FilterHeadersSource: filterHeadersURL,
+			HttpClient:          customClient,
+		}
+
+		blockSrc := opts.createBlockHeaderImportSrc()
+		httpSrc, ok := blockSrc.(*httpHeaderImportSource)
+		require.True(t, ok,
+			"block source should be httpHeaderImportSource")
+		require.Equal(t, customClient, httpSrc.httpClient,
+			"block HTTP source should use the injected client")
+
+		filterSrc := opts.createFilterHeaderImportSrc()
+		httpFilterSrc, ok := filterSrc.(*httpHeaderImportSource)
+		require.True(t, ok,
+			"filter source should be httpHeaderImportSource")
+		require.Equal(t, customClient, httpFilterSrc.httpClient,
+			"filter HTTP source should use the injected client")
+	})
+}

--- a/neutrino.go
+++ b/neutrino.go
@@ -661,6 +661,12 @@ type HeadersImportConfig struct {
 	// ValidationFlags specifies the behavior flags used during header
 	// validation. It defaults to BFNone.
 	ValidationFlags blockchain.BehaviorFlags
+
+	// HttpClient is an optional HTTP client for downloading headers from
+	// HTTP(s) sources. When set, this client is used instead of the
+	// default http.Client. This allows consumers to inject a
+	// proxy-configured client (e.g., SOCKS5 for Tor).
+	HttpClient chainimport.HttpClient
 }
 
 // peerSubscription holds a peer subscription which we'll notify about any
@@ -1672,6 +1678,7 @@ func (s *ChainService) Start(ctx context.Context) error {
 			TargetFilterHeaderStore: s.RegFilterHeaders,
 			ValidationFlags:         s.headersImport.ValidationFlags,
 			WriteBatchSizePerRegion: s.headersImport.WriteBatchSizePerRegion,
+			HttpClient:              s.headersImport.HttpClient,
 		}
 		importer, err := chainimport.NewHeadersImport(&options)
 		if err != nil {


### PR DESCRIPTION
This commit adds support for injecting a custom HTTP client in the chainimport package, enabling users to configure proxy settings (e.g., SOCKS5 for Tor) when downloading headers from HTTP(s) sources. The ImportOptions struct now includes an optional HttpClient field, and the header import sources use this client if provided, falling back to a default client otherwise. Additionally, tests have been added to verify this new functionality.