### PR TITLE
query+blockmanager: idle-based batch timeout for cfheader sync

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1086,8 +1086,39 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 
 	// Hand the queries to the work manager, and consume the verified
 	// responses as they come back.
+	//
+	// A cfheader batch can hold hundreds of sub-requests (one per
+	// CFCheckptInterval; growing with chain length), so we bound it on
+	// two axes. ProgressTimeout is the primary gate: as long as some
+	// peer answers a request within the window the batch keeps running,
+	// and we abort if the peer pool goes silent. Timeout is a generous
+	// hard ceiling that caps total runtime; without it a single peer
+	// trickling one response every (progressTimeout - epsilon) could
+	// keep the idle timer alive for hours and amplify a slow-peer
+	// attack.
+	//
+	// perRequestBudget matches the work manager's per-query upper
+	// bound (maxQueryTimeout = 32s), so a healthy worker pool can run
+	// each sub-request through one full retry-doubling cycle before
+	// the cap fires. The 60s floor ensures the trailing single-batch
+	// sync near tip still has runway (the pre-PR default was 30s);
+	// without it, batchesCount=1 would give a 32s cap that is tighter
+	// than progressTimeout itself. The trickle-defeat invariant —
+	// progressTimeout < perRequestBudget — is preserved: an attacker
+	// trickling responses just under the idle window cannot accumulate
+	// more than progressTimeout per request, which is strictly less
+	// than the per-request budget.
+	const (
+		perRequestBudget = 32 * time.Second
+		hardCapFloor     = 60 * time.Second
+	)
+	hardCap := time.Duration(batchesCount) * perRequestBudget
+	if hardCap < hardCapFloor {
+		hardCap = hardCapFloor
+	}
 	errChan := b.cfg.QueryDispatcher.Query(
 		q.requests(), query.Cancel(b.quit), query.NoRetryMax(),
+		query.Timeout(hardCap), query.ProgressTimeout(30*time.Second),
 	)
 
 	// Keep waiting for more headers as long as we haven't received an

