### PR TITLE
banman: add SQL backend implementation

### DIFF
--- a/banman/sql_store.go
+++ b/banman/sql_store.go
@@ -1,0 +1,194 @@
+package banman
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	sqldbv2 "github.com/lightningnetwork/lnd/sqldb/v2"
+
+	"github.com/lightninglabs/neutrino/sqldb"
+	"github.com/lightninglabs/neutrino/sqldb/sqlc"
+)
+
+// SQLBanStore is a SQL-backed implementation of the Store interface. It
+// stores peer bans in the banned_peers table provisioned by the neutrino SQL
+// migrations.
+type SQLBanStore struct {
+	db sqldb.BanTx
+
+	// mtx serialises access from concurrent callers so that observable
+	// semantics match the legacy walletdb-backed banStore: a Status call
+	// immediately following a BanIPNet always sees the new record.
+	mtx sync.Mutex
+}
+
+// A compile-time constraint to ensure SQLBanStore satisfies the Store
+// interface.
+var _ Store = (*SQLBanStore)(nil)
+
+// NewSQLStore returns a SQLBanStore that uses the provided BatchedTx for all
+// transactional access. The schema must already have been migrated by the
+// owning sqldb.Backend.
+func NewSQLStore(db sqldb.BanTx) (*SQLBanStore, error) {
+	if db == nil {
+		return nil, errors.New("nil ban tx executor")
+	}
+
+	return &SQLBanStore{db: db}, nil
+}
+
+// BanIPNet creates or refreshes a ban record for the given IP network. The
+// duration is added to the current time to derive the absolute expiration
+// stored in the database.
+//
+// NOTE: This method is part of the Store interface.
+func (s *SQLBanStore) BanIPNet(ipNet *net.IPNet, reason Reason,
+	duration time.Duration) error {
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	key, err := encodeIPNetKey(ipNet)
+	if err != nil {
+		return err
+	}
+
+	expiration := time.Now().Add(duration).UTC()
+
+	ctx := context.Background()
+	return s.db.ExecTx(
+		ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.BanQueries) error {
+			return q.UpsertBan(ctx, sqlc.UpsertBanParams{
+				IpNet:      key,
+				Expiration: expiration,
+				Reason:     int32(reason),
+			})
+		}, sqldbv2.NoOpReset,
+	)
+}
+
+// Status returns the current ban status for the given IP network. If a
+// previously-recorded ban has expired, Status sweeps the row from the table
+// in the same transaction and returns Banned: false.
+//
+// NOTE: This method is part of the Store interface.
+func (s *SQLBanStore) Status(ipNet *net.IPNet) (Status, error) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	key, err := encodeIPNetKey(ipNet)
+	if err != nil {
+		return Status{}, err
+	}
+
+	var status Status
+
+	ctx := context.Background()
+	err = s.db.ExecTx(
+		ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.BanQueries) error {
+			row, err := q.GetBan(ctx, key)
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+				status = Status{}
+				return nil
+
+			case err != nil:
+				return err
+			}
+
+			expiration := row.Expiration
+			if !time.Now().Before(expiration) {
+				// The ban has expired; remove the row in the
+				// same tx so the next caller observes a clean
+				// state.
+				if delErr := q.DeleteBan(ctx, key); delErr != nil {
+					return delErr
+				}
+
+				status = Status{}
+				return nil
+			}
+
+			status = Status{
+				Banned:     true,
+				Reason:     Reason(row.Reason),
+				Expiration: expiration,
+			}
+			return nil
+		}, sqldbv2.NoOpReset,
+	)
+	if err != nil {
+		return Status{}, err
+	}
+
+	return status, nil
+}
+
+// UnbanIPNet removes the ban record for the given IP network. It is a no-op
+// when no record exists for the network.
+//
+// NOTE: This method is part of the Store interface.
+func (s *SQLBanStore) UnbanIPNet(ipNet *net.IPNet) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	key, err := encodeIPNetKey(ipNet)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	return s.db.ExecTx(
+		ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.BanQueries) error {
+			return q.DeleteBan(ctx, key)
+		}, sqldbv2.NoOpReset,
+	)
+}
+
+// PurgeExpired sweeps every ban whose expiration has elapsed and returns the
+// number of rows removed. It is intended to be called opportunistically (for
+// example, at neutrino startup) to bound the size of the banned_peers table.
+func (s *SQLBanStore) PurgeExpired() (int64, error) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	var n int64
+	ctx := context.Background()
+	err := s.db.ExecTx(
+		ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.BanQueries) error {
+			rows, err := q.DeleteExpiredBans(ctx, time.Now().UTC())
+			if err != nil {
+				return err
+			}
+			n = rows
+			return nil
+		}, sqldbv2.NoOpReset,
+	)
+	return n, err
+}
+
+// encodeIPNetKey returns the canonical binary key used by both the legacy
+// walletdb and SQL ban stores. The format is byte-identical to the legacy
+// encoding so that the auto-migration can copy rows across without
+// re-encoding.
+func encodeIPNetKey(ipNet *net.IPNet) ([]byte, error) {
+	if ipNet == nil {
+		return nil, fmt.Errorf("nil IPNet")
+	}
+
+	var buf bytes.Buffer
+	if err := encodeIPNet(&buf, ipNet); err != nil {
+		return nil, fmt.Errorf("unable to encode %v: %w", ipNet, err)
+	}
+	return buf.Bytes(), nil
+}

