### PR TITLE
filterdb: add SQL backend implementation

### DIFF
--- a/filterdb/sql_store.go
+++ b/filterdb/sql_store.go
@@ -1,0 +1,227 @@
+package filterdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/btcsuite/btcd/btcutil/gcs"
+	"github.com/btcsuite/btcd/btcutil/gcs/builder"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	sqldbv2 "github.com/lightningnetwork/lnd/sqldb/v2"
+
+	"github.com/lightninglabs/neutrino/sqldb"
+	"github.com/lightninglabs/neutrino/sqldb/sqlc"
+)
+
+// SQLFilterStore is a SQL-backed implementation of the FilterDatabase
+// interface.
+//
+// The store is keyed exclusively by block hash because the only filter type
+// neutrino currently uses is RegularFilter; the schema reflects this and the
+// generated queries operate against the regular_filters table directly.
+type SQLFilterStore struct {
+	db          sqldb.FilterTx
+	chainParams chaincfg.Params
+
+	mtx sync.RWMutex
+}
+
+// A compile-time constraint to ensure SQLFilterStore satisfies the
+// FilterDatabase interface.
+var _ FilterDatabase = (*SQLFilterStore)(nil)
+
+// NewSQLFilterStore returns a new SQLFilterStore. The caller is expected to
+// have already migrated the schema via sqldb.NewBackend; this constructor
+// only ensures the genesis filter exists, mirroring the legacy walletdb
+// constructor.
+func NewSQLFilterStore(ctx context.Context, db sqldb.FilterTx,
+	params chaincfg.Params) (*SQLFilterStore, error) {
+
+	if db == nil {
+		return nil, errors.New("nil filter tx executor")
+	}
+
+	store := &SQLFilterStore{
+		db:          db,
+		chainParams: params,
+	}
+
+	if err := store.ensureGenesis(ctx); err != nil {
+		return nil, err
+	}
+
+	return store, nil
+}
+
+// ensureGenesis writes the genesis basic filter row if the regular_filters
+// table is empty for the genesis block. It is idempotent and safe to call on
+// every start.
+func (f *SQLFilterStore) ensureGenesis(ctx context.Context) error {
+	genesisBlock := f.chainParams.GenesisBlock
+	genesisHash := f.chainParams.GenesisHash
+
+	basicFilter, err := builder.BuildBasicFilter(genesisBlock, nil)
+	if err != nil {
+		return fmt.Errorf("build genesis filter: %w", err)
+	}
+
+	filterBytes, err := basicFilter.NBytes()
+	if err != nil {
+		return fmt.Errorf("encode genesis filter: %w", err)
+	}
+
+	return f.db.ExecTx(ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.FilterQueries) error {
+			_, err := q.GetFilter(ctx, genesisHash[:])
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+				return q.PutFilter(ctx, sqlc.PutFilterParams{
+					BlockHash:   genesisHash[:],
+					FilterBytes: filterBytes,
+				})
+
+			case err != nil:
+				return err
+
+			default:
+				// Genesis row already present.
+				return nil
+			}
+		}, sqldbv2.NoOpReset)
+}
+
+// PutFilters stores the supplied filters atomically. Filters with an unknown
+// type cause the entire batch to fail with an error matching the legacy
+// walletdb implementation.
+//
+// NOTE: This method is part of the FilterDatabase interface.
+func (f *SQLFilterStore) PutFilters(filterList ...*FilterData) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	if len(filterList) == 0 {
+		return nil
+	}
+
+	// Validate types up front so we don't begin a tx for a definitively
+	// invalid call.
+	for _, fd := range filterList {
+		if fd.Type != RegularFilter {
+			return fmt.Errorf("unknown filter type: %v", fd.Type)
+		}
+	}
+
+	ctx := context.Background()
+	return f.db.ExecTx(ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.FilterQueries) error {
+			for _, fd := range filterList {
+				bytes, err := encodeFilter(fd.Filter)
+				if err != nil {
+					return err
+				}
+
+				err = q.PutFilter(ctx, sqlc.PutFilterParams{
+					BlockHash:   fd.BlockHash[:],
+					FilterBytes: bytes,
+				})
+				if err != nil {
+					return err
+				}
+
+				log.Tracef("Wrote filter for block %s, "+
+					"type %d", fd.BlockHash, fd.Type)
+			}
+
+			return nil
+		}, sqldbv2.NoOpReset)
+}
+
+// FetchFilter loads a filter from persistent storage. It distinguishes
+// between three cases, matching the legacy walletdb semantics:
+//   - row absent: return ErrFilterNotFound.
+//   - row present, value zero-length: return (nil, nil) — the "deleted
+//     filter" sentinel.
+//   - row present, value populated: deserialize via gcs.FromNBytes.
+//
+// NOTE: This method is part of the FilterDatabase interface.
+func (f *SQLFilterStore) FetchFilter(blockHash *chainhash.Hash,
+	filterType FilterType) (*gcs.Filter, error) {
+
+	if filterType != RegularFilter {
+		return nil, fmt.Errorf("unknown filter type")
+	}
+
+	f.mtx.RLock()
+	defer f.mtx.RUnlock()
+
+	var (
+		filter *gcs.Filter
+		ctx    = context.Background()
+	)
+	err := f.db.ExecTx(ctx, sqldbv2.ReadTxOpt(),
+		func(q sqldb.FilterQueries) error {
+			bytes, err := q.GetFilter(ctx, blockHash[:])
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+				return ErrFilterNotFound
+
+			case err != nil:
+				return err
+			}
+
+			if len(bytes) == 0 {
+				// "Deleted filter" sentinel.
+				return nil
+			}
+
+			f, err := gcs.FromNBytes(
+				builder.DefaultP, builder.DefaultM, bytes,
+			)
+			if err != nil {
+				return err
+			}
+			filter = f
+			return nil
+		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return nil, err
+	}
+
+	return filter, nil
+}
+
+// PurgeFilters drops every filter of the given type. The legacy walletdb
+// implementation deletes and recreates the per-type bucket without
+// re-seeding the genesis filter; we match that by not re-inserting genesis
+// here.
+//
+// NOTE: This method is part of the FilterDatabase interface.
+func (f *SQLFilterStore) PurgeFilters(fType FilterType) error {
+	if fType != RegularFilter {
+		return fmt.Errorf("unknown filter type: %v", fType)
+	}
+
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	ctx := context.Background()
+	return f.db.ExecTx(ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.FilterQueries) error {
+			return q.PurgeRegularFilters(ctx)
+		}, sqldbv2.NoOpReset)
+}
+
+// encodeFilter serialises a (possibly nil) gcs.Filter into bytes. A nil
+// filter is encoded as a zero-length byte slice — the "deleted filter"
+// sentinel preserved for compatibility with the legacy walletdb store.
+func encodeFilter(f *gcs.Filter) ([]byte, error) {
+	if f == nil {
+		return []byte{}, nil
+	}
+
+	return f.NBytes()
+}