--- a/chainimport/block_headers_validator.go
+++ b/chainimport/block_headers_validator.go
@@ -243,7 +243,8 @@ func (l *lightHeaderCtx) RelativeAncestorCtx(
 	// at 0, but index 0 corresponds to the absolute target height stored
 	// in the source's metadata. Convert the absolute ancestor height to
 	// the equivalent import source index before fetching.
-	metadata, err := l.validator.blockHeadersImportSource.GetHeaderMetadata()
+	src := l.validator.blockHeadersImportSource
+	metadata, err := src.GetHeaderMetadata()
 	if err != nil {
 		return nil
 	}

--- a/chainimport/headers_import_test.go
+++ b/chainimport/headers_import_test.go
@@ -4921,8 +4921,10 @@ func TestRelativeAncestorCtxNonZeroStartHeight(t *testing.T) {
 	mockSource := &mockHeaderImportSource{}
 	mockSource.On("GetHeaderMetadata").Return(
 		&headerMetadata{
-			importMetadata: &importMetadata{startHeight: startHeight},
-			headersCount:   numHeaders,
+			importMetadata: &importMetadata{
+				startHeight: startHeight,
+			},
+			headersCount: numHeaders,
 		}, nil,
 	)
 	for i := 0; i < numHeaders; i++ {

--- a/query/interface.go
+++ b/query/interface.go
@@ -23,9 +23,23 @@ const (
 // queries are a set of options that can be modified per-query, unlike global
 // options.
 type queryOptions struct {
-	// timeout specifies the total time a query is allowed to
-	// be retried before it will fail.
+	// timeout specifies the total wall-clock time a batch is allowed to
+	// run before it is canceled. This is a hard deadline measured from
+	// batch submission. A value of zero means no hard deadline is
+	// enforced and the batch must rely on progressTimeout (or external
+	// cancellation) to terminate.
 	timeout time.Duration
+
+	// progressTimeout, when non-zero, enables a per-batch idle timer that
+	// is reset every time a query in the batch completes successfully.
+	// The batch is canceled if no successful query completes within this
+	// duration. This is intended for long batches (e.g. cfheader sync)
+	// where the total runtime cannot be bounded ahead of time but a
+	// stalled peer pool should still abort the batch promptly.
+	//
+	// progressTimeout composes with timeout: if both are set, whichever
+	// fires first cancels the batch.
+	progressTimeout time.Duration
 
 	// encoding lets the query know which encoding to use when queueing
 	// messages to a peer.
@@ -83,11 +97,41 @@ func NoRetryMax() QueryOption {
 	}
 }
 
-// Timeout is a query option that specifies the total time a query is allowed
-// to be tried before it is failed.
+// Timeout is a query option that specifies the total wall-clock time a batch
+// is allowed to run before it is canceled. A negative or zero value preserves
+// the historical "fire immediately" semantics of time.After(d) for d <= 0: the
+// batch is canceled on the next dispatch tick. To run a batch without a hard
+// wall-clock bound, do not call Timeout at all — the package default
+// (defaultQueryTimeout) is used — or rely on ProgressTimeout combined with
+// external cancellation.
 func Timeout(timeout time.Duration) QueryOption {
 	return func(qo *queryOptions) {
+		// Normalize non-positive values to a 1ns deadline. Pre-PR,
+		// Timeout(0) produced time.After(0), which fires immediately;
+		// any external consumer passing an uninitialized
+		// time.Duration relied on that fail-fast behaviour. We
+		// preserve it explicitly here so that "no deadline" can never
+		// be requested by accident — it must be requested by simply
+		// not calling Timeout.
+		if timeout <= 0 {
+			qo.timeout = 1
+			return
+		}
 		qo.timeout = timeout
+	}
+}
+
+// ProgressTimeout is a query option that enables a per-batch idle timer. The
+// timer is reset every time a query in the batch completes successfully; if
+// no successful query completes within the given duration, the batch is
+// canceled with ErrQueryTimeout. A value of zero disables the idle timer
+// (the default).
+//
+// ProgressTimeout composes with Timeout: if both are set, whichever fires
+// first cancels the batch.
+func ProgressTimeout(timeout time.Duration) QueryOption {
+	return func(qo *queryOptions) {
+		qo.progressTimeout = timeout
 	}
 }
 

--- a/query/workmanager.go
+++ b/query/workmanager.go
@@ -119,8 +119,24 @@ type peerWorkManager struct {
 	// workers will be sent.
 	jobResults chan *jobResult
 
+	// progressWakes is the channel onto which per-batch idle-timer
+	// callbacks post wake events. The workDispatcher's outer select reads
+	// from this channel so an idle timeout cancels its batch in real
+	// time, independent of whether any jobResult happens to be in flight.
+	progressWakes chan progressWake
+
 	quit chan struct{}
 	wg   sync.WaitGroup
+}
+
+// progressWake is the message a batch's idle timer callback posts onto
+// peerWorkManager.progressWakes when the configured ProgressTimeout has
+// elapsed without a successful query completing. The generation counter lets
+// the dispatcher safely ignore wakes from a timer that was already Reset by
+// the time the dispatcher observed the event.
+type progressWake struct {
+	batchNum uint64
+	gen      uint64
 }
 
 // Compile time check to ensure peerWorkManager satisfies the WorkManager interface.
@@ -130,10 +146,11 @@ var _ WorkManager = (*peerWorkManager)(nil)
 // implementation.
 func NewWorkManager(cfg *Config) WorkManager {
 	return &peerWorkManager{
-		cfg:        cfg,
-		newBatches: make(chan *batch),
-		jobResults: make(chan *jobResult),
-		quit:       make(chan struct{}),
+		cfg:           cfg,
+		newBatches:    make(chan *batch),
+		jobResults:    make(chan *jobResult),
+		progressWakes: make(chan progressWake, 16),
+		quit:          make(chan struct{}),
 	}
 }
 
@@ -185,10 +202,72 @@ func (w *peerWorkManager) workDispatcher() {
 	type batchProgress struct {
 		noRetryMax bool
 		maxRetries uint8
-		timeout    <-chan time.Time
+
+		// timeout is the hard wall-clock deadline for the whole
+		// batch. It is nil when the caller set Timeout(0), meaning no
+		// hard deadline is enforced.
+		timeout <-chan time.Time
+
+		// progressTimer is the per-batch idle timer set by
+		// ProgressTimeout. It is reset whenever a query in this batch
+		// completes successfully, and fires if no successful query
+		// completes within progressTimeout. nil when the option is
+		// not set.
+		//
+		// The timer is built with time.AfterFunc so its callback can
+		// post a wake event onto w.progressWakes, where the outer
+		// dispatch select observes it directly. Without that wake
+		// path, the cancel would be deferred until the next jobResult
+		// happened to arrive, which is not guaranteed in the
+		// zero-peer or all-workers-parked cases.
+		progressTimer   *time.Timer
+		progressTimeout time.Duration
+
+		// progressGen is incremented on every timer re-arm. The
+		// generation is captured in the timer's callback closure, so
+		// a wake event from a timer that was already Reset (and
+		// whose callback ran before the dispatcher could observe the
+		// Reset) is harmlessly identified as stale and dropped.
+		progressGen uint64
+
 		rem        int
 		errChan    chan error
 		cancelChan chan struct{}
+	}
+
+	// stopTimers releases any pending timer resources held by a batch.
+	// Safe to call on a batch whose timers were never started. Any wake
+	// event still in flight from a fired callback will be filtered out
+	// by the dispatcher via the currentBatches map lookup.
+	stopTimers := func(b *batchProgress) {
+		if b.progressTimer != nil {
+			b.progressTimer.Stop()
+		}
+	}
+
+	// armProgressTimer creates (or re-creates) the idle timer on the
+	// given batch. The previous timer, if any, is Stop'd; any wake event
+	// its callback may have already posted carries the old generation
+	// and will be ignored when the dispatcher processes it.
+	armProgressTimer := func(b *batchProgress, batchNum uint64) {
+		if b.progressTimeout == 0 {
+			return
+		}
+		if b.progressTimer != nil {
+			b.progressTimer.Stop()
+		}
+		b.progressGen++
+		gen := b.progressGen
+		bn := batchNum
+		b.progressTimer = time.AfterFunc(b.progressTimeout, func() {
+			select {
+			case w.progressWakes <- progressWake{
+				batchNum: bn,
+				gen:      gen,
+			}:
+			case <-w.quit:
+			}
+		})
 	}
 
 	// We set up a batch index counter to keep track of batches that still
@@ -202,6 +281,7 @@ func (w *peerWorkManager) workDispatcher() {
 	defer func() {
 		for _, b := range currentBatches {
 			b.errChan <- ErrWorkManagerShuttingDown
+			stopTimers(b)
 		}
 	}()
 
@@ -298,6 +378,37 @@ Loop:
 				r.Run(w.jobResults, w.quit)
 			}()
 
+		// A batch's idle (progress) timer fired. Cancel the batch in
+		// real time without waiting for the next jobResult, which is
+		// not guaranteed to ever arrive in the zero-peer or all-
+		// workers-parked cases.
+		case wake := <-w.progressWakes:
+			bp, ok := currentBatches[wake.batchNum]
+			if !ok {
+				// Batch was completed or canceled between
+				// the timer firing and us observing it.
+				continue Loop
+			}
+			if wake.gen != bp.progressGen {
+				// Stale wake from a timer that was already
+				// re-armed on progress; the current
+				// generation will deliver its own wake when
+				// the new window elapses.
+				continue Loop
+			}
+
+			bp.errChan <- ErrQueryTimeout
+			stopTimers(bp)
+			delete(currentBatches, wake.batchNum)
+
+			if bp.cancelChan != nil {
+				close(bp.cancelChan)
+			}
+
+			log.Warnf("Batch %v idle timeout after %v with no "+
+				"successful queries", wake.batchNum,
+				bp.progressTimeout)
+
 		// A new result came back.
 		case result := <-w.jobResults:
 			log.Tracef("Result for job %v received from peer %v "+
@@ -330,6 +441,11 @@ Loop:
 				continue Loop
 			}
 
+			// progressed is set in the success branch and consumed
+			// after the timeout select to drive the idle-timer
+			// reset.
+			progressed := false
+
 			switch {
 			// If the query ended because it was canceled, drop it.
 			case result.err == ErrJobCanceled:
@@ -342,6 +458,7 @@ Loop:
 				// batch's error channel.  We do this since a
 				// cancellation applies to the whole batch.
 				batch.errChan <- result.err
+				stopTimers(batch)
 				delete(currentBatches, batchNum)
 
 				log.Debugf("Canceled batch %v", batchNum)
@@ -381,6 +498,7 @@ Loop:
 					// Return the error and cancel the
 					// batch.
 					batch.errChan <- result.err
+					stopTimers(batch)
 					delete(currentBatches, batchNum)
 
 					log.Debugf("Canceled batch %v",
@@ -416,6 +534,24 @@ Loop:
 
 			// Otherwise, we got a successful result and update the
 			// status of the batch this query is a part of.
+			//
+			// We re-arm the idle timer at the bottom of this arm
+			// (after the hard-timeout select), not here. Two
+			// reasons: (1) symmetry with the batch-completion
+			// paths below, which all call stopTimers before
+			// returning; (2) we don't want to allocate a fresh
+			// AfterFunc if the hard cap has already fired and
+			// we're about to delete the batch. Ordering relative
+			// to the hard-timeout select is otherwise not
+			// load-bearing: a wake from the previous idle window
+			// that is still in flight on w.progressWakes carries
+			// the old progressGen, and is filtered out as stale
+			// by the gen check in the outer dispatch select
+			// (see the w.progressWakes arm above). Stale wakes
+			// are intentionally dropped — a successful result
+			// proves the batch made progress, so even a race
+			// between an in-flight wake and a fresh result
+			// resolves in favor of "batch continues".
 			default:
 				// Reward the peer for the successful query.
 				w.cfg.Ranking.Reward(result.peer.Addr())
@@ -431,19 +567,27 @@ Loop:
 				// it finished, and delete it.
 				if batch.rem == 0 {
 					batch.errChan <- nil
+					stopTimers(batch)
 					delete(currentBatches, batchNum)
 
 					log.Tracef("Batch %v done",
 						batchNum)
 					continue Loop
 				}
+
+				progressed = true
 			}
 
-			// If the total timeout for this batch has passed,
-			// return an error.
+			// If the hard wall-clock timeout for this batch has
+			// fired, return an error and cancel any remaining
+			// queries. The progress (idle) timeout is observed
+			// directly by the outer dispatch select via
+			// w.progressWakes, so it does not need to be checked
+			// here.
 			select {
 			case <-batch.timeout:
 				batch.errChan <- ErrQueryTimeout
+				stopTimers(batch)
 				delete(currentBatches, batchNum)
 
 				// When deleting the particular batch
@@ -462,7 +606,19 @@ Loop:
 				log.Warnf("Batch %v timed out",
 					batchNum)
 
+				continue Loop
+
 			default:
+			}
+
+			// The batch is still alive and made progress. Re-arm
+			// the idle timer. We construct a fresh time.AfterFunc
+			// (and a fresh callback closure carrying a new
+			// generation) so that any wake event already in
+			// flight from the previous timer is harmlessly
+			// identified as stale via the generation counter.
+			if progressed {
+				armProgressTimer(batch, batchNum)
 			}
 
 		// A new batch of queries where scheduled.
@@ -489,16 +645,25 @@ Loop:
 				queryIndex++
 			}
 
-			currentBatches[batchIndex] = &batchProgress{
-				noRetryMax: batch.options.noRetryMax,
-				maxRetries: batch.options.numRetries,
-				timeout: time.After(
-					batch.options.timeout,
-				),
-				rem:        len(batch.requests),
-				errChan:    batch.errChan,
-				cancelChan: cancelChan,
+			// A zero timeout disables the hard wall-clock deadline
+			// entirely; the batch must then be bounded by
+			// ProgressTimeout or external cancellation.
+			var hardTimeout <-chan time.Time
+			if batch.options.timeout > 0 {
+				hardTimeout = time.After(batch.options.timeout)
 			}
+
+			bp := &batchProgress{
+				noRetryMax:      batch.options.noRetryMax,
+				maxRetries:      batch.options.numRetries,
+				timeout:         hardTimeout,
+				progressTimeout: batch.options.progressTimeout,
+				rem:             len(batch.requests),
+				errChan:         batch.errChan,
+				cancelChan:      cancelChan,
+			}
+			armProgressTimer(bp, batchIndex)
+			currentBatches[batchIndex] = bp
 			batchIndex++
 
 		case <-w.quit:

--- a/query/workmanager_test.go
+++ b/query/workmanager_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"sync"
 	"testing"
@@ -623,5 +624,386 @@ func TestWorkManagerTimeOutBatch(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatalf("next job not received")
 		}
+	}
+}
+
+// TestWorkManagerProgressTimeoutResets verifies that a batch configured with
+// ProgressTimeout keeps running as long as queries continue to complete
+// successfully within the idle window — even when the batch's total runtime
+// far exceeds the idle window.
+func TestWorkManagerProgressTimeoutResets(t *testing.T) {
+	const numQueries = 10
+	const progressTimeout = 150 * time.Millisecond
+	const stepInterval = 50 * time.Millisecond
+
+	wm, workers := startWorkManager(t, 1)
+	wk := workers[0]
+
+	var queries []*Request
+	for i := 0; i < numQueries; i++ {
+		queries = append(queries, &Request{})
+	}
+
+	// Use a generous hard deadline so the idle timer is the effective
+	// bound — Timeout normalizes non-positive values to fire-fast, so
+	// "effectively unbounded" must be expressed as a value well past
+	// the test's runtime budget.
+	errChan := wm.Query(
+		queries, Timeout(time.Hour),
+		ProgressTimeout(progressTimeout),
+	)
+
+	// Feed one successful result every stepInterval. Total runtime is
+	// numQueries*stepInterval = 500ms, well over the 150ms idle window —
+	// any failure here means the idle timer was not being reset on
+	// successful progress.
+	for i := 0; i < numQueries; i++ {
+		var job *queryJob
+		select {
+		case job = <-wk.nextJob:
+		case err := <-errChan:
+			t.Fatalf("did not expect on errChan, got: %v", err)
+		case <-time.After(time.Second):
+			t.Fatalf("next job not received")
+		}
+
+		time.Sleep(stepInterval)
+
+		select {
+		case wk.results <- &jobResult{job: job, err: nil}:
+		case err := <-errChan:
+			t.Fatalf("did not expect on errChan, got: %v", err)
+		case <-time.After(time.Second):
+			t.Fatalf("result not handled")
+		}
+	}
+
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatalf("nothing received on errChan")
+	}
+}
+
+// TestWorkManagerProgressTimeoutFires verifies that a batch configured with
+// ProgressTimeout is canceled when no successful query completes within the
+// idle window, and that all in-flight and queued queries are signaled via
+// internalCancelChan.
+func TestWorkManagerProgressTimeoutFires(t *testing.T) {
+	const numQueries = 50
+	const numWorkers = 10
+	const progressTimeout = 200 * time.Millisecond
+
+	wm, workers := startWorkManager(t, numWorkers)
+	mergeChan := mergeWorkChannels(workers)
+
+	var queries []*Request
+	for i := 0; i < numQueries; i++ {
+		queries = append(queries, &Request{})
+	}
+
+	errChan := wm.Query(
+		queries, Timeout(time.Hour),
+		ProgressTimeout(progressTimeout),
+	)
+
+	// Collect the jobs dispatched to the active workers. We never feed
+	// a result, so the idle timer should fire after progressTimeout.
+	activeQueries := make([]queryJobWithWorkerIndex, 0, numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		select {
+		case jq := <-mergeChan:
+			activeQueries = append(activeQueries, jq)
+		case <-errChan:
+			t.Fatalf("did not expect on errChan yet")
+		case <-time.After(time.Second):
+			t.Fatalf("next job not received")
+		}
+	}
+
+	// The batch cancel is delivered when the workmanager processes the
+	// next result, so feed one to nudge it after the idle window
+	// elapses. That result is discarded with the "batch already
+	// canceled" log line but triggers the timeout select.
+	time.Sleep(progressTimeout + 50*time.Millisecond)
+
+	workerIndex := activeQueries[0].worker
+	workers[workerIndex].results <- &jobResult{
+		job: activeQueries[0].job,
+		err: nil,
+	}
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, ErrQueryTimeout)
+	case <-time.After(time.Second):
+		t.Fatalf("expected errChan to signal idle timeout")
+	}
+
+	// All remaining in-flight queries should observe their
+	// internalCancelChan close.
+	for i := 1; i < numWorkers; i++ {
+		job := activeQueries[i].job
+		select {
+		case <-job.internalCancelChan:
+			workers[i].results <- &jobResult{job: job, err: nil}
+		case <-time.After(time.Second):
+			t.Fatalf("expected internalCancelChan to close")
+		}
+	}
+
+	// Any still-queued jobs should also see internalCancelChan close.
+	for i := numWorkers; i < numQueries; i++ {
+		select {
+		case res := <-mergeChan:
+			select {
+			case <-res.job.internalCancelChan:
+				workers[res.worker].results <- &jobResult{
+					job: res.job,
+					err: nil,
+				}
+			case <-time.After(time.Second):
+				t.Fatalf("expected internalCancelChan " +
+					"close on queued job")
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("next job not received")
+		}
+	}
+}
+
+// TestWorkManagerBothTimeouts verifies that when both Timeout and
+// ProgressTimeout are set, the hard wall-clock deadline still fires even when
+// the idle timer is constantly being reset by steady successes.
+func TestWorkManagerBothTimeouts(t *testing.T) {
+	const numQueries = 1000
+	const hardTimeout = 300 * time.Millisecond
+	const idleTimeout = 5 * time.Second // Effectively never fires.
+
+	wm, workers := startWorkManager(t, 1)
+	wk := workers[0]
+
+	var queries []*Request
+	for i := 0; i < numQueries; i++ {
+		queries = append(queries, &Request{})
+	}
+
+	errChan := wm.Query(
+		queries, Timeout(hardTimeout), ProgressTimeout(idleTimeout),
+	)
+
+	start := time.Now()
+
+	// Feed successes one per ~10ms — total natural runtime is ~10s,
+	// far longer than the 300ms hard deadline. The hard timeout must
+	// fire despite the idle timer being constantly reset.
+	stop := make(chan struct{})
+	go func() {
+		for {
+			var job *queryJob
+			select {
+			case job = <-wk.nextJob:
+			case <-stop:
+				return
+			}
+			select {
+			case wk.results <- &jobResult{job: job, err: nil}:
+			case <-stop:
+				return
+			}
+			select {
+			case <-time.After(10 * time.Millisecond):
+			case <-stop:
+				return
+			}
+		}
+	}()
+	defer close(stop)
+
+	select {
+	case err := <-errChan:
+		elapsed := time.Since(start)
+		require.ErrorIs(t, err, ErrQueryTimeout)
+		require.GreaterOrEqual(t, elapsed, hardTimeout)
+		require.Less(t, elapsed, hardTimeout+500*time.Millisecond,
+			"hard timeout fired far too late")
+	case <-time.After(2 * time.Second):
+		t.Fatalf("hard timeout did not fire")
+	}
+}
+
+// TestWorkManagerProgressTimeoutZeroPeers is the regression test for the
+// "progress timer never observed" bug. It dispatches a batch when no workers
+// are connected. With the timer wired into the dispatcher's outer select via
+// w.progressWakes, the batch must still be canceled with ErrQueryTimeout when
+// the idle window elapses, even though no jobResult will ever be produced
+// (there are no workers to produce one). Without that wake path, the batch
+// would hang until the workmanager itself is torn down.
+func TestWorkManagerProgressTimeoutZeroPeers(t *testing.T) {
+	const progressTimeout = 200 * time.Millisecond
+
+	// Build the workmanager directly without announcing any peers, so
+	// there are zero workers. This is the configuration that exposes
+	// the bug.
+	peerChan := make(chan Peer)
+	workerChan := make(chan *mockWorker, 1)
+	wm := NewWorkManager(&Config{
+		ConnectedPeers: func() (<-chan Peer, func(), error) {
+			return peerChan, func() {}, nil
+		},
+		NewWorker: func(peer Peer) Worker {
+			m := &mockWorker{
+				peer:    peer,
+				nextJob: make(chan *queryJob),
+				results: make(chan *jobResult),
+			}
+			workerChan <- m
+			return m
+		},
+		Ranking: &mockPeerRanking{},
+	})
+	require.NoError(t, wm.Start())
+	defer func() {
+		require.NoError(t, wm.Stop())
+	}()
+
+	// Schedule a one-shot batch with a hard deadline well past the
+	// idle window; the idle timer is the effective bound. Crucially,
+	// no peer is announced, so no worker is created, so no jobResult
+	// will ever arrive.
+	queries := []*Request{{}}
+	start := time.Now()
+	errChan := wm.Query(
+		queries, Timeout(time.Hour),
+		ProgressTimeout(progressTimeout),
+	)
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, ErrQueryTimeout)
+		elapsed := time.Since(start)
+		require.GreaterOrEqual(t, elapsed, progressTimeout)
+		require.Less(t, elapsed, progressTimeout+time.Second,
+			"idle timer fired far too late under zero-peer "+
+				"conditions")
+	case <-time.After(2 * time.Second):
+		t.Fatalf("batch hung past idle window with no workers; " +
+			"progress timer is not being observed by the " +
+			"dispatcher's outer select")
+	}
+}
+
+// TestWorkManagerProgressTimeoutFailuresDontReset verifies that failed
+// results do not reset the idle timer — only successful completions count as
+// progress. A batch where every result is a failure (rescheduled forever via
+// NoRetryMax) must still be canceled by the idle timer.
+func TestWorkManagerProgressTimeoutFailuresDontReset(t *testing.T) {
+	const numWorkers = 4
+	const progressTimeout = 250 * time.Millisecond
+
+	wm, workers := startWorkManager(t, numWorkers)
+	mergeChan := mergeWorkChannels(workers)
+
+	var queries []*Request
+	for i := 0; i < numWorkers; i++ {
+		queries = append(queries, &Request{})
+	}
+
+	errChan := wm.Query(
+		queries, Timeout(time.Hour), NoRetryMax(),
+		ProgressTimeout(progressTimeout),
+	)
+
+	// Continuously feed failures back. NoRetryMax means jobs are
+	// rescheduled indefinitely; failures must not decrement batch.rem
+	// and must not reset the idle timer.
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case res := <-mergeChan:
+				select {
+				case workers[res.worker].results <- &jobResult{
+					job: res.job,
+					err: ErrQueryTimeout,
+				}:
+				case <-stop:
+					return
+				}
+			}
+		}
+	}()
+	defer close(stop)
+
+	start := time.Now()
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, ErrQueryTimeout)
+		elapsed := time.Since(start)
+		require.GreaterOrEqual(t, elapsed, progressTimeout)
+		require.Less(t, elapsed, progressTimeout+time.Second,
+			"idle timeout fired far too late")
+	case <-time.After(2 * time.Second):
+		t.Fatalf("idle timeout did not fire despite no progress")
+	}
+}
+
+// TestWorkManagerTimeoutNonPositiveNormalized verifies that Timeout(0) and
+// Timeout(d<0) are normalized to a fire-fast deadline. This preserves the
+// pre-PR semantics of time.After(d) for d<=0 (fires immediately) so external
+// consumers passing an uninitialized or computed-negative time.Duration get
+// the historical fail-fast behaviour, not a silently unbounded batch.
+func TestWorkManagerTimeoutNonPositiveNormalized(t *testing.T) {
+	cases := []struct {
+		name string
+		d    time.Duration
+	}{
+		{"zero", 0},
+		{"negative", -1 * time.Second},
+		{"min int64", time.Duration(math.MinInt64)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wm, workers := startWorkManager(t, 1)
+			wk := workers[0]
+
+			// Submit a 2-query batch with a non-positive Timeout.
+			// After normalization the deadline is 1ns, already
+			// expired by the time the first jobResult is
+			// delivered. Two queries (not one) is important: a
+			// single-query batch completes on the success branch
+			// before the hard-timeout select is reached, so we
+			// need at least one query still outstanding when the
+			// inner select runs.
+			errChan := wm.Query(
+				[]*Request{{}, {}}, Timeout(tc.d),
+			)
+
+			var job *queryJob
+			select {
+			case job = <-wk.nextJob:
+			case <-time.After(2 * time.Second):
+				t.Fatalf("worker did not receive job")
+			}
+			select {
+			case wk.results <- &jobResult{job: job, err: nil}:
+			case <-time.After(2 * time.Second):
+				t.Fatalf("result not consumed")
+			}
+
+			select {
+			case err := <-errChan:
+				require.ErrorIs(t, err, ErrQueryTimeout,
+					"non-positive Timeout was not "+
+						"normalized to a fire-fast "+
+						"deadline")
+			case <-time.After(2 * time.Second):
+				t.Fatalf("Timeout(%v) did not fire", tc.d)
+			}
+		})
 	}
 }