--- a/banman/sql_store_test.go
+++ b/banman/sql_store_test.go
@@ -1,0 +1,207 @@
+package banman_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lightninglabs/neutrino/banman"
+	"github.com/lightninglabs/neutrino/sqldb"
+)
+
+// newSQLBanStore constructs a SQLBanStore backed by a fresh in-memory SQLite
+// database. The Backend is closed automatically at the end of the test.
+func newSQLBanStore(t *testing.T) *banman.SQLBanStore {
+	t.Helper()
+
+	backend := sqldb.NewTestBackend(t)
+	store, err := banman.NewSQLStore(backend.BanTxer)
+	require.NoError(t, err)
+	return store
+}
+
+// banStoreFactory wires a banman.Store implementation up for parameterized
+// tests so the same assertion bodies cover both backends. The kvdb factory
+// is the existing createTestBanStore from store_test.go.
+type banStoreFactory func(t *testing.T) banman.Store
+
+func banStoreFactories() map[string]banStoreFactory {
+	return map[string]banStoreFactory{
+		"kvdb": func(t *testing.T) banman.Store {
+			store, cleanup := createTestBanStore(t)
+			t.Cleanup(cleanup)
+			return store
+		},
+		"sqlite": func(t *testing.T) banman.Store {
+			return newSQLBanStore(t)
+		},
+	}
+}
+
+// TestBanStoreBackends runs the canonical BanStore lifecycle against every
+// supported backend so behaviour parity is verified at the test level.
+func TestBanStoreBackends(t *testing.T) {
+	t.Parallel()
+
+	for name, makeStore := range banStoreFactories() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			testBanStoreLifecycle(t, makeStore(t))
+		})
+	}
+}
+
+// testBanStoreLifecycle is the shared body of the lifecycle test. It exercises
+// banning, expiration sweep on read, repeated bans (idempotency), and
+// explicit unban.
+func testBanStoreLifecycle(t *testing.T, store banman.Store) {
+	t.Helper()
+
+	check := func(ipNet *net.IPNet, banned bool, reason banman.Reason,
+		within time.Duration) {
+
+		t.Helper()
+		status, err := store.Status(ipNet)
+		require.NoError(t, err)
+		require.Equal(t, banned, status.Banned)
+
+		if !banned {
+			return
+		}
+
+		require.Equal(t, reason, status.Reason)
+		remaining := time.Until(status.Expiration)
+		require.LessOrEqual(t, remaining, within)
+	}
+
+	ipNet1, err := banman.ParseIPNet("127.0.0.1:8333", nil)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		store.BanIPNet(ipNet1, banman.NoCompactFilters, time.Hour),
+	)
+
+	ipNet2, err := banman.ParseIPNet("192.168.1.1:8333", nil)
+	require.NoError(t, err)
+	require.NoError(
+		t, store.BanIPNet(
+			ipNet2, banman.ExceededBanThreshold, time.Second,
+		),
+	)
+
+	check(ipNet1, true, banman.NoCompactFilters, time.Hour)
+	check(ipNet2, true, banman.ExceededBanThreshold, time.Second)
+
+	// Wait for the second ban to elapse, then verify it has been swept.
+	time.Sleep(1100 * time.Millisecond)
+	check(ipNet1, true, banman.NoCompactFilters, time.Hour)
+	check(ipNet2, false, 0, 0)
+
+	// Repeating Status on a swept entry must continue to report unbanned.
+	check(ipNet2, false, 0, 0)
+
+	// Explicit unban removes the active entry.
+	require.NoError(t, store.UnbanIPNet(ipNet1))
+	check(ipNet1, false, 0, 0)
+}
+
+// TestSQLBanIdempotent verifies that repeated BanIPNet calls for the same
+// network refresh the existing row instead of inserting a duplicate.
+func TestSQLBanIdempotent(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLBanStore(t)
+	ipNet, err := banman.ParseIPNet("10.0.0.1:8333", nil)
+	require.NoError(t, err)
+
+	require.NoError(t,
+		store.BanIPNet(ipNet, banman.ExceededBanThreshold, time.Hour),
+	)
+	first, err := store.Status(ipNet)
+	require.NoError(t, err)
+	require.True(t, first.Banned)
+
+	// Re-ban with a different reason and a longer duration. The row must
+	// be updated in place.
+	require.NoError(t, store.BanIPNet(
+		ipNet, banman.InvalidBlock, 2*time.Hour,
+	))
+	second, err := store.Status(ipNet)
+	require.NoError(t, err)
+	require.True(t, second.Banned)
+	require.Equal(t, banman.InvalidBlock, second.Reason)
+	require.True(t, second.Expiration.After(first.Expiration))
+}
+
+// TestSQLBanIPv6 verifies that IPv6 addresses round-trip through the SQL
+// backend with the binary IPNet encoding intact.
+func TestSQLBanIPv6(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLBanStore(t)
+	ipNet, err := banman.ParseIPNet("[2001:db8::1]:8333", nil)
+	require.NoError(t, err)
+
+	require.NoError(
+		t,
+		store.BanIPNet(ipNet, banman.NoCompactFilters, time.Minute),
+	)
+	status, err := store.Status(ipNet)
+	require.NoError(t, err)
+	require.True(t, status.Banned)
+	require.Equal(t, banman.NoCompactFilters, status.Reason)
+}
+
+// TestSQLBanExpirationSweep verifies that a ban whose duration is already
+// non-positive is treated as expired the first time Status is read.
+func TestSQLBanExpirationSweep(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLBanStore(t)
+	ipNet, err := banman.ParseIPNet("10.0.0.2:8333", nil)
+	require.NoError(t, err)
+
+	// Ban for a tiny duration so expiration is effectively immediate.
+	require.NoError(
+		t,
+		store.BanIPNet(ipNet, banman.ExceededBanThreshold, 0),
+	)
+
+	status, err := store.Status(ipNet)
+	require.NoError(t, err)
+	require.False(t, status.Banned)
+
+	// A second Status should also report unbanned (the row was removed).
+	status, err = store.Status(ipNet)
+	require.NoError(t, err)
+	require.False(t, status.Banned)
+}
+
+// TestSQLBanPurgeExpired verifies the bulk-sweep helper.
+func TestSQLBanPurgeExpired(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLBanStore(t)
+
+	for i, addr := range []string{
+		"10.0.0.10:8333", "10.0.0.11:8333", "10.0.0.12:8333",
+	} {
+		ipNet, err := banman.ParseIPNet(addr, nil)
+		require.NoError(t, err)
+
+		// Half are already expired, half are not.
+		duration := -time.Hour
+		if i%2 == 0 {
+			duration = time.Hour
+		}
+		require.NoError(t, store.BanIPNet(
+			ipNet, banman.NoCompactFilters, duration,
+		))
+	}
+
+	purged, err := store.PurgeExpired()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), purged)
+}


