### PR TITLE
headerfs: add SQL backend implementation

### DIFF
--- a/headerfs/sql_store.go
+++ b/headerfs/sql_store.go
@@ -1,0 +1,961 @@
+package headerfs
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil/gcs/builder"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	sqldbv2 "github.com/lightningnetwork/lnd/sqldb/v2"
+
+	"github.com/lightninglabs/neutrino/sqldb"
+	"github.com/lightninglabs/neutrino/sqldb/sqlc"
+)
+
+// SQLBlockHeaderStore is a SQL-backed implementation of BlockHeaderStore.
+type SQLBlockHeaderStore struct {
+	db          sqldb.HeaderTx
+	chainParams *chaincfg.Params
+
+	// mtx preserves the linearizable semantics that callers like
+	// blockmanager rely on: a ChainTip immediately following a
+	// successful WriteHeaders must observe the new tip.
+	mtx sync.RWMutex
+}
+
+// A compile-time check to ensure SQLBlockHeaderStore satisfies the
+// BlockHeaderStore interface.
+var _ BlockHeaderStore = (*SQLBlockHeaderStore)(nil)
+
+// NewSQLBlockHeaderStore returns a new SQL-backed block header store. On a
+// freshly-migrated database it inserts the genesis row before returning.
+func NewSQLBlockHeaderStore(ctx context.Context, db sqldb.HeaderTx,
+	netParams *chaincfg.Params) (*SQLBlockHeaderStore, error) {
+
+	if db == nil {
+		return nil, errors.New("nil header tx executor")
+	}
+
+	store := &SQLBlockHeaderStore{
+		db:          db,
+		chainParams: netParams,
+	}
+
+	if err := store.ensureGenesis(ctx); err != nil {
+		return nil, err
+	}
+
+	return store, nil
+}
+
+// ensureGenesis writes the genesis block header row into block_headers if
+// the table is empty. The check + insert run inside a single tx so multiple
+// processes racing on first start cannot insert duplicate genesis rows.
+func (s *SQLBlockHeaderStore) ensureGenesis(ctx context.Context) error {
+	header := s.chainParams.GenesisBlock.Header
+	hash := header.BlockHash()
+
+	var raw bytes.Buffer
+	if err := header.Serialize(&raw); err != nil {
+		return fmt.Errorf("serialize genesis block header: %w", err)
+	}
+
+	return s.db.ExecTx(ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			n, err := q.CountBlockHeaders(ctx)
+			if err != nil {
+				return err
+			}
+			if n > 0 {
+				return nil
+			}
+
+			if err := q.InsertBlockHeader(
+				ctx, sqlc.InsertBlockHeaderParams{
+					Height:    0,
+					BlockHash: hash[:],
+					RawHeader: raw.Bytes(),
+				},
+			); err != nil {
+				return err
+			}
+
+			return q.UpsertChainTip(
+				ctx, sqlc.UpsertChainTipParams{
+					ChainType: sqldb.ChainTypeBlock,
+					TipHash:   hash[:],
+					TipHeight: 0,
+				},
+			)
+		}, sqldbv2.NoOpReset)
+}
+
+// ChainTip returns the current chain tip's header and height.
+//
+// NOTE: Part of the BlockHeaderStore interface.
+func (s *SQLBlockHeaderStore) ChainTip() (*wire.BlockHeader, uint32, error) {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	var (
+		header *wire.BlockHeader
+		height uint32
+		ctx    = context.Background()
+	)
+	err := s.db.ExecTx(ctx, sqldbv2.ReadTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			tip, err := q.GetChainTip(ctx, sqldb.ChainTypeBlock)
+			if err != nil {
+				return err
+			}
+
+			raw, err := q.GetBlockHeaderByHeight(ctx, tip.TipHeight)
+			if err != nil {
+				return err
+			}
+
+			h, err := decodeBlockHeader(raw)
+			if err != nil {
+				return err
+			}
+
+			header = h
+			height = uint32(tip.TipHeight)
+			return nil
+		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("unable to fetch chain tip: %w", err)
+	}
+
+	return header, height, nil
+}
+
+// FetchHeaderByHeight returns the block header at the requested height.
+//
+// NOTE: Part of the BlockHeaderStore interface.
+func (s *SQLBlockHeaderStore) FetchHeaderByHeight(height uint32) (
+	*wire.BlockHeader, error) {
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	var (
+		header *wire.BlockHeader
+		ctx    = context.Background()
+	)
+	err := s.db.ExecTx(ctx, sqldbv2.ReadTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			raw, err := q.GetBlockHeaderByHeight(
+				ctx, int64(height),
+			)
+			if err != nil {
+				return mapHeaderNotFound(err)
+			}
+
+			h, err := decodeBlockHeader(raw)
+			if err != nil {
+				return err
+			}
+			header = h
+			return nil
+		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return nil, err
+	}
+
+	return header, nil
+}
+
+// FetchHeader returns the block header for a given hash along with its
+// height in the chain.
+//
+// NOTE: Part of the BlockHeaderStore interface.
+func (s *SQLBlockHeaderStore) FetchHeader(hash *chainhash.Hash) (
+	*wire.BlockHeader, uint32, error) {
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	var (
+		header *wire.BlockHeader
+		height uint32
+		ctx    = context.Background()
+	)
+	err := s.db.ExecTx(ctx, sqldbv2.ReadTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			row, err := q.GetBlockHeaderByHash(ctx, hash[:])
+			if err != nil {
+				return mapHeaderNotFound(err)
+			}
+
+			h, err := decodeBlockHeader(row.RawHeader)
+			if err != nil {
+				return err
+			}
+			header = h
+			height = uint32(row.Height)
+			return nil
+		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return header, height, nil
+}
+
+// HeightFromHash returns the height of the given block hash.
+//
+// NOTE: Part of the BlockHeaderStore interface.
+func (s *SQLBlockHeaderStore) HeightFromHash(hash *chainhash.Hash) (uint32,
+	error) {
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	var (
+		height uint32
+		ctx    = context.Background()
+	)
+	err := s.db.ExecTx(ctx, sqldbv2.ReadTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			h, err := q.GetBlockHeaderHeightByHash(ctx, hash[:])
+			if err != nil {
+				return mapHeaderNotFound(err)
+			}
+			height = uint32(h)
+			return nil
+		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return 0, err
+	}
+	return height, nil
+}
+
+// FetchHeaderAncestors returns the numHeaders headers preceding stopHash plus
+// the stopHash header itself, for a total of numHeaders+1 headers. It also
+// returns the starting height of the returned range.
+//
+// NOTE: Part of the BlockHeaderStore interface.
+func (s *SQLBlockHeaderStore) FetchHeaderAncestors(numHeaders uint32,
+	stopHash *chainhash.Hash) ([]wire.BlockHeader, uint32, error) {
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	var (
+		headers     []wire.BlockHeader
+		startHeight uint32
+		ctx         = context.Background()
+	)
+
+	err := s.db.ExecTx(ctx, sqldbv2.ReadTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			endHeight, err := q.GetBlockHeaderHeightByHash(
+				ctx, stopHash[:],
+			)
+			if err != nil {
+				return mapHeaderNotFound(err)
+			}
+			if uint32(endHeight) < numHeaders {
+				return fmt.Errorf("cannot fetch %d ancestors "+
+					"of header at height %d",
+					numHeaders, endHeight)
+			}
+
+			startHeight = uint32(endHeight) - numHeaders
+
+			rows, err := q.GetBlockHeaderRange(
+				ctx, sqlc.GetBlockHeaderRangeParams{
+					StartHeight: int64(startHeight),
+					EndHeight:   endHeight,
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			headers = make([]wire.BlockHeader, len(rows))
+			for i, r := range rows {
+				h, err := decodeBlockHeader(r.RawHeader)
+				if err != nil {
+					return err
+				}
+				headers[i] = *h
+			}
+			return nil
+		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return nil, 0, err
+	}
+	return headers, startHeight, nil
+}
+
+// LatestBlockLocator returns a block locator anchored at the chain tip.
+//
+// NOTE: Part of the BlockHeaderStore interface.
+func (s *SQLBlockHeaderStore) LatestBlockLocator() (blockchain.BlockLocator,
+	error) {
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	var (
+		locator blockchain.BlockLocator
+		ctx     = context.Background()
+	)
+
+	err := s.db.ExecTx(ctx, sqldbv2.ReadTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			tip, err := q.GetChainTip(ctx, sqldb.ChainTypeBlock)
+			if err != nil {
+				return err
+			}
+
+			tipHash, err := chainhash.NewHash(tip.TipHash)
+			if err != nil {
+				return err
+			}
+			locator = append(locator, tipHash)
+
+			height := uint32(tip.TipHeight)
+			if height == 0 {
+				return nil
+			}
+
+			decrement := uint32(1)
+			for height > 0 &&
+				len(locator) < wire.MaxBlockLocatorsPerMsg {
+
+				if len(locator) > 10 {
+					decrement *= 2
+				}
+				if decrement > height {
+					height = 0
+				} else {
+					height -= decrement
+				}
+
+				raw, err := q.GetBlockHeaderByHeight(
+					ctx, int64(height),
+				)
+				if err != nil {
+					return err
+				}
+				h, err := decodeBlockHeader(raw)
+				if err != nil {
+					return err
+				}
+				bh := h.BlockHash()
+				locator = append(locator, &bh)
+			}
+			return nil
+		}, sqldbv2.NoOpReset)
+	return locator, err
+}
+
+// WriteHeaders inserts the given headers atomically and updates the chain
+// tip pointer to the highest header in the batch.
+//
+// NOTE: Part of the BlockHeaderStore interface.
+func (s *SQLBlockHeaderStore) WriteHeaders(hdrs ...BlockHeader) error {
+	if len(hdrs) == 0 {
+		return nil
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	ctx := context.Background()
+	return s.db.ExecTx(ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			var lastHash chainhash.Hash
+			var lastHeight uint32
+
+			for _, hdr := range hdrs {
+				var raw bytes.Buffer
+				if err := hdr.Serialize(&raw); err != nil {
+					return err
+				}
+				hash := hdr.BlockHash()
+
+				err := q.InsertBlockHeader(
+					ctx, sqlc.InsertBlockHeaderParams{
+						Height:    int64(hdr.Height),
+						BlockHash: hash[:],
+						RawHeader: raw.Bytes(),
+					},
+				)
+				if err != nil {
+					return err
+				}
+
+				lastHash = hash
+				lastHeight = hdr.Height
+			}
+
+			return q.UpsertChainTip(
+				ctx, sqlc.UpsertChainTipParams{
+					ChainType: sqldb.ChainTypeBlock,
+					TipHash:   lastHash[:],
+					TipHeight: int64(lastHeight),
+				},
+			)
+		}, sqldbv2.NoOpReset)
+}
+
+// RollbackBlockHeaders deletes the n most recent headers and resets the
+// chain tip to the previous height. Returns a BlockStamp describing the new
+// tip.
+//
+// NOTE: Part of the BlockHeaderStore interface.
+func (s *SQLBlockHeaderStore) RollbackBlockHeaders(n uint32) (*BlockStamp,
+	error) {
+
+	if n == 0 {
+		return &BlockStamp{}, nil
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	var (
+		stamp BlockStamp
+		ctx   = context.Background()
+	)
+	err := s.db.ExecTx(ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			tip, err := q.GetChainTip(ctx, sqldb.ChainTypeBlock)
+			if err != nil {
+				return err
+			}
+			tipHeight := uint32(tip.TipHeight)
+			if n > tipHeight {
+				return fmt.Errorf("cannot roll back %d "+
+					"headers when chain height is %d", n,
+					tipHeight)
+			}
+
+			newTipHeight := tipHeight - n
+
+			raw, err := q.GetBlockHeaderByHeight(
+				ctx, int64(newTipHeight),
+			)
+			if err != nil {
+				return err
+			}
+			newTipHeader, err := decodeBlockHeader(raw)
+			if err != nil {
+				return err
+			}
+			newTipHash := newTipHeader.BlockHash()
+
+			err = q.DeleteBlockHeadersFromHeight(
+				ctx, int64(newTipHeight),
+			)
+			if err != nil {
+				return err
+			}
+
+			err = q.UpsertChainTip(
+				ctx, sqlc.UpsertChainTipParams{
+					ChainType: sqldb.ChainTypeBlock,
+					TipHash:   newTipHash[:],
+					TipHeight: int64(newTipHeight),
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			stamp = BlockStamp{
+				Height:    int32(newTipHeight),
+				Hash:      newTipHash,
+				Timestamp: newTipHeader.Timestamp,
+			}
+			return nil
+		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return nil, err
+	}
+	return &stamp, nil
+}
+
+// RollbackLastBlock removes a single header from the tip.
+//
+// NOTE: Part of the BlockHeaderStore interface.
+func (s *SQLBlockHeaderStore) RollbackLastBlock() (*BlockStamp, error) {
+	return s.RollbackBlockHeaders(1)
+}
+
+// SQLFilterHeaderStore is a SQL-backed implementation of FilterHeaderStore.
+type SQLFilterHeaderStore struct {
+	db          sqldb.HeaderTx
+	chainParams *chaincfg.Params
+	indexType   HeaderType
+
+	mtx sync.RWMutex
+}
+
+// A compile-time check to ensure SQLFilterHeaderStore satisfies the
+// FilterHeaderStore interface.
+var _ FilterHeaderStore = (*SQLFilterHeaderStore)(nil)
+
+// NewSQLFilterHeaderStore returns a new SQL-backed filter header store. On a
+// fresh DB it inserts the genesis filter header row. When headerStateAssertion
+// is non-nil and the asserted height is present but does not match, the
+// store transactionally purges every filter header row and re-seeds genesis.
+func NewSQLFilterHeaderStore(ctx context.Context, db sqldb.HeaderTx,
+	filterType HeaderType, netParams *chaincfg.Params,
+	headerStateAssertion *FilterHeader) (*SQLFilterHeaderStore, error) {
+
+	if db == nil {
+		return nil, errors.New("nil header tx executor")
+	}
+	if filterType != RegularFilter {
+		return nil, fmt.Errorf("unknown filter type: %v", filterType)
+	}
+
+	store := &SQLFilterHeaderStore{
+		db:          db,
+		chainParams: netParams,
+		indexType:   filterType,
+	}
+
+	if err := store.ensureGenesis(ctx); err != nil {
+		return nil, err
+	}
+
+	if headerStateAssertion != nil {
+		if err := store.maybeReset(ctx, headerStateAssertion); err != nil {
+			return nil, err
+		}
+	}
+
+	return store, nil
+}
+
+// ensureGenesis seeds the filter_headers table and chain_tips row when the
+// table is empty.
+func (s *SQLFilterHeaderStore) ensureGenesis(ctx context.Context) error {
+	genesisHash, genesisFilterHash, err := s.computeGenesis()
+	if err != nil {
+		return err
+	}
+
+	return s.db.ExecTx(ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			n, err := q.CountFilterHeaders(ctx)
+			if err != nil {
+				return err
+			}
+			if n > 0 {
+				return nil
+			}
+
+			err = q.InsertFilterHeader(
+				ctx, sqlc.InsertFilterHeaderParams{
+					Height:     0,
+					BlockHash:  genesisHash[:],
+					FilterHash: genesisFilterHash[:],
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			return q.UpsertChainTip(
+				ctx, sqlc.UpsertChainTipParams{
+					ChainType: sqldb.ChainTypeFilter,
+					TipHash:   genesisFilterHash[:],
+					TipHeight: 0,
+				},
+			)
+		}, sqldbv2.NoOpReset)
+}
+
+// maybeReset performs the equivalent of the legacy maybeResetHeaderState,
+// but transactionally. If the asserted height is missing the assertion is a
+// no-op; if the asserted filter hash differs from the stored value, every
+// row in filter_headers is purged and genesis is re-seeded — all within one
+// SQL transaction.
+func (s *SQLFilterHeaderStore) maybeReset(ctx context.Context,
+	assertion *FilterHeader) error {
+
+	genesisHash, genesisFilterHash, err := s.computeGenesis()
+	if err != nil {
+		return err
+	}
+
+	return s.db.ExecTx(ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			row, err := q.GetFilterHeaderByHeight(
+				ctx, int64(assertion.Height),
+			)
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+				// Asserted height is not yet known. Mirroring
+				// the legacy behaviour, we treat this as a
+				// no-op rather than an error.
+				return nil
+
+			case err != nil:
+				return err
+			}
+
+			var stored chainhash.Hash
+			copy(stored[:], row.FilterHash)
+			if stored == assertion.FilterHash {
+				return nil
+			}
+
+			// Assertion mismatch: purge and re-seed genesis.
+			if err := q.PurgeFilterHeaders(ctx); err != nil {
+				return err
+			}
+			if err := q.DeleteChainTip(
+				ctx, sqldb.ChainTypeFilter,
+			); err != nil {
+				return err
+			}
+
+			err = q.InsertFilterHeader(
+				ctx, sqlc.InsertFilterHeaderParams{
+					Height:     0,
+					BlockHash:  genesisHash[:],
+					FilterHash: genesisFilterHash[:],
+				},
+			)
+			if err != nil {
+				return err
+			}
+			return q.UpsertChainTip(
+				ctx, sqlc.UpsertChainTipParams{
+					ChainType: sqldb.ChainTypeFilter,
+					TipHash:   genesisFilterHash[:],
+					TipHeight: 0,
+				},
+			)
+		}, sqldbv2.NoOpReset)
+}
+
+// computeGenesis returns the genesis block hash and the genesis filter
+// header hash for the configured chain.
+func (s *SQLFilterHeaderStore) computeGenesis() (chainhash.Hash, chainhash.Hash,
+	error) {
+
+	var zero chainhash.Hash
+
+	basicFilter, err := builder.BuildBasicFilter(
+		s.chainParams.GenesisBlock, nil,
+	)
+	if err != nil {
+		return zero, zero, err
+	}
+
+	genesisFilterHash, err := builder.MakeHeaderForFilter(
+		basicFilter, s.chainParams.GenesisBlock.Header.PrevBlock,
+	)
+	if err != nil {
+		return zero, zero, err
+	}
+
+	return *s.chainParams.GenesisHash, genesisFilterHash, nil
+}
+
+// ChainTip returns the tip filter header hash and height.
+//
+// NOTE: Part of the FilterHeaderStore interface.
+func (s *SQLFilterHeaderStore) ChainTip() (*chainhash.Hash, uint32, error) {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	var (
+		hash   chainhash.Hash
+		height uint32
+		ctx    = context.Background()
+	)
+	err := s.db.ExecTx(ctx, sqldbv2.ReadTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			tip, err := q.GetChainTip(ctx, sqldb.ChainTypeFilter)
+			if err != nil {
+				return err
+			}
+			h, err := chainhash.NewHash(tip.TipHash)
+			if err != nil {
+				return err
+			}
+			hash = *h
+			height = uint32(tip.TipHeight)
+			return nil
+		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("unable to fetch chain tip: %w", err)
+	}
+
+	return &hash, height, nil
+}
+
+// FetchHeader returns the filter header for the given block hash.
+//
+// NOTE: Part of the FilterHeaderStore interface.
+func (s *SQLFilterHeaderStore) FetchHeader(hash *chainhash.Hash) (
+	*chainhash.Hash, error) {
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	var (
+		out chainhash.Hash
+		ctx = context.Background()
+	)
+	err := s.db.ExecTx(ctx, sqldbv2.ReadTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			row, err := q.GetFilterHeaderByBlockHash(ctx, hash[:])
+			if err != nil {
+				return mapHeaderNotFound(err)
+			}
+			h, err := chainhash.NewHash(row.FilterHash)
+			if err != nil {
+				return err
+			}
+			out = *h
+			return nil
+		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// FetchHeaderByHeight returns the filter header at a specific block height.
+//
+// NOTE: Part of the FilterHeaderStore interface.
+func (s *SQLFilterHeaderStore) FetchHeaderByHeight(height uint32) (
+	*chainhash.Hash, error) {
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	var (
+		out chainhash.Hash
+		ctx = context.Background()
+	)
+	err := s.db.ExecTx(ctx, sqldbv2.ReadTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			row, err := q.GetFilterHeaderByHeight(
+				ctx, int64(height),
+			)
+			if err != nil {
+				return mapHeaderNotFound(err)
+			}
+			h, err := chainhash.NewHash(row.FilterHash)
+			if err != nil {
+				return err
+			}
+			out = *h
+			return nil
+		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// FetchHeaderAncestors returns numHeaders ancestors of stopHash plus stopHash
+// itself, for a total of numHeaders+1 entries, along with the starting
+// height.
+//
+// NOTE: Part of the FilterHeaderStore interface.
+func (s *SQLFilterHeaderStore) FetchHeaderAncestors(numHeaders uint32,
+	stopHash *chainhash.Hash) ([]chainhash.Hash, uint32, error) {
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	var (
+		out         []chainhash.Hash
+		startHeight uint32
+		ctx         = context.Background()
+	)
+	err := s.db.ExecTx(ctx, sqldbv2.ReadTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			row, err := q.GetFilterHeaderByBlockHash(
+				ctx, stopHash[:],
+			)
+			if err != nil {
+				return mapHeaderNotFound(err)
+			}
+			endHeight := uint32(row.Height)
+			if endHeight < numHeaders {
+				return fmt.Errorf("cannot fetch %d "+
+					"ancestors of filter header at "+
+					"height %d", numHeaders, endHeight)
+			}
+			startHeight = endHeight - numHeaders
+
+			rows, err := q.GetFilterHeaderRange(
+				ctx, sqlc.GetFilterHeaderRangeParams{
+					StartHeight: int64(startHeight),
+					EndHeight:   int64(endHeight),
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			out = make([]chainhash.Hash, len(rows))
+			for i, r := range rows {
+				h, err := chainhash.NewHash(r.FilterHash)
+				if err != nil {
+					return err
+				}
+				out[i] = *h
+			}
+			return nil
+		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return nil, 0, err
+	}
+	return out, startHeight, nil
+}
+
+// WriteHeaders inserts a batch of filter headers atomically and updates the
+// chain tip pointer.
+//
+// NOTE: Part of the FilterHeaderStore interface.
+func (s *SQLFilterHeaderStore) WriteHeaders(hdrs ...FilterHeader) error {
+	if len(hdrs) == 0 {
+		return nil
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	ctx := context.Background()
+	return s.db.ExecTx(ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			var (
+				tipHash   chainhash.Hash
+				tipHeight uint32
+			)
+			for _, hdr := range hdrs {
+				err := q.InsertFilterHeader(
+					ctx, sqlc.InsertFilterHeaderParams{
+						Height:     int64(hdr.Height),
+						BlockHash:  hdr.HeaderHash[:],
+						FilterHash: hdr.FilterHash[:],
+					},
+				)
+				if err != nil {
+					return err
+				}
+				tipHash = hdr.FilterHash
+				tipHeight = hdr.Height
+			}
+
+			return q.UpsertChainTip(
+				ctx, sqlc.UpsertChainTipParams{
+					ChainType: sqldb.ChainTypeFilter,
+					TipHash:   tipHash[:],
+					TipHeight: int64(tipHeight),
+				},
+			)
+		}, sqldbv2.NoOpReset)
+}
+
+// RollbackLastBlock removes the most recent filter header and updates the
+// chain tip to point at newTip.
+//
+// NOTE: Part of the FilterHeaderStore interface.
+func (s *SQLFilterHeaderStore) RollbackLastBlock(
+	newTip *chainhash.Hash) (*BlockStamp, error) {
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	var (
+		stamp BlockStamp
+		ctx   = context.Background()
+	)
+	err := s.db.ExecTx(ctx, sqldbv2.WriteTxOpt(),
+		func(q sqldb.HeaderQueries) error {
+			tip, err := q.GetChainTip(ctx, sqldb.ChainTypeFilter)
+			if err != nil {
+				return err
+			}
+			if tip.TipHeight == 0 {
+				return errors.New("cannot roll back filter " +
+					"header chain past genesis")
+			}
+
+			newHeight := tip.TipHeight - 1
+
+			row, err := q.GetFilterHeaderByHeight(ctx, newHeight)
+			if err != nil {
+				return err
+			}
+			prevHash, err := chainhash.NewHash(row.FilterHash)
+			if err != nil {
+				return err
+			}
+
+			err = q.DeleteFilterHeadersFromHeight(ctx, newHeight)
+			if err != nil {
+				return err
+			}
+
+			tipHash := prevHash[:]
+			if newTip != nil {
+				tipHash = newTip[:]
+			}
+
+			err = q.UpsertChainTip(
+				ctx, sqlc.UpsertChainTipParams{
+					ChainType: sqldb.ChainTypeFilter,
+					TipHash:   tipHash,
+					TipHeight: newHeight,
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			stamp = BlockStamp{
+				Height: int32(newHeight),
+				Hash:   *prevHash,
+			}
+			return nil
+		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return nil, err
+	}
+	return &stamp, nil
+}
+
+// decodeBlockHeader deserializes the raw 80-byte representation of a block
+// header. It returns a heap-allocated *wire.BlockHeader to match the existing
+// interface return shape.
+func decodeBlockHeader(raw []byte) (*wire.BlockHeader, error) {
+	var hdr wire.BlockHeader
+	if err := hdr.Deserialize(bytes.NewReader(raw)); err != nil {
+		return nil, err
+	}
+	return &hdr, nil
+}
+
+// mapHeaderNotFound translates sql.ErrNoRows into the headerfs-specific
+// ErrHeaderNotFound type so callers can use the existing type assertion
+// pattern (`if _, ok := err.(*ErrHeaderNotFound); ok { ... }`).
+func mapHeaderNotFound(err error) error {
+	if errors.Is(err, sql.ErrNoRows) {
+		return &ErrHeaderNotFound{err}
+	}
+	return err
+}

--- a/headerfs/sql_store_test.go
+++ b/headerfs/sql_store_test.go
@@ -1,0 +1,293 @@
+package headerfs
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lightninglabs/neutrino/sqldb"
+)
+
+// newSQLBlockHeaderStore creates a SQLBlockHeaderStore backed by a fresh
+// in-memory SQLite database. It uses the SimNet chain params to match the
+// chain context used by the existing kvdb-based test helpers.
+func newSQLBlockHeaderStore(t *testing.T) *SQLBlockHeaderStore {
+	t.Helper()
+
+	backend := sqldb.NewTestBackend(t)
+	store, err := NewSQLBlockHeaderStore(
+		context.Background(), backend.HeaderTxer,
+		&chaincfg.SimNetParams,
+	)
+	require.NoError(t, err)
+	return store
+}
+
+// newSQLFilterHeaderStore creates a SQLFilterHeaderStore against a fresh
+// SQLite database.
+func newSQLFilterHeaderStore(t *testing.T,
+	assertion *FilterHeader) *SQLFilterHeaderStore {
+
+	t.Helper()
+
+	backend := sqldb.NewTestBackend(t)
+	store, err := NewSQLFilterHeaderStore(
+		context.Background(), backend.HeaderTxer, RegularFilter,
+		&chaincfg.SimNetParams, assertion,
+	)
+	require.NoError(t, err)
+	return store
+}
+
+// TestSQLBlockHeaderStoreOperations is a SQL analog of
+// TestBlockHeaderStoreOperations. It writes a header chain and verifies
+// reads, ChainTip, and rollback semantics.
+func TestSQLBlockHeaderStoreOperations(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLBlockHeaderStore(t)
+
+	const numHeaders = 100
+	blockHeaders := createTestBlockHeaderChain(numHeaders)
+
+	require.NoError(t, store.WriteHeaders(blockHeaders...))
+
+	last := blockHeaders[len(blockHeaders)-1]
+	tipHeader, tipHeight, err := store.ChainTip()
+	require.NoError(t, err)
+	require.True(t, reflect.DeepEqual(last.BlockHeader, tipHeader))
+	require.Equal(t, last.Height, tipHeight)
+
+	for _, hdr := range blockHeaders {
+		got, err := store.FetchHeaderByHeight(hdr.Height)
+		require.NoError(t, err)
+		require.True(t, reflect.DeepEqual(*hdr.BlockHeader, *got),
+			"FetchHeaderByHeight mismatch at height %d: %s",
+			hdr.Height, spew.Sdump(got))
+
+		blockHash := hdr.BlockHash()
+		gotByHash, gotHeight, err := store.FetchHeader(&blockHash)
+		require.NoError(t, err)
+		require.True(t, reflect.DeepEqual(*hdr.BlockHeader, *gotByHash))
+		require.Equal(t, hdr.Height, gotHeight)
+	}
+
+	// Rollback by one and verify tip moves to the second-to-last header.
+	secondToLast := blockHeaders[len(blockHeaders)-2]
+	stamp, err := store.RollbackLastBlock()
+	require.NoError(t, err)
+	require.Equal(t, int32(secondToLast.Height), stamp.Height)
+	stlHash := secondToLast.BlockHash()
+	require.Equal(t, stlHash[:], stamp.Hash[:])
+
+	tipHeader, tipHeight, err = store.ChainTip()
+	require.NoError(t, err)
+	require.True(t, reflect.DeepEqual(secondToLast.BlockHeader, tipHeader))
+	require.Equal(t, secondToLast.Height, tipHeight)
+}
+
+// TestSQLBlockHeaderRollbackAtomic verifies that a failed WriteHeaders batch
+// does not leave any rows behind (full transactional rollback).
+func TestSQLBlockHeaderRollbackAtomic(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLBlockHeaderStore(t)
+
+	chain := createTestBlockHeaderChain(10)
+	require.NoError(t, store.WriteHeaders(chain[:5]...))
+
+	// Now construct a batch where the second header collides on height
+	// with an already-inserted row. The legacy bdb impl rolls back the
+	// full batch on failure. With SQL we get the same atomicity for free
+	// from the surrounding transaction.
+	collide := chain[3] // height 4, already inserted
+	collide.Height = chain[7].Height
+	bad := []BlockHeader{chain[5], collide}
+
+	err := store.WriteHeaders(bad...)
+	require.Error(t, err)
+
+	// Tip must still be at height 5 (the last successful write), and
+	// height 6 must NOT be present (the first insert in the failed batch).
+	tip, height, err := store.ChainTip()
+	require.NoError(t, err)
+	require.Equal(t, chain[4].Height, height)
+	require.True(t, reflect.DeepEqual(chain[4].BlockHeader, tip))
+
+	_, err = store.FetchHeaderByHeight(chain[5].Height)
+	require.Error(t, err)
+}
+
+// TestSQLBlockHeaderGenesisIdempotent verifies that constructing the SQL
+// block header store twice against the same database leaves a single
+// genesis row.
+func TestSQLBlockHeaderGenesisIdempotent(t *testing.T) {
+	t.Parallel()
+
+	backend := sqldb.NewTestBackend(t)
+
+	_, err := NewSQLBlockHeaderStore(
+		context.Background(), backend.HeaderTxer,
+		&chaincfg.SimNetParams,
+	)
+	require.NoError(t, err)
+
+	store, err := NewSQLBlockHeaderStore(
+		context.Background(), backend.HeaderTxer,
+		&chaincfg.SimNetParams,
+	)
+	require.NoError(t, err)
+
+	tip, height, err := store.ChainTip()
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), height)
+	require.NotNil(t, tip)
+	expectedHash := chaincfg.SimNetParams.GenesisHash
+	tipHash := tip.BlockHash()
+	require.Equal(t, expectedHash[:], tipHash[:])
+}
+
+// TestSQLBlockHeaderFetchAncestors verifies the ancestor-range query.
+func TestSQLBlockHeaderFetchAncestors(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLBlockHeaderStore(t)
+
+	const numHeaders = 50
+	chain := createTestBlockHeaderChain(numHeaders)
+	require.NoError(t, store.WriteHeaders(chain...))
+
+	stop := chain[40].BlockHash()
+	headers, startHeight, err := store.FetchHeaderAncestors(10, &stop)
+	require.NoError(t, err)
+	require.Len(t, headers, 11)            // 10 ancestors + stop
+	require.Equal(t, uint32(31), startHeight)
+	for i, h := range headers {
+		require.True(t, reflect.DeepEqual(*chain[31+i-1].BlockHeader,
+			h), "ancestor %d mismatch", i)
+	}
+}
+
+// TestSQLFilterHeaderStoreOperations is a SQL analog of the existing
+// TestFilterHeaderStoreOperations test.
+func TestSQLFilterHeaderStoreOperations(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLFilterHeaderStore(t, nil)
+
+	const numHeaders = 100
+	chain := createTestFilterHeaderChain(numHeaders)
+	require.NoError(t, store.WriteHeaders(chain...))
+
+	last := chain[len(chain)-1]
+	tipHash, tipHeight, err := store.ChainTip()
+	require.NoError(t, err)
+	require.Equal(t, last.FilterHash, *tipHash)
+	require.Equal(t, last.Height, tipHeight)
+
+	for _, hdr := range chain {
+		got, err := store.FetchHeaderByHeight(hdr.Height)
+		require.NoError(t, err)
+		require.Equal(t, hdr.FilterHash, *got)
+
+		blockHash := hdr.HeaderHash
+		gotByHash, err := store.FetchHeader(&blockHash)
+		require.NoError(t, err)
+		require.Equal(t, hdr.FilterHash, *gotByHash)
+	}
+
+	// Roll back one header.
+	prev := chain[len(chain)-2]
+	prevFilterHash := prev.FilterHash
+	stamp, err := store.RollbackLastBlock(&prev.HeaderHash)
+	require.NoError(t, err)
+	require.Equal(t, int32(prev.Height), stamp.Height)
+	require.Equal(t, prevFilterHash[:], stamp.Hash[:])
+}
+
+// TestSQLFilterHeaderAssertReset verifies that constructing the store with a
+// matching assertion leaves the chain intact, while a mismatched assertion
+// purges every row and re-seeds genesis — all transactionally.
+func TestSQLFilterHeaderAssertReset(t *testing.T) {
+	t.Parallel()
+
+	backend := sqldb.NewTestBackend(t)
+	chain := createTestFilterHeaderChain(20)
+
+	store, err := NewSQLFilterHeaderStore(
+		context.Background(), backend.HeaderTxer, RegularFilter,
+		&chaincfg.SimNetParams, nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.WriteHeaders(chain...))
+
+	// Matching assertion: should be a no-op.
+	matching := chain[10]
+	store, err = NewSQLFilterHeaderStore(
+		context.Background(), backend.HeaderTxer, RegularFilter,
+		&chaincfg.SimNetParams, &matching,
+	)
+	require.NoError(t, err)
+	tipHash, tipHeight, err := store.ChainTip()
+	require.NoError(t, err)
+	require.Equal(t, uint32(20), tipHeight)
+	require.Equal(t, chain[19].FilterHash[:], tipHash[:])
+
+	// Mismatched assertion: must purge and re-seed genesis.
+	bad := matching
+	bad.FilterHash[0] ^= 0xFF
+	store, err = NewSQLFilterHeaderStore(
+		context.Background(), backend.HeaderTxer, RegularFilter,
+		&chaincfg.SimNetParams, &bad,
+	)
+	require.NoError(t, err)
+	tipHash, tipHeight, err = store.ChainTip()
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), tipHeight)
+	require.NotEqual(t, chain[19].FilterHash[:], tipHash[:])
+
+	// All written rows should be gone.
+	for _, hdr := range chain {
+		_, err := store.FetchHeaderByHeight(hdr.Height)
+		if hdr.Height == 0 {
+			require.NoError(t, err)
+			continue
+		}
+		require.Error(t, err)
+	}
+}
+
+// TestSQLFilterHeaderAssertMissingHeight verifies that asserting at a
+// not-yet-known height is treated as a no-op (matches legacy behavior in
+// maybeResetHeaderState that returns false when the assertion height isn't
+// stored).
+func TestSQLFilterHeaderAssertMissingHeight(t *testing.T) {
+	t.Parallel()
+
+	backend := sqldb.NewTestBackend(t)
+	chain := createTestFilterHeaderChain(5)
+
+	store, err := NewSQLFilterHeaderStore(
+		context.Background(), backend.HeaderTxer, RegularFilter,
+		&chaincfg.SimNetParams, nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.WriteHeaders(chain...))
+
+	bogus := FilterHeader{Height: 999}
+	bogus.FilterHash[0] = 0xCD
+	bogus.HeaderHash[0] = 0xCD
+
+	store, err = NewSQLFilterHeaderStore(
+		context.Background(), backend.HeaderTxer, RegularFilter,
+		&chaincfg.SimNetParams, &bogus,
+	)
+	require.NoError(t, err)
+	_, tipHeight, err := store.ChainTip()
+	require.NoError(t, err)
+	require.Equal(t, uint32(5), tipHeight)
+}


### PR DESCRIPTION
In this PR, we add `SQLBlockHeaderStore` and `SQLFilterHeaderStore`,
the SQL-backed implementations of the existing `BlockHeaderStore` and
`FilterHeaderStore` interfaces. This is the largest correctness-critical
piece of the stack: the existing bbolt + flat-file implementation has a
documented inconsistency window between the on-disk binary and the
walletdb index, and pulling everything into a single SQL transaction
removes the entire class of failures that the existing
reconciliation-on-startup logic exists to repair.

## Stack

This is PR 4 of 6 in the SQL backend stack. Stacks on top of #354.

## Atomicity wins

The legacy `WriteHeaders` writes the raw bytes to `block_headers.bin`
first, then updates the bbolt header-index, with each step in its own
tx boundary (file `Write` + `walletdb.Update`). If the database update
fails mid-batch, the existing code does its best to truncate the flat
file back to the previous valid offset, but there are still corner
cases where the file and index can drift out of sync. The constructor
at `headerfs/store.go:294-327` exists specifically to detect that drift
on next startup and truncate the file to match the index.

In the SQL implementation, the entire batch (every `InsertBlockHeader`
plus the closing `UpsertChainTip`) runs in one `ExecTx` write tx. If
any insert fails (UNIQUE violation, retryable error, anything else),
the whole tx rolls back atomically and there is no drift to detect on
next startup. We delete the reconciliation logic from the SQL path
entirely; it's only relevant on the bbolt side.

`RollbackBlockHeaders` and `RollbackLastBlock` get the same treatment:
read the current tip, look up the new tip header, `DELETE FROM
block_headers WHERE height > N`, and `UpsertChainTip` to the new value,
all in one tx. Strictly better than the legacy two-step truncate +
walletdb update.

## LatestBlockLocator in one tx

The bbolt `blockLocatorFromHash` walks back from the chain tip with an
exponentially increasing decrement, hitting `FetchHeaderByHeight` for
each step and incurring a fresh read tx per call. There's been a TODO
on that loop for years to put the whole walk inside a single
transaction. The SQL implementation does just that: one `ExecTx` read
tx scopes the entire walk, every `GetBlockHeaderByHeight` runs in the
same snapshot, and the locator is returned at the end.

## maybeReset rewritten as one tx

The bbolt filter header store has an `AssertFilterHeader` mechanism
where, on first start, the caller can pass an expected
`(height, filter_hash)` tuple. If the on-disk row at `height` doesn't
match, the store closes the file, calls `os.Remove`, and recursively
re-invokes `NewFilterHeaderStore` to re-init from genesis. That flow is
brittle: two separate filesystem operations between the assertion check
and the re-init, no atomicity, Windows-specific handling for the file
close before remove.

In the SQL version, the whole reset is one write tx:
`PurgeFilterHeaders` to drop every row, `DeleteChainTip(filter)` to
reset the tip pointer, then `InsertFilterHeader` + `UpsertChainTip`
with the recomputed genesis. No recursion, no os.Remove, no Windows
edge case.

## Linearizability

Both stores keep a `sync.RWMutex`. The SQL engine's isolation alone is
enough for correctness, but callers like `blockmanager` rely on the
observable property that a `ChainTip` immediately following a
successful `WriteHeaders` returns the new tip without a write-then-read
gap. The mutex preserves that contract.

## Tests

`TestSQLBlockHeaderStoreOperations` exercises a 100-header
write-and-fetch chain plus a single rollback, mirroring the existing
bbolt test. `TestSQLBlockHeaderRollbackAtomic` injects a UNIQUE
violation mid-batch and asserts that no rows from the failed batch
persist (full tx rollback proves itself).
`TestSQLBlockHeaderGenesisIdempotent` constructs the store twice
against the same DB and asserts `block_headers` has exactly one row at
height 0. `TestSQLFilterHeaderAssertReset` covers the matching,
mismatched, and missing-height cases of the assertion path.