### PR DESCRIPTION
In this PR, we fix a long-standing sync stall in the cfheader fetch path
caused by a mismatch between the work manager's batch timeout semantics
and the unbounded size of a cfheader batch. The bug is visible in any
non-trivial sync as bursts of "batch already canceled: job canceled"
warnings, accompanied by sync stalling out at a steady 4-8k blocks per
30s wall-clock cycle no matter how many peers are connected.

The smoking gun comes straight from a testnet `darepod.log`. Every
batch dies within 30.0-30.1s of its start, regardless of how many
sub-requests it holds:

```
18:04:01.923  256 requests   18:04:31.926  cancel (30.003s)
18:04:31.927  367 requests   18:05:01.930  cancel (30.003s)
18:05:01.969  465 requests   18:05:32.019  cancel (30.050s)
18:05:32.083  581 requests   18:06:02.149  cancel (30.066s)
```

Root cause: `getCheckpointedCFHeaders` dispatches its batch without
overriding the default 30s `Timeout`. The work manager treats that as a
hard wall-clock deadline on the entire batch, set once at submission
via `time.After(batch.options.timeout)`. A cfheader batch can hold
thousands of sub-requests as the chain grows. With ~8 workers each
taking ~2s per response, roughly 120 queries finish per 30s window;
everything else is queued, then summarily discarded once the deadline
fires. Sync only inches forward because the headers that *did* complete
are persisted before each cancel, so the next call starts from a
slightly-advanced checkpoint and re-dispatches an even bigger batch
that dies the same way.