### PR DESCRIPTION
In this PR, we add `SQLBanStore`, the SQL-backed implementation of the
existing `banman.Store` interface. It's the smallest of the four
domains in the SQL stack (just three methods) so it makes a useful
sanity check on the house style before we tackle the more involved
header and filter stores.

The store is wired via the `BanTx` executor that landed in the previous
PR. Every method dispatches a single `ExecTx` so the entire body of the
operation runs as one serialisable transaction with automatic retry on
serialization-or-deadlock errors. The on-the-wire IPNet key format is
preserved verbatim from `banman/codec.go::encodeIPNet`, so when the
legacy importer in PR 5 walks the bbolt `ban-index` bucket it can copy
rows straight across without re-encoding anything.

## Stack

This is PR 2 of 6 in the SQL backend stack. Stacks on top of #352.

## Sweep on read

The legacy `banStore.Status` deletes any expired record in the same
write tx that read it, so a caller never sees a stale `Banned: true`
return for an IP whose ban has elapsed. We carry that semantic over
exactly: `SQLBanStore.Status` runs as a write tx, fetches the row, and
if `time.Now()` is past the stored expiration, deletes the row before
returning `Status{Banned: false}`. Doing both reads and the delete in
one tx avoids the read-then-delete race that would show up if we split
them.

A small `sync.Mutex` guards the public methods. The SQL engine's
isolation is enough for correctness on its own, but the legacy bbolt
store is observably linearizable from a Go caller's perspective: a
`Status` immediately following a successful `BanIPNet` always sees the
new record. Keeping the mutex preserves that contract for callers like
the connection manager that rely on it.

## Tests

The existing `TestBanStore` body is refactored into a parameterised
helper that runs against both backends via a small factory map (`kvdb`
+ `sqlite`). `TestBanStoreBackends` covers ban, expiration sweep,
explicit unban, and the post-sweep idempotent return. SQL-specific
tests verify upsert idempotency on repeat ban (with a longer duration
correctly extending the existing record), IPv6 round-tripping through
`encodeIPNet`, and the bulk `PurgeExpired` helper that callers can call
opportunistically at startup to bound the size of the `banned_peers`
table.

```go
type SQLBanStore struct {
    db  sqldb.BanTx
    mtx sync.Mutex
}

var _ Store = (*SQLBanStore)(nil)
```