### PR TITLE
filterdb: fall back to Update when backend lacks BatchDB

### DIFF
--- a/filterdb/db.go
+++ b/filterdb/db.go
@@ -168,7 +168,7 @@ func putFilter(bucket walletdb.ReadWriteBucket, hash *chainhash.Hash,
 // NOTE: This method is a part of the FilterDatabase interface.
 func (f *FilterStore) PutFilters(filterList ...*FilterData) error {
 	var updateErr error
-	err := walletdb.Batch(f.db, func(tx walletdb.ReadWriteTx) error {
+	putFilters := func(tx walletdb.ReadWriteTx) error {
 		filters := tx.ReadWriteBucket(filterBucket)
 		regularFilterBkt := filters.NestedReadWriteBucket(regBucket)
 
@@ -197,7 +197,19 @@ func (f *FilterStore) PutFilters(filterList ...*FilterData) error {
 		}
 
 		return nil
-	})
+	}
+
+	var err error
+
+	// Batch is an optimization that some walletdb backends, such as bdb,
+	// implement to coalesce concurrent write transactions. Other backends
+	// only satisfy the base walletdb.DB interface, so fall back to a normal
+	// write transaction when batching is unavailable.
+	if _, ok := f.db.(walletdb.BatchDB); ok {
+		err = walletdb.Batch(f.db, putFilters)
+	} else {
+		err = walletdb.Update(f.db, putFilters)
+	}
 	if err != nil {
 		return err
 	}

--- a/filterdb/db_test.go
+++ b/filterdb/db_test.go
@@ -14,7 +14,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createTestDatabase(t *testing.T) FilterDatabase {
+// nonBatchDB embeds a walletdb.DB while shadowing any Batch method on the
+// underlying value. It lets tests exercise the PutFilters fallback path used
+// by backends that satisfy walletdb.DB but not walletdb.BatchDB.
+type nonBatchDB struct {
+	walletdb.DB
+}
+
+// createTestWalletDB creates a temporary bdb-backed walletdb.DB that is
+// cleaned up when the test finishes.
+func createTestWalletDB(t *testing.T) walletdb.DB {
 	tempDir := t.TempDir()
 
 	db, err := walletdb.Create(
@@ -25,6 +34,19 @@ func createTestDatabase(t *testing.T) FilterDatabase {
 		require.NoError(t, db.Close())
 	})
 
+	return db
+}
+
+// createTestDatabase creates a FilterDatabase backed by a fresh temporary
+// bdb walletdb instance for use in tests.
+func createTestDatabase(t *testing.T) FilterDatabase {
+	return createTestDatabaseWithDB(t, createTestWalletDB(t))
+}
+
+// createTestDatabaseWithDB wraps the given walletdb.DB in a FilterDatabase so
+// that tests can supply a custom backend, for example one that hides
+// optional interfaces such as walletdb.BatchDB.
+func createTestDatabaseWithDB(t *testing.T, db walletdb.DB) FilterDatabase {
 	filterDB, err := New(db, chaincfg.SimNetParams)
 	require.NoError(t, err)
 
@@ -75,7 +97,24 @@ func genRandFilter(t *testing.T, numElements uint32) *gcs.Filter {
 // TestFilterStorage test writing to and reading from the filter DB.
 func TestFilterStorage(t *testing.T) {
 	database := createTestDatabase(t)
+	assertFilterStorage(t, database)
+}
 
+// TestFilterStorageWithoutBatch tests writing filters to a database that
+// supports normal read/write transactions, but not batched transactions.
+func TestFilterStorageWithoutBatch(t *testing.T) {
+	db := createTestWalletDB(t)
+
+	// Wrapping the bdb handle hides its Batch method and gives us the same
+	// interface shape as walletdb backends that do not implement BatchDB.
+	database := createTestDatabaseWithDB(t, &nonBatchDB{DB: db})
+	assertFilterStorage(t, database)
+}
+
+// assertFilterStorage runs the filter store round-trip assertions against
+// the provided FilterDatabase: it generates random regular filters, writes
+// them via PutFilters, and verifies they can be read back.
+func assertFilterStorage(t *testing.T, database FilterDatabase) {
 	// We'll generate a random block hash to create our test filters
 	// against.
 	var randHash chainhash.Hash


### PR DESCRIPTION
## Summary

`FilterStore.PutFilters` calls `walletdb.Batch` unconditionally to coalesce
concurrent write transactions. `walletdb.Batch` requires the underlying
database to implement `walletdb.BatchDB` and returns `"need batch"` when the
type assertion fails, so any backend that only satisfies the base
`walletdb.DB` interface cannot persist filters at all.

This change detects `BatchDB` support at runtime and falls back to a regular
`walletdb.Update` transaction when batching is unavailable. The batched fast
path is preserved for backends like `bdb` that implement it.

## Changes

- `filterdb/db.go`: type-assert the backend for `walletdb.BatchDB` in
  `PutFilters`; use `walletdb.Batch` when available, otherwise
  `walletdb.Update`.
- `filterdb/db_test.go`: add `TestFilterStorageWithoutBatch`, which wraps the
  test `bdb` handle in a struct that hides the `Batch` method to exercise the
  non-`BatchDB` code path against the existing storage assertions.

## Test plan

- [x] `go test ./filterdb/...` passes (`TestFilterStorage` and
      `TestFilterStorageWithoutBatch`).
- [x] Existing batched path is unchanged for `bdb` backends.