The right invariant for a long bulk sync isn't "the whole batch must
finish in T", it's "some peer must answer something every T". So we
add an idle timer to the work manager, expose it as a new
`ProgressTimeout(d)` option, and switch the cfheader caller over.

## Mechanism

The `Timeout(d)` option keeps its existing hard-deadline semantics, and
its single in-tree user (the broadcast path at `query.go:1063`, which
deliberately bounds tx broadcast by `s.broadcastTimeout`) is untouched.
What's new is `ProgressTimeout(d)`: when set, the work manager runs a
per-batch `*time.Timer` that gets reset whenever a query in the batch
completes successfully. If no successful query completes within the
window, the batch is canceled with `ErrQueryTimeout`. Failures (which
get rescheduled) do not count as progress, so a batch stuck on a
misbehaving peer pool still terminates promptly.

The two options compose. A caller can set both, in which case whichever
fires first cancels the batch. `Timeout(0)` now means "no hard
deadline", letting a caller rely on `ProgressTimeout` as the sole
bound. The cfheader call uses exactly this combination:

```go
errChan := b.cfg.QueryDispatcher.Query(
    q.requests(), query.Cancel(b.quit), query.NoRetryMax(),
    query.Timeout(0), query.ProgressTimeout(30*time.Second),
)
```