--- a/filterdb/sql_store_test.go
+++ b/filterdb/sql_store_test.go
@@ -1,0 +1,204 @@
+package filterdb
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lightninglabs/neutrino/sqldb"
+)
+
+// newSQLFilterStore returns a SQLFilterStore backed by a fresh in-memory
+// SQLite database.
+func newSQLFilterStore(t *testing.T) *SQLFilterStore {
+	t.Helper()
+
+	backend := sqldb.NewTestBackend(t)
+	store, err := NewSQLFilterStore(
+		context.Background(), backend.FilterTxer,
+		chaincfg.SimNetParams,
+	)
+	require.NoError(t, err)
+	return store
+}
+
+// filterStoreFactory wires a FilterDatabase implementation up for
+// parameterized tests. The kvdb factory reuses createTestDatabase from
+// db_test.go.
+type filterStoreFactory func(t *testing.T) FilterDatabase
+
+func filterStoreFactories() map[string]filterStoreFactory {
+	return map[string]filterStoreFactory{
+		"kvdb":   func(t *testing.T) FilterDatabase { return createTestDatabase(t) },
+		"sqlite": func(t *testing.T) FilterDatabase { return newSQLFilterStore(t) },
+	}
+}
+
+// TestFilterStoreBackends covers the genesis filter creation and the basic
+// store-and-fetch round-trip across both backends.
+func TestFilterStoreBackends(t *testing.T) {
+	t.Parallel()
+
+	for name, makeStore := range filterStoreFactories() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			store := makeStore(t)
+			testGenesisFilter(t, store)
+			testFilterRoundTrip(t, store)
+		})
+	}
+}
+
+func testGenesisFilter(t *testing.T, store FilterDatabase) {
+	t.Helper()
+
+	genesisHash := chaincfg.SimNetParams.GenesisHash
+	regGenesisFilter, err := store.FetchFilter(genesisHash, RegularFilter)
+	require.NoError(t, err)
+	require.NotNil(t, regGenesisFilter)
+}
+
+func testFilterRoundTrip(t *testing.T, store FilterDatabase) {
+	t.Helper()
+
+	var randHash chainhash.Hash
+	_, err := rand.Read(randHash[:])
+	require.NoError(t, err)
+
+	regFilter := genRandFilter(t, 100)
+	require.NoError(t, store.PutFilters(&FilterData{
+		Filter:    regFilter,
+		BlockHash: &randHash,
+		Type:      RegularFilter,
+	}))
+
+	got, err := store.FetchFilter(&randHash, RegularFilter)
+	require.NoError(t, err)
+	require.Equal(t, regFilter, got)
+}
+
+// TestSQLFilterStoreNilSentinel verifies that storing a nil filter and then
+// fetching it returns (nil, nil), matching the legacy "deleted filter"
+// sentinel semantics. ErrFilterNotFound must NOT be returned for a row that
+// is present but holds a zero-length value.
+func TestSQLFilterStoreNilSentinel(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLFilterStore(t)
+
+	var randHash chainhash.Hash
+	_, err := rand.Read(randHash[:])
+	require.NoError(t, err)
+
+	require.NoError(t, store.PutFilters(&FilterData{
+		Filter:    nil,
+		BlockHash: &randHash,
+		Type:      RegularFilter,
+	}))
+
+	got, err := store.FetchFilter(&randHash, RegularFilter)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+// TestSQLFilterStoreNotFound verifies that an absent row maps to
+// ErrFilterNotFound.
+func TestSQLFilterStoreNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLFilterStore(t)
+
+	var randHash chainhash.Hash
+	_, err := rand.Read(randHash[:])
+	require.NoError(t, err)
+
+	_, err = store.FetchFilter(&randHash, RegularFilter)
+	require.ErrorIs(t, err, ErrFilterNotFound)
+}
+
+// TestSQLFilterStorePurge inserts several filters, purges the table, and
+// verifies that all entries (including the genesis filter) become absent —
+// matching the legacy bucket-recreate semantics.
+func TestSQLFilterStorePurge(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLFilterStore(t)
+
+	hashes := make([]chainhash.Hash, 5)
+	filters := make([]*FilterData, 5)
+	for i := range hashes {
+		_, err := rand.Read(hashes[i][:])
+		require.NoError(t, err)
+
+		filters[i] = &FilterData{
+			Filter:    genRandFilter(t, 50),
+			BlockHash: &hashes[i],
+			Type:      RegularFilter,
+		}
+	}
+	require.NoError(t, store.PutFilters(filters...))
+
+	require.NoError(t, store.PurgeFilters(RegularFilter))
+
+	for i := range hashes {
+		_, err := store.FetchFilter(&hashes[i], RegularFilter)
+		require.ErrorIs(t, err, ErrFilterNotFound)
+	}
+
+	// Even the genesis row, which the constructor seeded, must be gone:
+	// the legacy walletdb impl drops and recreates the per-type bucket
+	// without re-seeding genesis, and we faithfully match that.
+	genesisHash := chaincfg.SimNetParams.GenesisHash
+	_, err := store.FetchFilter(genesisHash, RegularFilter)
+	require.ErrorIs(t, err, ErrFilterNotFound)
+}
+
+// TestSQLFilterStoreUnknownType ensures that unsupported FilterType values
+// produce an error rather than silently ignoring the row.
+func TestSQLFilterStoreUnknownType(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLFilterStore(t)
+
+	var randHash chainhash.Hash
+	_, err := rand.Read(randHash[:])
+	require.NoError(t, err)
+
+	bogus := FilterType(99)
+	_, err = store.FetchFilter(&randHash, bogus)
+	require.Error(t, err)
+
+	err = store.PurgeFilters(bogus)
+	require.Error(t, err)
+}
+
+// TestSQLFilterStoreGenesisIdempotent verifies that constructing the SQL
+// filter store twice against the same database leaves a single genesis row.
+func TestSQLFilterStoreGenesisIdempotent(t *testing.T) {
+	t.Parallel()
+
+	backend := sqldb.NewTestBackend(t)
+
+	_, err := NewSQLFilterStore(
+		context.Background(), backend.FilterTxer,
+		chaincfg.SimNetParams,
+	)
+	require.NoError(t, err)
+
+	store, err := NewSQLFilterStore(
+		context.Background(), backend.FilterTxer,
+		chaincfg.SimNetParams,
+	)
+	require.NoError(t, err)
+
+	got, err := store.FetchFilter(
+		chaincfg.SimNetParams.GenesisHash, RegularFilter,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+}


### PR DESCRIPTION
In this PR, we add `SQLFilterStore`, the SQL-backed implementation of
`filterdb.FilterDatabase`. It mirrors the legacy bbolt store's contract
exactly, including the three subtle distinctions between an absent
filter, a present-but-nil-sentinel filter, and the
delete-and-recreate-without-reseeding behaviour of `PurgeFilters`.

## Stack

This is PR 3 of 6 in the SQL backend stack. Stacks on top of #353.

## The three states

Three different conditions can be observed when looking up a filter,
and each has a distinct return:

- **Row absent.** `GetFilter` returns `sql.ErrNoRows`, which the store
  maps to `ErrFilterNotFound`. This is the same behaviour as the bbolt
  store returning `nil` from `bucket.Get` for a missing key.
- **Row present, value zero-length.** This is the legacy "deleted
  filter" sentinel: the bbolt store writes a zero-length value via
  `bucket.Put(hash, nil)`, and the SQL store coerces that to an empty
  byte slice (so the `NOT NULL filter_bytes` column accepts the row).
  `FetchFilter` returns `(nil, nil)` here, matching the existing
  contract that callers like the batch writer rely on.
- **Row present, value populated.** Standard path: deserialise via
  `gcs.FromNBytes` and return the filter.

The `PurgeFilters` method drops every row of the chosen type without
re-seeding genesis, which exactly matches the bbolt
delete-and-recreate-bucket pattern that the existing test suite
encodes. The current production code only ever uses `RegularFilter`, so
there's no `filter_type` column in the schema; if a second type ever
shows up we add it via a follow-up migration that introduces the
column.

## Genesis

Genesis filter creation runs once at construction inside a single write
tx. The check is `GetFilter(genesisHash) → sql.ErrNoRows` followed by a
`PutFilter` in the same tx, so two processes racing on first start can
never both win and end up with two genesis rows.

## Tests

The existing `db_test.go` cases are refactored into a parameterised
suite (`kvdb` + `sqlite`) that exercises genesis creation and
store-and-fetch round-tripping against both backends. SQL-specific
tests cover the nil-sentinel round-trip, the `ErrFilterNotFound`
absent-row mapping, the purge contract (genesis included), the
`unknown filter type` error path on both `FetchFilter` and
`PurgeFilters`, and the constructor's idempotency on repeat
construction against the same DB.