### PR TITLE
banman: support Tor v3 addresses

### DIFF
--- a/banman/codec.go
+++ b/banman/codec.go
@@ -5,40 +5,28 @@ import (
 	"net"
 )
 
-// ipType represents the different types of IP addresses supported by the
-// BanStore interface.
-type ipType = byte
-
-const (
-	// ipv4 represents an IP address of type IPv4.
-	ipv4 ipType = 0
-
-	// ipv6 represents an IP address of type IPv6.
-	ipv6 ipType = 1
-)
-
 // encodeIPNet serializes the IP network into the given reader.
 func encodeIPNet(w io.Writer, ipNet *net.IPNet) error {
-	// Determine the appropriate IP type for the IP address contained in the
+	// Determine the appropriate network for the IP address contained in the
 	// network.
 	var (
-		ip     []byte
-		ipType ipType
+		ip      []byte
+		network Network
 	)
 	switch {
 	case ipNet.IP.To4() != nil:
 		ip = ipNet.IP.To4()
-		ipType = ipv4
+		network = NetworkIPv4
 	case ipNet.IP.To16() != nil:
 		ip = ipNet.IP.To16()
-		ipType = ipv6
+		network = NetworkIPv6
 	default:
 		return ErrUnsupportedIP
 	}
 
-	// Write the IP type first in order to properly identify it when
+	// Write the network first in order to properly identify it when
 	// deserializing it, followed by the IP itself and its mask.
-	if _, err := w.Write([]byte{ipType}); err != nil {
+	if _, err := w.Write([]byte{byte(network)}); err != nil {
 		return err
 	}
 	if _, err := w.Write(ip); err != nil {
@@ -51,33 +39,78 @@ func encodeIPNet(w io.Writer, ipNet *net.IPNet) error {
 	return nil
 }
 
+// encodeKey serializes a ban key into the given writer.
+func encodeKey(w io.Writer, key *Key) error {
+	if key == nil {
+		return ErrUnsupportedIP
+	}
+
+	switch key.Net {
+	case NetworkIPv4, NetworkIPv6:
+		ipNet, err := keyToIPNet(key)
+		if err != nil {
+			return err
+		}
+
+		return encodeIPNet(w, ipNet)
+
+	default:
+		return ErrUnsupportedIP
+	}
+}
+
 // decodeIPNet deserialized an IP network from the given reader.
 func decodeIPNet(r io.Reader) (*net.IPNet, error) {
-	// Read the IP address type and determine whether it is supported.
-	var ipType [1]byte
-	if _, err := r.Read(ipType[:]); err != nil {
+	var network [1]byte
+	if _, err := io.ReadFull(r, network[:]); err != nil {
 		return nil, err
 	}
 
+	return decodeIPNetWithNetwork(r, Network(network[0]))
+}
+
+// decodeIPNetWithNetwork deserializes an IP network after its family byte has
+// already been read.
+func decodeIPNetWithNetwork(r io.Reader, network Network) (*net.IPNet, error) {
 	var ipLen int
-	switch ipType[0] {
-	case ipv4:
+	switch network {
+	case NetworkIPv4:
 		ipLen = net.IPv4len
-	case ipv6:
+	case NetworkIPv6:
 		ipLen = net.IPv6len
 	default:
 		return nil, ErrUnsupportedIP
 	}
 
-	// Once we have the type and its corresponding length, attempt to read
-	// it and its mask.
 	ip := make([]byte, ipLen)
-	if _, err := r.Read(ip); err != nil {
+	if _, err := io.ReadFull(r, ip); err != nil {
 		return nil, err
 	}
 	mask := make([]byte, ipLen)
-	if _, err := r.Read(mask); err != nil {
+	if _, err := io.ReadFull(r, mask); err != nil {
 		return nil, err
 	}
+
 	return &net.IPNet{IP: ip, Mask: mask}, nil
+}
+
+// decodeKey deserializes a ban key from the given reader.
+func decodeKey(r io.Reader) (*Key, error) {
+	var network [1]byte
+	if _, err := io.ReadFull(r, network[:]); err != nil {
+		return nil, err
+	}
+
+	switch Network(network[0]) {
+	case NetworkIPv4, NetworkIPv6:
+		ipNet, err := decodeIPNetWithNetwork(r, Network(network[0]))
+		if err != nil {
+			return nil, err
+		}
+
+		return keyFromIPNet(ipNet)
+
+	default:
+		return nil, ErrUnsupportedIP
+	}
 }

--- a/banman/codec.go
+++ b/banman/codec.go
@@ -54,6 +54,18 @@ func encodeKey(w io.Writer, key *Key) error {
 
 		return encodeIPNet(w, ipNet)
 
+	case NetworkTorV3:
+		if len(key.Addr) != torV3KeySize || len(key.Mask) != 0 {
+			return ErrUnsupportedIP
+		}
+
+		if _, err := w.Write([]byte{byte(key.Net)}); err != nil {
+			return err
+		}
+
+		_, err := w.Write(key.Addr)
+		return err
+
 	default:
 		return ErrUnsupportedIP
 	}
@@ -109,6 +121,17 @@ func decodeKey(r io.Reader) (*Key, error) {
 		}
 
 		return keyFromIPNet(ipNet)
+
+	case NetworkTorV3:
+		key := &Key{
+			Net:  NetworkTorV3,
+			Addr: make([]byte, torV3KeySize),
+		}
+		if _, err := io.ReadFull(r, key.Addr); err != nil {
+			return nil, err
+		}
+
+		return key, nil
 
 	default:
 		return nil, ErrUnsupportedIP

--- a/banman/codec_test.go
+++ b/banman/codec_test.go
@@ -201,6 +201,13 @@ func TestKeySerialization(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "torv3",
+			key: &Key{
+				Net:  NetworkTorV3,
+				Addr: testTorV3PubKey,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -217,4 +224,22 @@ func TestKeySerialization(t *testing.T) {
 			return
 		}
 	}
+}
+
+// TestTorV3KeyEncodingBytes ensures that Tor v3 keys retain their expected
+// on-disk encoding.
+func TestTorV3KeyEncodingBytes(t *testing.T) {
+	t.Parallel()
+
+	key := &Key{
+		Net:  NetworkTorV3,
+		Addr: testTorV3PubKey,
+	}
+
+	expected := append([]byte{0x02}, testTorV3PubKey...)
+
+	var b bytes.Buffer
+	err := encodeKey(&b, key)
+	require.NoError(t, err)
+	require.Equal(t, expected, b.Bytes())
 }

--- a/banman/codec_test.go
+++ b/banman/codec_test.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestIPNetSerialization ensures that we can serialize different supported IP
@@ -99,6 +101,117 @@ func TestIPNetSerialization(t *testing.T) {
 				t.Fatalf("expected mask %#v, got %#v",
 					testCase.ipNet.Mask, ipNet.Mask)
 			}
+		})
+		if !success {
+			return
+		}
+	}
+}
+
+// TestIPNetEncodingBytes ensures that IPv4 and IPv6 networks retain their
+// current on-disk encoding.
+func TestIPNetEncodingBytes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		ipNet   *net.IPNet
+		encoded []byte
+	}{
+		{
+			name: "ipv4",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("172.217.6.46"),
+				Mask: net.IPv4Mask(0xff, 0xff, 0x00, 0x00),
+			},
+			encoded: []byte{
+				0x00,
+				0xac, 0xd9, 0x06, 0x2e,
+				0xff, 0xff, 0x00, 0x00,
+			},
+		},
+		{
+			name: "ipv6",
+			ipNet: &net.IPNet{
+				IP: net.ParseIP("2001:db8:a0b:12f0::1"),
+				Mask: net.IPMask([]byte{
+					0xff, 0xff, 0x00, 0x00, 0x00, 0xff,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00,
+				}),
+			},
+			encoded: []byte{
+				0x01,
+				0x20, 0x01, 0x0d, 0xb8,
+				0x0a, 0x0b, 0x12, 0xf0,
+				0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x01,
+				0xff, 0xff, 0x00, 0x00,
+				0x00, 0xff, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		success := t.Run(testCase.name, func(t *testing.T) {
+			var b bytes.Buffer
+			err := encodeIPNet(&b, testCase.ipNet)
+			require.NoError(t, err)
+			require.Equal(t, testCase.encoded, b.Bytes())
+		})
+		if !success {
+			return
+		}
+	}
+}
+
+// TestKeySerialization ensures that typed ban keys round trip through the
+// codec.
+func TestKeySerialization(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		key  *Key
+	}{
+		{
+			name: "ipv4",
+			key: &Key{
+				Net:  NetworkIPv4,
+				Addr: []byte{0xac, 0xd9, 0x06, 0x2e},
+				Mask: []byte{0xff, 0xff, 0x00, 0x00},
+			},
+		},
+		{
+			name: "ipv6",
+			key: &Key{
+				Net: NetworkIPv6,
+				Addr: []byte{
+					0x20, 0x01, 0x0d, 0xb8,
+					0x0a, 0x0b, 0x12, 0xf0,
+					0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x01,
+				},
+				Mask: []byte{
+					0xff, 0xff, 0x00, 0x00, 0x00, 0xff,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		success := t.Run(testCase.name, func(t *testing.T) {
+			var b bytes.Buffer
+			err := encodeKey(&b, testCase.key)
+			require.NoError(t, err)
+
+			key, err := decodeKey(&b)
+			require.NoError(t, err)
+			require.Equal(t, testCase.key, key)
 		})
 		if !success {
 			return

--- a/banman/key.go
+++ b/banman/key.go
@@ -1,0 +1,117 @@
+package banman
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+)
+
+// Network identifies the address family represented by a ban key.
+//
+// NOTE: These values are part of the on-disk encoding and must remain stable.
+type Network byte
+
+const (
+	// NetworkIPv4 represents an IPv4 address and mask.
+	NetworkIPv4 Network = 0
+
+	// NetworkIPv6 represents an IPv6 address and mask.
+	NetworkIPv6 Network = 1
+)
+
+// String returns the human-readable name of a network.
+func (n Network) String() string {
+	switch n {
+	case NetworkIPv4:
+		return "ipv4"
+
+	case NetworkIPv6:
+		return "ipv6"
+
+	default:
+		return fmt.Sprintf("network(%d)", n)
+	}
+}
+
+// Key identifies a banned peer address.
+type Key struct {
+	// Net describes which address family is used by the key.
+	Net Network
+
+	// Addr contains the network-specific address payload.
+	Addr []byte
+
+	// Mask contains the network mask for IP-based keys.
+	Mask []byte
+}
+
+// String returns a human-readable representation of a ban key.
+func (k *Key) String() string {
+	if k == nil {
+		return "<nil>"
+	}
+
+	ipNet, err := keyToIPNet(k)
+	if err == nil {
+		return ipNet.String()
+	}
+
+	return fmt.Sprintf("%v:%x", k.Net, k.Addr)
+}
+
+// keyFromIPNet converts an IP network into a typed ban key.
+func keyFromIPNet(ipNet *net.IPNet) (*Key, error) {
+	if ipNet == nil {
+		return nil, ErrUnsupportedIP
+	}
+
+	switch {
+	case ipNet.IP.To4() != nil:
+		return &Key{
+			Net:  NetworkIPv4,
+			Addr: bytes.Clone(ipNet.IP.To4()),
+			Mask: bytes.Clone([]byte(ipNet.Mask)),
+		}, nil
+
+	case ipNet.IP.To16() != nil:
+		return &Key{
+			Net:  NetworkIPv6,
+			Addr: bytes.Clone(ipNet.IP.To16()),
+			Mask: bytes.Clone([]byte(ipNet.Mask)),
+		}, nil
+
+	default:
+		return nil, ErrUnsupportedIP
+	}
+}
+
+// keyToIPNet converts a typed key back into an IP network.
+func keyToIPNet(key *Key) (*net.IPNet, error) {
+	if key == nil {
+		return nil, ErrUnsupportedIP
+	}
+
+	switch key.Net {
+	case NetworkIPv4:
+		if len(key.Addr) != net.IPv4len ||
+			len(key.Mask) != net.IPv4len {
+
+			return nil, ErrUnsupportedIP
+		}
+
+	case NetworkIPv6:
+		if len(key.Addr) != net.IPv6len ||
+			len(key.Mask) != net.IPv6len {
+
+			return nil, ErrUnsupportedIP
+		}
+
+	default:
+		return nil, ErrUnsupportedIP
+	}
+
+	return &net.IPNet{
+		IP:   net.IP(bytes.Clone(key.Addr)),
+		Mask: net.IPMask(bytes.Clone(key.Mask)),
+	}, nil
+}

--- a/banman/key.go
+++ b/banman/key.go
@@ -17,6 +17,9 @@ const (
 
 	// NetworkIPv6 represents an IPv6 address and mask.
 	NetworkIPv6 Network = 1
+
+	// NetworkTorV3 represents a Tor v3 pubkey without a mask.
+	NetworkTorV3 Network = 2
 )
 
 // String returns the human-readable name of a network.
@@ -28,12 +31,15 @@ func (n Network) String() string {
 	case NetworkIPv6:
 		return "ipv6"
 
+	case NetworkTorV3:
+		return "torv3"
+
 	default:
 		return fmt.Sprintf("network(%d)", n)
 	}
 }
 
-// Key identifies a banned peer address.
+// Key identifies a banned peer address or overlay network identity.
 type Key struct {
 	// Net describes which address family is used by the key.
 	Net Network

--- a/banman/store.go
+++ b/banman/store.go
@@ -56,8 +56,8 @@ type Status struct {
 
 // Store is the store responsible for maintaining records of banned peer
 // identities. IP callers can continue to use IP networks to coalesce multiple
-// addresses that are likely to be correlated, while typed keys provide an
-// extensible on-disk representation.
+// addresses that are likely to be correlated, while overlay networks use typed
+// keys.
 type Store interface {
 	// BanIPNet creates a ban record for the IP network within the store for
 	// the given duration. A reason can also be provided to note why the IP

--- a/banman/store.go
+++ b/banman/store.go
@@ -23,14 +23,14 @@ var (
 	// banBucket is the main index in which we keep track of IP networks and
 	// their absolute expiration time.
 	//
-	// The key is the IP network host and the value is the absolute
+	// The key is the encoded ban key and the value is the absolute
 	// expiration time.
 	banBucket = []byte("ban-index")
 
-	// reasonBucket is an index in which we keep track of why an IP network
-	// was banned.
+	// reasonBucket is an index in which we keep track of why a peer
+	// identity was banned.
 	//
-	// The key is the IP network and the value is the Reason.
+	// The key is the encoded ban key and the value is the Reason.
 	reasonBucket = []byte("reason-index")
 
 	// ErrCorruptedStore is an error returned when we attempt to locate any
@@ -54,9 +54,10 @@ type Status struct {
 	Expiration time.Time
 }
 
-// Store is the store responsible for maintaining records of banned IP networks.
-// It uses IP networks, rather than single IP addresses, in order to coalesce
-// multiple IP addresses that are likely to be correlated.
+// Store is the store responsible for maintaining records of banned peer
+// identities. IP callers can continue to use IP networks to coalesce multiple
+// addresses that are likely to be correlated, while typed keys provide an
+// extensible on-disk representation.
 type Store interface {
 	// BanIPNet creates a ban record for the IP network within the store for
 	// the given duration. A reason can also be provided to note why the IP
@@ -64,11 +65,21 @@ type Store interface {
 	// is made after the ban expiration.
 	BanIPNet(*net.IPNet, Reason, time.Duration) error
 
+	// BanKey creates a ban record for a typed ban key within the store for
+	// the given duration.
+	BanKey(*Key, Reason, time.Duration) error
+
 	// Status returns the ban status for a given IP network.
 	Status(*net.IPNet) (Status, error)
 
+	// StatusKey returns the ban status for a given typed ban key.
+	StatusKey(*Key) (Status, error)
+
 	// UnbanIPNet removes the ban imposed on the specified peer.
 	UnbanIPNet(ipNet *net.IPNet) error
+
+	// UnbanKey removes the ban imposed on the specified typed ban key.
+	UnbanKey(*Key) error
 }
 
 // NewStore returns a Store backed by a database.
@@ -115,6 +126,19 @@ func newBanStore(db walletdb.DB) (*banStore, error) {
 // being banned. The record will exist until a call to Status is made after the
 // ban expiration.
 func (s *banStore) BanIPNet(ipNet *net.IPNet, reason Reason, duration time.Duration) error {
+	key, err := keyFromIPNet(ipNet)
+	if err != nil {
+		return err
+	}
+
+	return s.BanKey(key, reason, duration)
+}
+
+// BanKey creates a ban record for the typed ban key within the store for the
+// given duration.
+func (s *banStore) BanKey(key *Key, reason Reason,
+	duration time.Duration) error {
+
 	return walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
 		banStore := tx.ReadWriteBucket(banStoreBucket)
 		if banStore == nil {
@@ -129,18 +153,27 @@ func (s *banStore) BanIPNet(ipNet *net.IPNet, reason Reason, duration time.Durat
 			return ErrCorruptedStore
 		}
 
-		var ipNetBuf bytes.Buffer
-		if err := encodeIPNet(&ipNetBuf, ipNet); err != nil {
-			return fmt.Errorf("unable to encode %v: %v", ipNet, err)
+		k, err := serializeKey(key)
+		if err != nil {
+			return err
 		}
-		k := ipNetBuf.Bytes()
 
-		return addBannedIPNet(banIndex, reasonIndex, k, reason, duration)
+		return addBannedKey(banIndex, reasonIndex, k, reason, duration)
 	})
 }
 
 // UnbanIPNet removes a ban record for the IP network within the store.
 func (s *banStore) UnbanIPNet(ipNet *net.IPNet) error {
+	key, err := keyFromIPNet(ipNet)
+	if err != nil {
+		return err
+	}
+
+	return s.UnbanKey(key)
+}
+
+// UnbanKey removes a ban record for the typed ban key within the store.
+func (s *banStore) UnbanKey(key *Key) error {
 	err := walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
 		banStore := tx.ReadWriteBucket(banStoreBucket)
 		if banStore == nil {
@@ -157,36 +190,43 @@ func (s *banStore) UnbanIPNet(ipNet *net.IPNet) error {
 			return ErrCorruptedStore
 		}
 
-		var ipNetBuf bytes.Buffer
-		if err := encodeIPNet(&ipNetBuf, ipNet); err != nil {
-			return fmt.Errorf("unable to encode %v: %v", ipNet,
-				err)
+		k, err := serializeKey(key)
+		if err != nil {
+			return err
 		}
 
-		k := ipNetBuf.Bytes()
-
-		return removeBannedIPNet(banIndex, reasonIndex, k)
+		return removeBannedKey(banIndex, reasonIndex, k)
 	})
 
 	return err
 }
 
-// addBannedIPNet adds an entry to the ban store for the given IP network.
-func addBannedIPNet(banIndex, reasonIndex walletdb.ReadWriteBucket,
-	ipNetKey []byte, reason Reason, duration time.Duration) error {
+// addBannedKey adds an entry to the ban store for the given ban key.
+func addBannedKey(banIndex, reasonIndex walletdb.ReadWriteBucket,
+	key []byte, reason Reason, duration time.Duration) error {
 
 	var v [8]byte
 	banExpiration := time.Now().Add(duration)
 	byteOrder.PutUint64(v[:], uint64(banExpiration.Unix()))
 
-	if err := banIndex.Put(ipNetKey, v[:]); err != nil {
+	if err := banIndex.Put(key, v[:]); err != nil {
 		return err
 	}
-	return reasonIndex.Put(ipNetKey, []byte{byte(reason)})
+	return reasonIndex.Put(key, []byte{byte(reason)})
 }
 
 // Status returns the ban status for a given IP network.
 func (s *banStore) Status(ipNet *net.IPNet) (Status, error) {
+	key, err := keyFromIPNet(ipNet)
+	if err != nil {
+		return Status{}, err
+	}
+
+	return s.StatusKey(key)
+}
+
+// StatusKey returns the ban status for a given typed ban key.
+func (s *banStore) StatusKey(key *Key) (Status, error) {
 	var banStatus Status
 	err := walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
 		banStore := tx.ReadWriteBucket(banStoreBucket)
@@ -202,18 +242,17 @@ func (s *banStore) Status(ipNet *net.IPNet) (Status, error) {
 			return ErrCorruptedStore
 		}
 
-		var ipNetBuf bytes.Buffer
-		if err := encodeIPNet(&ipNetBuf, ipNet); err != nil {
-			return fmt.Errorf("unable to encode %v: %v", ipNet, err)
+		k, err := serializeKey(key)
+		if err != nil {
+			return err
 		}
-		k := ipNetBuf.Bytes()
 
 		status := fetchStatus(banIndex, reasonIndex, k)
 
-		// If the IP network's ban duration has expired, we can remove
-		// its entry from the store.
+		// If the ban duration has expired, we can remove its entry
+		// from the store.
 		if !time.Now().Before(status.Expiration) {
-			return removeBannedIPNet(banIndex, reasonIndex, k)
+			return removeBannedKey(banIndex, reasonIndex, k)
 		}
 
 		banStatus = status
@@ -244,13 +283,22 @@ func fetchStatus(banIndex, reasonIndex walletdb.ReadWriteBucket,
 	}
 }
 
-// removeBannedIPNet removes all references to a banned IP network within the
-// ban store.
-func removeBannedIPNet(banIndex, reasonIndex walletdb.ReadWriteBucket,
-	ipNetKey []byte) error {
+// removeBannedKey removes all references to a banned key within the ban store.
+func removeBannedKey(banIndex, reasonIndex walletdb.ReadWriteBucket,
+	key []byte) error {
 
-	if err := banIndex.Delete(ipNetKey); err != nil {
+	if err := banIndex.Delete(key); err != nil {
 		return err
 	}
-	return reasonIndex.Delete(ipNetKey)
+	return reasonIndex.Delete(key)
+}
+
+// serializeKey encodes a typed ban key into its on-disk representation.
+func serializeKey(key *Key) ([]byte, error) {
+	var keyBuf bytes.Buffer
+	if err := encodeKey(&keyBuf, key); err != nil {
+		return nil, fmt.Errorf("unable to encode %v: %v", key, err)
+	}
+
+	return keyBuf.Bytes(), nil
 }

--- a/banman/store.go
+++ b/banman/store.go
@@ -63,6 +63,8 @@ type Store interface {
 	// the given duration. A reason can also be provided to note why the IP
 	// network is being banned. The record will exist until a call to Status
 	// is made after the ban expiration.
+	//
+	// Deprecated: use BanKey.
 	BanIPNet(*net.IPNet, Reason, time.Duration) error
 
 	// BanKey creates a ban record for a typed ban key within the store for
@@ -70,12 +72,16 @@ type Store interface {
 	BanKey(*Key, Reason, time.Duration) error
 
 	// Status returns the ban status for a given IP network.
+	//
+	// Deprecated: use StatusKey.
 	Status(*net.IPNet) (Status, error)
 
 	// StatusKey returns the ban status for a given typed ban key.
 	StatusKey(*Key) (Status, error)
 
 	// UnbanIPNet removes the ban imposed on the specified peer.
+	//
+	// Deprecated: use UnbanKey.
 	UnbanIPNet(ipNet *net.IPNet) error
 
 	// UnbanKey removes the ban imposed on the specified typed ban key.

--- a/banman/store_test.go
+++ b/banman/store_test.go
@@ -73,7 +73,7 @@ func TestBanStore(t *testing.T) {
 			t.Fatalf("expected %v to not be banned", ipNet)
 		}
 
-		if banned {
+		if !banned {
 			return
 		}
 

--- a/banman/store_test.go
+++ b/banman/store_test.go
@@ -131,3 +131,45 @@ func TestBanStore(t *testing.T) {
 	// We would now check that ipNet1 is indeed unbanned.
 	checkBanStore(ipNet1, false, 0, 0)
 }
+
+// TestBanStoreKey ensures that the BanStore's key-based APIs correctly
+// persist IP address bans.
+func TestBanStoreKey(t *testing.T) {
+	t.Parallel()
+
+	banStore, cleanUp := createTestBanStore(t)
+	defer cleanUp()
+
+	key := &banman.Key{
+		Net:  banman.NetworkIPv4,
+		Addr: []byte{0x7f, 0x00, 0x00, 0x01},
+		Mask: []byte{0xff, 0xff, 0xff, 0xff},
+	}
+
+	err := banStore.BanKey(
+		key, banman.InvalidFilterHeader, time.Second,
+	)
+	require.NoError(t, err)
+
+	status, err := banStore.StatusKey(key)
+	require.NoError(t, err)
+	require.True(t, status.Banned)
+	require.Equal(t, banman.InvalidFilterHeader, status.Reason)
+	require.LessOrEqual(t, time.Until(status.Expiration), time.Second)
+
+	<-time.After(time.Second)
+
+	status, err = banStore.StatusKey(key)
+	require.NoError(t, err)
+	require.False(t, status.Banned)
+
+	err = banStore.BanKey(
+		key, banman.InvalidFilterHeaderCheckpoint, time.Hour,
+	)
+	require.NoError(t, err)
+	require.NoError(t, banStore.UnbanKey(key))
+
+	status, err = banStore.StatusKey(key)
+	require.NoError(t, err)
+	require.False(t, status.Banned)
+}

--- a/banman/store_test.go
+++ b/banman/store_test.go
@@ -173,3 +173,49 @@ func TestBanStoreKey(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, status.Banned)
 }
+
+// TestBanStoreTorV3Key ensures that the BanStore's key-based APIs correctly
+// persist overlay address bans.
+func TestBanStoreTorV3Key(t *testing.T) {
+	t.Parallel()
+
+	banStore, cleanUp := createTestBanStore(t)
+	defer cleanUp()
+
+	key := &banman.Key{
+		Net: banman.NetworkTorV3,
+		Addr: []byte{
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+			0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+		},
+	}
+
+	err := banStore.BanKey(
+		key, banman.InvalidFilterHeader, time.Second,
+	)
+	require.NoError(t, err)
+
+	status, err := banStore.StatusKey(key)
+	require.NoError(t, err)
+	require.True(t, status.Banned)
+	require.Equal(t, banman.InvalidFilterHeader, status.Reason)
+	require.LessOrEqual(t, time.Until(status.Expiration), time.Second)
+
+	<-time.After(time.Second)
+
+	status, err = banStore.StatusKey(key)
+	require.NoError(t, err)
+	require.False(t, status.Banned)
+
+	err = banStore.BanKey(
+		key, banman.InvalidFilterHeaderCheckpoint, time.Hour,
+	)
+	require.NoError(t, err)
+	require.NoError(t, banStore.UnbanKey(key))
+
+	status, err = banStore.StatusKey(key)
+	require.NoError(t, err)
+	require.False(t, status.Banned)
+}

--- a/banman/util.go
+++ b/banman/util.go
@@ -2,7 +2,13 @@ package banman
 
 import (
 	"bytes"
+	"encoding/base32"
+	"fmt"
 	"net"
+	"strings"
+
+	"github.com/btcsuite/btcd/wire"
+	"golang.org/x/crypto/sha3"
 )
 
 var (
@@ -17,6 +23,26 @@ var (
 	defaultIPv6Mask = net.CIDRMask(128, 128)
 )
 
+const (
+	// onionSuffix is the suffix shared by all Tor onion addresses.
+	onionSuffix = ".onion"
+
+	// torV3ChecksumPrefix is included in the Tor v3 checksum preimage.
+	torV3ChecksumPrefix = ".onion checksum"
+
+	// torV3Version identifies a Tor v3 address payload.
+	torV3Version = byte(0x03)
+
+	// torV3KeySize is the number of pubkey bytes encoded by a Tor v3 host.
+	torV3KeySize = wire.TorV3Size
+
+	// torV3ChecksumSize is the checksum length encoded in a Tor v3 host.
+	torV3ChecksumSize = 2
+
+	// torV3PayloadSize is the decoded Tor v3 payload size.
+	torV3PayloadSize = torV3KeySize + torV3ChecksumSize + 1
+)
+
 // ParseIPNet parses the IP network that contains the given address. An optional
 // mask can be provided, to expand the scope of the IP network, otherwise the
 // IP's default is used.
@@ -29,6 +55,20 @@ func ParseIPNet(addr string, mask net.IPMask) (*net.IPNet, error) {
 	}
 
 	return keyToIPNet(key)
+}
+
+// ParseAddr parses the peer address into a typed ban key.
+func ParseAddr(addr string) (*Key, error) {
+	host := strings.TrimSpace(parseHost(addr))
+	lowerHost := strings.ToLower(host)
+
+	switch {
+	case strings.HasSuffix(lowerHost, onionSuffix):
+		return parseTorV3Key(lowerHost)
+
+	default:
+		return parseIPKey(host, nil)
+	}
 }
 
 // parseHost extracts the host from an address, ignoring the port when present.
@@ -88,4 +128,59 @@ func parseIPKey(host string, mask net.IPMask) (*Key, error) {
 	default:
 		return nil, ErrUnsupportedIP
 	}
+}
+
+// parseTorV3Key parses a Tor v3 onion address into a typed ban key.
+//
+// TODO: this code is a better fit for btcd/addrmgr. Move it there.
+func parseTorV3Key(host string) (*Key, error) {
+	if len(host) != wire.TorV3EncodedSize {
+		return nil, fmt.Errorf("invalid tor v3 address length: %d",
+			len(host))
+	}
+
+	encodedHost := host[:len(host)-len(onionSuffix)]
+	payload, err := base32.StdEncoding.DecodeString(
+		strings.ToUpper(encodedHost),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tor v3 address: %w", err)
+	}
+	if len(payload) != torV3PayloadSize {
+		return nil, fmt.Errorf("invalid tor v3 payload length: %d",
+			len(payload))
+	}
+
+	pubKey := payload[:torV3KeySize]
+	checksum := payload[torV3KeySize : torV3KeySize+torV3ChecksumSize]
+	version := payload[torV3PayloadSize-1]
+
+	if version != torV3Version {
+		return nil, fmt.Errorf("invalid tor v3 version: %x", version)
+	}
+
+	expectedChecksum := torV3Checksum(pubKey)
+	if !bytes.Equal(checksum, expectedChecksum[:]) {
+		return nil, fmt.Errorf("invalid tor v3 checksum")
+	}
+
+	return &Key{
+		Net:  NetworkTorV3,
+		Addr: bytes.Clone(pubKey),
+	}, nil
+}
+
+// torV3Checksum computes the BIP-155 checksum for a Tor v3 pubkey.
+func torV3Checksum(pubKey []byte) [torV3ChecksumSize]byte {
+	h := sha3.New256()
+
+	// Write never returns an error, so there is no need to handle it.
+	h.Write([]byte(torV3ChecksumPrefix))
+	h.Write(pubKey)
+	h.Write([]byte{torV3Version})
+
+	var checksum [torV3ChecksumSize]byte
+	copy(checksum[:], h.Sum(nil))
+
+	return checksum
 }

--- a/banman/util.go
+++ b/banman/util.go
@@ -22,12 +22,7 @@ var (
 //
 // NOTE: This assumes that the address has already been resolved.
 func ParseIPNet(addr string, mask net.IPMask) (*net.IPNet, error) {
-	// If the address includes a port, we'll remove it.
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		// Address doesn't include a port.
-		host = addr
-	}
+	host := parseHost(addr)
 
 	// Parse the IP from the host to ensure it is supported.
 	ip := net.ParseIP(host)
@@ -45,4 +40,20 @@ func ParseIPNet(addr string, mask net.IPMask) (*net.IPNet, error) {
 	}
 
 	return &net.IPNet{IP: ip.Mask(mask), Mask: mask}, nil
+}
+
+// parseHost extracts the host from an address, ignoring the port when present.
+// It also strips IPv6 brackets so bracketed hosts behave the same with and
+// without an explicit port.
+func parseHost(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		return host[1 : len(host)-1]
+	}
+
+	return host
 }

--- a/banman/util.go
+++ b/banman/util.go
@@ -1,6 +1,7 @@
 package banman
 
 import (
+	"bytes"
 	"net"
 )
 
@@ -22,24 +23,12 @@ var (
 //
 // NOTE: This assumes that the address has already been resolved.
 func ParseIPNet(addr string, mask net.IPMask) (*net.IPNet, error) {
-	host := parseHost(addr)
-
-	// Parse the IP from the host to ensure it is supported.
-	ip := net.ParseIP(host)
-	switch {
-	case ip.To4() != nil:
-		if mask == nil {
-			mask = defaultIPv4Mask
-		}
-	case ip.To16() != nil:
-		if mask == nil {
-			mask = defaultIPv6Mask
-		}
-	default:
-		return nil, ErrUnsupportedIP
+	key, err := parseIPKey(parseHost(addr), mask)
+	if err != nil {
+		return nil, err
 	}
 
-	return &net.IPNet{IP: ip.Mask(mask), Mask: mask}, nil
+	return keyToIPNet(key)
 }
 
 // parseHost extracts the host from an address, ignoring the port when present.
@@ -56,4 +45,47 @@ func parseHost(addr string) string {
 	}
 
 	return host
+}
+
+// parseIPKey parses an IPv4 or IPv6 host into a typed ban key.
+func parseIPKey(host string, mask net.IPMask) (*Key, error) {
+	ip := net.ParseIP(host)
+	switch {
+	case ip.To4() != nil:
+		ip = ip.To4()
+		if mask == nil {
+			mask = defaultIPv4Mask
+		}
+
+		maskedIP := ip.Mask(mask)
+		if maskedIP == nil {
+			return nil, ErrUnsupportedIP
+		}
+
+		return &Key{
+			Net:  NetworkIPv4,
+			Addr: bytes.Clone(maskedIP),
+			Mask: bytes.Clone([]byte(mask)),
+		}, nil
+
+	case ip.To16() != nil:
+		ip = ip.To16()
+		if mask == nil {
+			mask = defaultIPv6Mask
+		}
+
+		maskedIP := ip.Mask(mask)
+		if maskedIP == nil {
+			return nil, ErrUnsupportedIP
+		}
+
+		return &Key{
+			Net:  NetworkIPv6,
+			Addr: bytes.Clone(maskedIP),
+			Mask: bytes.Clone([]byte(mask)),
+		}, nil
+
+	default:
+		return nil, ErrUnsupportedIP
+	}
 }

--- a/banman/util_test.go
+++ b/banman/util_test.go
@@ -4,6 +4,8 @@ import (
 	"net"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestParseIPNet ensures that we can parse different combinations of
@@ -86,4 +88,22 @@ func TestParseIPNet(t *testing.T) {
 			return
 		}
 	}
+}
+
+// TestParseIPNetBracketedIPv6WithoutPort ensures bracketed IPv6 addresses are
+// parsed consistently with and without an explicit port.
+func TestParseIPNetBracketedIPv6WithoutPort(t *testing.T) {
+	t.Parallel()
+
+	addrWithoutPort := "[2001:db8:a0b:12f0::1]"
+	addrWithPort := "[2001:db8:a0b:12f0::1]:8333"
+
+	ipNetWithoutPort, err := ParseIPNet(addrWithoutPort, nil)
+	require.NoError(t, err)
+
+	ipNetWithPort, err := ParseIPNet(addrWithPort, nil)
+	require.NoError(t, err)
+
+	require.True(t, ipNetWithoutPort.IP.Equal(ipNetWithPort.IP))
+	require.Equal(t, ipNetWithPort.Mask, ipNetWithoutPort.Mask)
 }

--- a/banman/util_test.go
+++ b/banman/util_test.go
@@ -3,9 +3,26 @@ package banman
 import (
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+)
+
+var testTorV3PubKey = []byte{
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+	0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+	0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+}
+
+const (
+	testTorV3Host = "aaaqeayeaudaocajbifqydiob4ibceqtcqkrmfyydenbwha5" +
+		"dyp3kead.onion"
+	testTorV3BadChecksumHost = "aaaqeayeaudaocajbifqydiob4ibceqtcqkrm" +
+		"fyydenbwha5dypqaaad.onion"
+	testTorV3BadVersionHost = "aaaqeayeaudaocajbifqydiob4ibceqtcqkrmf" +
+		"yydenbwha5dyp3keae.onion"
 )
 
 // TestParseIPNet ensures that we can parse different combinations of
@@ -106,4 +123,120 @@ func TestParseIPNetBracketedIPv6WithoutPort(t *testing.T) {
 
 	require.True(t, ipNetWithoutPort.IP.Equal(ipNetWithPort.IP))
 	require.Equal(t, ipNetWithPort.Mask, ipNetWithoutPort.Mask)
+}
+
+// TestParseIPNetRejectsTorV3 ensures the IP-only wrapper does not accept
+// overlay addresses.
+func TestParseIPNetRejectsTorV3(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseIPNet(testTorV3Host, nil)
+	require.Error(t, err)
+}
+
+// TestParseAddr ensures that peer addresses are parsed into typed ban keys.
+func TestParseAddr(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		addr   string
+		result *Key
+	}{
+		{
+			name: "ipv4 with default mask",
+			addr: "192.168.1.1",
+			result: &Key{
+				Net:  NetworkIPv4,
+				Addr: []byte{0xc0, 0xa8, 0x01, 0x01},
+				Mask: []byte(defaultIPv4Mask),
+			},
+		},
+		{
+			name: "ipv6 with default mask",
+			addr: "[2001:db8:a0b:12f0::1]:80",
+			result: &Key{
+				Net: NetworkIPv6,
+				Addr: []byte{
+					0x20, 0x01, 0x0d, 0xb8,
+					0x0a, 0x0b, 0x12, 0xf0,
+					0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x01,
+				},
+				Mask: []byte(defaultIPv6Mask),
+			},
+		},
+		{
+			name: "torv3 with port and mixed case",
+			addr: strings.ToUpper(testTorV3Host) + ":9735",
+			result: &Key{
+				Net:  NetworkTorV3,
+				Addr: testTorV3PubKey,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		success := t.Run(testCase.name, func(t *testing.T) {
+			key, err := ParseAddr(testCase.addr)
+			require.NoError(t, err)
+			require.Equal(t, testCase.result.Net, key.Net)
+			require.Equal(t, testCase.result.Addr, key.Addr)
+			require.Equal(t, testCase.result.Mask, key.Mask)
+		})
+		if !success {
+			return
+		}
+	}
+}
+
+// TestParseAddrRejectsInvalidTorV3 ensures malformed onion addresses are
+// rejected.
+func TestParseAddrRejectsInvalidTorV3(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		addr string
+	}{
+		{
+			name: "wrong length",
+			addr: "short.onion",
+		},
+		{
+			name: "bad checksum",
+			addr: testTorV3BadChecksumHost,
+		},
+		{
+			name: "bad version",
+			addr: testTorV3BadVersionHost,
+		},
+	}
+
+	for _, testCase := range testCases {
+		success := t.Run(testCase.name, func(t *testing.T) {
+			_, err := ParseAddr(testCase.addr)
+			require.Error(t, err)
+		})
+		if !success {
+			return
+		}
+	}
+}
+
+// TestParseAddrBracketedIPv6WithoutPort ensures bracketed IPv6 addresses are
+// parsed consistently with and without an explicit port.
+func TestParseAddrBracketedIPv6WithoutPort(t *testing.T) {
+	t.Parallel()
+
+	addrWithoutPort := "[2001:db8:a0b:12f0::1]"
+	addrWithPort := "[2001:db8:a0b:12f0::1]:8333"
+
+	keyWithoutPort, err := ParseAddr(addrWithoutPort)
+	require.NoError(t, err)
+
+	keyWithPort, err := ParseAddr(addrWithPort)
+	require.NoError(t, err)
+
+	require.Equal(t, keyWithPort, keyWithoutPort)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/lightninglabs/neutrino/cache v1.1.2
 	github.com/lightningnetwork/lnd/queue v1.0.1
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/crypto v0.22.0
 	golang.org/x/exp v0.0.0-20250811191247-51f88131bc50
 )
 
@@ -33,7 +34,6 @@ require (
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.etcd.io/bbolt v1.3.7 // indirect
-	golang.org/x/crypto v0.22.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/neutrino.go
+++ b/neutrino.go
@@ -1117,25 +1117,25 @@ func (s *ChainService) BanPeer(addr string, reason banman.Reason) error {
 		}()
 	}()
 
-	ipNet, err := banman.ParseIPNet(addr, nil)
+	key, err := banman.ParseAddr(addr)
 	if err != nil {
-		return fmt.Errorf("unable to parse IP network for peer %v: %v",
-			addr, err)
+		return fmt.Errorf("unable to parse peer address for peer %v: "+
+			"%v", addr, err)
 	}
-	return s.banStore.BanIPNet(ipNet, reason, BanDuration)
+	return s.banStore.BanKey(key, reason, BanDuration)
 }
 
 // UnbanPeer connects and unbans a previously banned peer.
 func (s *ChainService) UnbanPeer(addr string, parmanent bool) error {
 	log.Infof("UnBanning peer %v", addr)
 
-	ipNet, err := banman.ParseIPNet(addr, nil)
+	key, err := banman.ParseAddr(addr)
 	if err != nil {
-		return fmt.Errorf("unable to parse IP network for peer %v: %v",
-			addr, err)
+		return fmt.Errorf("unable to parse peer address for peer %v: "+
+			"%v", addr, err)
 	}
 
-	err = s.banStore.UnbanIPNet(ipNet)
+	err = s.banStore.UnbanKey(key)
 	if err != nil {
 		return fmt.Errorf("unable to unban peer: %v", err)
 	}
@@ -1145,13 +1145,13 @@ func (s *ChainService) UnbanPeer(addr string, parmanent bool) error {
 
 // IsBanned returns true if the peer is banned, and false otherwise.
 func (s *ChainService) IsBanned(addr string) bool {
-	ipNet, err := banman.ParseIPNet(addr, nil)
+	key, err := banman.ParseAddr(addr)
 	if err != nil {
-		log.Errorf("Unable to parse IP network for peer %v: %v", addr,
+		log.Errorf("Unable to parse peer address for peer %v: %v", addr,
 			err)
 		return false
 	}
-	banStatus, err := s.banStore.Status(ipNet)
+	banStatus, err := s.banStore.StatusKey(key)
 	if err != nil {
 		log.Errorf("Unable to determine ban status for peer %v: %v",
 			addr, err)


### PR DESCRIPTION
Currently neutrino's banman doesn't recognize Tor v3 addresses like "aaaqeayeaudaocajbifqydiob4ibceqtcqkrmfyydenbwha5dyp3kead.onion" of neutrino peers, they are not banned and can be tried again right after misbehaving.

```
[ERR] BTCN: Unable to parse IP network for peer xxx.onion:8333: unsupported IP type
```

This PR fixes this.

A key to ban already has a version byte in front. It had two values: 0 - for IPv4, 1 - for IPv6. I added 2 for Tor v3 addresses. After the version byte such a record had the main address bytes and its mask. Tor v3 addresses do not have masks, so the mask part is skipped. For the address bytes I put the EC key (ed25519) which is encoded in the Tor v3 address.

---

This is an alternative to https://github.com/lightninglabs/neutrino/pull/341
https://github.com/lightninglabs/neutrino/pull/341 translates Tor v3 addresses to IPv6 (OnionCat technique). It also works, but uses only 80 entropy bits of the address.