### PR TITLE
Update UserAgentVersion to 0.16.2

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -50,7 +50,7 @@ var (
 
 	// UserAgentVersion is the user agent version and is used to help
 	// identify ourselves to other bitcoin peers.
-	UserAgentVersion = "0.12.0-beta"
+	UserAgentVersion = "0.16.2"
 
 	// Services describes the services that are supported by the server.
 	Services = wire.SFNodeWitness | wire.SFNodeCF


### PR DESCRIPTION
The UserAgentVersion was stuck at "0.12.0-beta" and did not reflect the actual release version. Update it to match the latest release tag.

Fixes lightninglabs/neutrino#346