### PR TITLE
.github: point gateway workflow at public gateway-action

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       GATEWAY_REVIEW_MODE: multi
     steps:
-      - uses: lightninglabs/gateway/.github/actions/review@v0.4.2
+      - uses: lightninglabs/gateway-action@v0.4.2
         with:
           event_name:      ${{ github.event_name }}
           event_action:    ${{ github.event.action }}


### PR DESCRIPTION
## What

Point the gateway review workflow at the new public entry point
`lightninglabs/gateway-action@v0.4.2` instead of the action inside the private
`lightninglabs/gateway` repo.

## Why

neutrino is a **public** repo. GitHub only extends a private repo's actions to
*private and internal* org repos, so the previous `uses:` could not be resolved
here — the job failed at setup, before any step ran:

```
##[error]Unable to resolve action `lightninglabs/gateway`, not found
```

`lightninglabs/gateway-action` is a thin **public** composite action that any
consumer can resolve. At runtime it mints a least-privilege token, checks out
the private review runtime, and runs it unchanged. The review logic stays
private; only the entry point is public.

See lightninglabs/gateway#27 for the design discussion.

## Change

Only the `uses:` line changes — all inputs (`installation_id`, credentials,
event wiring) are identical.