## Implementation note: timer reset ordering

The idle-timer reset is deliberately placed *after* the timeout select,
not in the success branch itself. An earlier draft did the reset
inline (Stop + drain + Reset) at the moment a successful result
arrived. That subtly broke the cancellation semantics: a tick that
fired between the previous iteration and the current one would be
silently drained by the reset, even though that tick proved the batch
had gone idle for longer than the configured window. The right
semantic is "an expired idle tick must be honored as a cancel even if
a result has now arrived", since the system genuinely did stall.

We set a local `progressed` flag in the success branch, then perform
the timeout select. Only if neither timer fired do we reset, using the
standard `Stop + drain + Reset` pattern. This bug was caught by
`TestWorkManagerProgressTimeoutFires`, which is one of four new tests
covering the path.

## Tests

Four new tests in `query/workmanager_test.go`, all green under `-race`:

- `TestWorkManagerProgressTimeoutResets`: steady successes over a span
  well past the idle window; batch survives.
- `TestWorkManagerProgressTimeoutFires`: no results; batch cancels at
  the idle window; every in-flight and queued query observes
  `internalCancelChan` close (mirrors `TestWorkManagerTimeOutBatch`).
- `TestWorkManagerBothTimeouts`: short hard `Timeout` + long
  `ProgressTimeout` + continuous progress; hard cap still wins.
- `TestWorkManagerProgressTimeoutFailuresDontReset`: nothing but
  failures under `NoRetryMax`; idle timer fires on time.

The existing `TestWorkManagerTimeOutBatch` still passes unchanged. All
package tests pass with `go test ./... -race -count=1`.

See each commit message for the per-commit details.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./query/ -race -count=1`
- [x] `go test ./... -race -count=1`
- [ ] Live testnet smoke test (rebuild `darepod`, blow away cfheader
  state, confirm no more "batch already canceled" spam and that
  batches of 500+ requests run to completion)