### PR TITLE
blockmanager: disconnect unresponsive peers instead of banning them

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -96,6 +96,11 @@ type blockManagerCfg struct {
 	// BanPeer bans and disconnects the given peer.
 	BanPeer func(addr string, reason banman.Reason) error
 
+	// DisconnectPeer disconnects the given peer without banning it. We use
+	// this for peers that did not respond to a follow-up query, since a
+	// missing response is not proof that the peer served invalid data.
+	DisconnectPeer func(addr string) error
+
 	// GetBlock fetches a block from the p2p network.
 	GetBlock func(chainhash.Hash, ...QueryOption) (*btcutil.Block, error)
 
@@ -802,24 +807,18 @@ func (b *blockManager) getUncheckpointedCFHeaders(
 		if checkForCFHeaderMismatch(headers, i) {
 			targetHeight := startHeight + uint32(i)
 
-			badPeers, err := b.detectBadPeers(
+			invalidPeers, unresponsivePeers, err := b.detectBadPeers(
 				headers, targetHeight, uint32(i), fType,
 			)
 			if err != nil {
 				return err
 			}
 
-			log.Warnf("Banning %v peers due to invalid filter "+
-				"headers", len(badPeers))
-
-			for _, peer := range badPeers {
-				err := b.cfg.BanPeer(
-					peer, banman.InvalidFilterHeader,
-				)
-				if err != nil {
-					log.Errorf("Unable to ban peer %v: %v",
-						peer, err)
-				}
+			actedOn := b.banAndDisconnect(
+				invalidPeers, unresponsivePeers,
+				banman.InvalidFilterHeader,
+			)
+			for _, peer := range actedOn {
 				delete(headers, peer)
 			}
 		}
@@ -1529,24 +1528,18 @@ func (b *blockManager) resolveConflict(
 			// block as well.
 			targetHeight := startHeight + uint32(i)
 
-			badPeers, err := b.detectBadPeers(
+			invalidPeers, unresponsivePeers, err := b.detectBadPeers(
 				headers, targetHeight, uint32(i), fType,
 			)
 			if err != nil {
 				return nil, err
 			}
 
-			log.Warnf("Banning %v peers due to invalid filter "+
-				"headers", len(badPeers))
-
-			for _, peer := range badPeers {
-				err := b.cfg.BanPeer(
-					peer, banman.InvalidFilterHeader,
-				)
-				if err != nil {
-					log.Errorf("Unable to ban peer %v: %v",
-						peer, err)
-				}
+			actedOn := b.banAndDisconnect(
+				invalidPeers, unresponsivePeers,
+				banman.InvalidFilterHeader,
+			)
+			for _, peer := range actedOn {
 				delete(headers, peer)
 				delete(checkpoints, peer)
 			}
@@ -1554,16 +1547,15 @@ func (b *blockManager) resolveConflict(
 	}
 
 	// Any mismatches have now been thrown out. Delete any checkpoint
-	// lists that don't have matching headers, as these are peers that
-	// didn't respond, and ban them from future queries.
+	// lists that don't have matching headers. These are peers that did not
+	// respond, which is not proof that they served invalid data, so we
+	// disconnect them instead of banning them.
 	for peer := range checkpoints {
 		if _, ok := headers[peer]; !ok {
-			err := b.cfg.BanPeer(
-				peer, banman.InvalidFilterHeaderCheckpoint,
-			)
+			err := b.cfg.DisconnectPeer(peer)
 			if err != nil {
-				log.Errorf("Unable to ban peer %v: %v", peer,
-					err)
+				log.Errorf("Unable to disconnect peer %v: %v",
+					peer, err)
 			}
 			delete(checkpoints, peer)
 		}
@@ -1616,18 +1608,61 @@ func checkForCFHeaderMismatch(headers map[string]*wire.MsgCFHeaders,
 	return false
 }
 
+// banAndDisconnect bans every peer that served verified invalid filter data
+// using the given reason, and disconnects (without banning) every peer that
+// did not respond to a follow-up query. It returns all peers that were acted
+// on so the caller can drop them from its working maps.
+func (b *blockManager) banAndDisconnect(invalidPeers,
+	unresponsivePeers []string, banReason banman.Reason) []string {
+
+	if len(invalidPeers) > 0 {
+		log.Warnf("Banning %v peers due to invalid filters",
+			len(invalidPeers))
+	}
+	for _, peer := range invalidPeers {
+		err := b.cfg.BanPeer(peer, banReason)
+		if err != nil {
+			log.Errorf("Unable to ban peer %v: %v", peer, err)
+		}
+	}
+
+	if len(unresponsivePeers) > 0 {
+		log.Warnf("Disconnecting %v unresponsive peers without ban",
+			len(unresponsivePeers))
+	}
+	for _, peer := range unresponsivePeers {
+		err := b.cfg.DisconnectPeer(peer)
+		if err != nil {
+			log.Errorf("Unable to disconnect peer %v: %v", peer,
+				err)
+		}
+	}
+
+	actedOn := make([]string, 0, len(invalidPeers)+len(unresponsivePeers))
+	actedOn = append(actedOn, invalidPeers...)
+	actedOn = append(actedOn, unresponsivePeers...)
+
+	return actedOn
+}
+
 // detectBadPeers fetches filters and the block at the given height to attempt
-// to detect which peers are serving bad filters.
+// to detect which peers are serving bad filters. It returns two separate sets
+// of peers. invalidPeers are peers that we verified served invalid filter
+// data, and should be banned. unresponsivePeers are peers that did not answer
+// the follow-up filter query. A missing response is not proof that a peer
+// served invalid data, so those peers should be disconnected rather than
+// banned.
 func (b *blockManager) detectBadPeers(headers map[string]*wire.MsgCFHeaders,
 	targetHeight, filterIndex uint32,
-	fType wire.FilterType) ([]string, error) {
+	fType wire.FilterType) (invalidPeers, unresponsivePeers []string,
+	err error) {
 
 	log.Warnf("Detected cfheader mismatch at height=%v!!!", targetHeight)
 
 	// Get the block header for this height.
 	header, err := b.cfg.BlockHeaders.FetchHeaderByHeight(targetHeight)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Fetch filters from the peers in question.
@@ -1636,15 +1671,18 @@ func (b *blockManager) detectBadPeers(headers map[string]*wire.MsgCFHeaders,
 		targetHeight, header.BlockHash(), fType,
 	)
 
-	var badPeers []string
 	for peer, msg := range headers {
 		filter, ok := filtersFromPeers[peer]
 
-		// If a peer did not respond, ban it immediately.
+		// If a peer did not respond, we have not proven that it served
+		// invalid data. We still drop it from this round so it cannot
+		// stall our sync by only answering header queries, but we mark
+		// it unresponsive so the caller disconnects it instead of
+		// banning it.
 		if !ok {
 			log.Warnf("Peer %v did not respond to filter "+
-				"request, considering bad", peer)
-			badPeers = append(badPeers, peer)
+				"request, disconnecting without ban", peer)
+			unresponsivePeers = append(unresponsivePeers, peer)
 			continue
 		}
 
@@ -1652,36 +1690,43 @@ func (b *blockManager) detectBadPeers(headers map[string]*wire.MsgCFHeaders,
 		// its filter hashes, ban it.
 		hash, err := builder.GetFilterHash(filter)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if hash != *msg.FilterHashes[filterIndex] {
 			log.Warnf("Peer %v serving filters not consistent "+
 				"with filter hashes, considering bad.", peer)
-			badPeers = append(badPeers, peer)
+			invalidPeers = append(invalidPeers, peer)
 		}
 	}
 
-	if len(badPeers) != 0 {
-		return badPeers, nil
+	// If we already found peers to act on, ban or disconnect them without
+	// doing the more expensive block-based reconciliation.
+	if len(invalidPeers) != 0 || len(unresponsivePeers) != 0 {
+		return invalidPeers, unresponsivePeers, nil
 	}
 
 	// If all peers responded with consistent filters and hashes, get the
 	// block and use it to detect who is serving bad filters.
 	block, err := b.cfg.GetBlock(header.BlockHash())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	log.Warnf("Attempting to reconcile cfheader mismatch amongst %v peers",
 		len(headers))
 
-	return resolveFilterMismatchFromBlock(
+	invalidPeers, err = resolveFilterMismatchFromBlock(
 		block.MsgBlock(), fType, filtersFromPeers,
 
 		// We'll require a strict majority of our peers to agree on
 		// filters.
 		(len(filtersFromPeers)+2)/2,
 	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return invalidPeers, unresponsivePeers, nil
 }
 
 // resolveFilterMismatchFromBlock will attempt to cross-reference each filter

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -748,23 +748,35 @@ func TestBlockManagerDetectBadPeers(t *testing.T) {
 		blockHeader     = wire.BlockHeader{}
 		targetBlockHash = block.BlockHash()
 
-		peers  = []string{"good1:1", "good2:1", "bad:1", "good3:1"}
-		expBad = map[string]struct{}{
-			"bad:1": {},
-		}
+		peers = []string{"good1:1", "good2:1", "bad:1", "good3:1"}
 	)
 
 	testCases := []struct {
+		// name describes the scenario under test.
+		name string
+
 		// filterAnswers is used by each testcase to set the anwers we
 		// want each peer to respond with on filter queries.
 		filterAnswers func(string, map[string]wire.Message)
+
+		// expInvalid is the set of peers we expect to be classified as
+		// serving verified invalid data (and therefore banned).
+		expInvalid map[string]struct{}
+
+		// expUnresponsive is the set of peers we expect to be
+		// classified as not responding (and therefore disconnected
+		// without a ban).
+		expUnresponsive map[string]struct{}
 	}{
 		{
 			// We let the "bad" peers not respond to the filter
-			// query. They should be marked bad because they are
-			// unresponsive. We do this to ensure peers cannot
-			// only respond to us with headers, and stall our sync
-			// by not responding to filter requests.
+			// query. A missing response is not proof that they
+			// served invalid data, so they should be reported as
+			// unresponsive (disconnected without a ban) rather than
+			// banned. We still drop them from this round so they
+			// cannot stall our sync by only responding with
+			// headers.
+			name: "unresponsive peers are not banned",
 			filterAnswers: func(p string,
 				answers map[string]wire.Message) {
 
@@ -776,10 +788,16 @@ func TestBlockManagerDetectBadPeers(t *testing.T) {
 					fType, &targetBlockHash, filterBytes,
 				)
 			},
+			expInvalid: map[string]struct{}{},
+			expUnresponsive: map[string]struct{}{
+				"bad:1": {},
+			},
 		},
 		{
 			// We let the "bad" peers serve filters that don't hash
-			// to the filter headers they have sent.
+			// to the filter headers they have sent. This is
+			// verified invalid data, so they should be banned.
+			name: "peers serving invalid filters are banned",
 			filterAnswers: func(p string,
 				answers map[string]wire.Message) {
 
@@ -792,6 +810,10 @@ func TestBlockManagerDetectBadPeers(t *testing.T) {
 					fType, &targetBlockHash, filterData,
 				)
 			},
+			expInvalid: map[string]struct{}{
+				"bad:1": {},
+			},
+			expUnresponsive: map[string]struct{}{},
 		},
 	}
 
@@ -859,15 +881,21 @@ func TestBlockManagerDetectBadPeers(t *testing.T) {
 			},
 		}
 
-		// Now trying to detect which peers are bad, we should detect the
-		// bad ones.
-		badPeers, err := bm.detectBadPeers(
+		// Now trying to detect which peers are bad, we should split
+		// them into the verified-invalid set and the unresponsive set.
+		invalidPeers, unresponsivePeers, err := bm.detectBadPeers(
 			headers, targetIndex, badIndex, fType,
 		)
-		require.NoError(t, err)
+		require.NoError(t, err, test.name)
 
-		err = assertBadPeers(expBad, badPeers)
-		require.NoError(t, err)
+		require.NoError(
+			t, assertBadPeers(test.expInvalid, invalidPeers),
+			test.name,
+		)
+		require.NoError(
+			t, assertBadPeers(test.expUnresponsive, unresponsivePeers),
+			test.name,
+		)
 	}
 }
 

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -97,6 +97,9 @@ func setupBlockManager(t *testing.T) (*blockManager, headerfs.BlockHeaderStore,
 		BanPeer: func(string, banman.Reason) error {
 			return nil
 		},
+		DisconnectPeer: func(string) error {
+			return nil
+		},
 	})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to create "+
@@ -748,23 +751,35 @@ func TestBlockManagerDetectBadPeers(t *testing.T) {
 		blockHeader     = wire.BlockHeader{}
 		targetBlockHash = block.BlockHash()
 
-		peers  = []string{"good1:1", "good2:1", "bad:1", "good3:1"}
-		expBad = map[string]struct{}{
-			"bad:1": {},
-		}
+		peers = []string{"good1:1", "good2:1", "bad:1", "good3:1"}
 	)
 
 	testCases := []struct {
+		// name describes the scenario under test.
+		name string
+
 		// filterAnswers is used by each testcase to set the anwers we
 		// want each peer to respond with on filter queries.
 		filterAnswers func(string, map[string]wire.Message)
+
+		// expInvalid is the set of peers we expect to be classified as
+		// serving verified invalid data (and therefore banned).
+		expInvalid map[string]struct{}
+
+		// expUnresponsive is the set of peers we expect to be
+		// classified as not responding (and therefore disconnected
+		// without a ban).
+		expUnresponsive map[string]struct{}
 	}{
 		{
 			// We let the "bad" peers not respond to the filter
-			// query. They should be marked bad because they are
-			// unresponsive. We do this to ensure peers cannot
-			// only respond to us with headers, and stall our sync
-			// by not responding to filter requests.
+			// query. A missing response is not proof that they
+			// served invalid data, so they should be reported as
+			// unresponsive (disconnected without a ban) rather than
+			// banned. We still drop them from this round so they
+			// cannot stall our sync by only responding with
+			// headers.
+			name: "unresponsive peers are not banned",
 			filterAnswers: func(p string,
 				answers map[string]wire.Message) {
 
@@ -776,10 +791,16 @@ func TestBlockManagerDetectBadPeers(t *testing.T) {
 					fType, &targetBlockHash, filterBytes,
 				)
 			},
+			expInvalid: map[string]struct{}{},
+			expUnresponsive: map[string]struct{}{
+				"bad:1": {},
+			},
 		},
 		{
 			// We let the "bad" peers serve filters that don't hash
-			// to the filter headers they have sent.
+			// to the filter headers they have sent. This is
+			// verified invalid data, so they should be banned.
+			name: "peers serving invalid filters are banned",
 			filterAnswers: func(p string,
 				answers map[string]wire.Message) {
 
@@ -792,6 +813,10 @@ func TestBlockManagerDetectBadPeers(t *testing.T) {
 					fType, &targetBlockHash, filterData,
 				)
 			},
+			expInvalid: map[string]struct{}{
+				"bad:1": {},
+			},
+			expUnresponsive: map[string]struct{}{},
 		},
 	}
 
@@ -859,15 +884,21 @@ func TestBlockManagerDetectBadPeers(t *testing.T) {
 			},
 		}
 
-		// Now trying to detect which peers are bad, we should detect the
-		// bad ones.
-		badPeers, err := bm.detectBadPeers(
+		// Now trying to detect which peers are bad, we should split
+		// them into the verified-invalid set and the unresponsive set.
+		invalidPeers, unresponsivePeers, err := bm.detectBadPeers(
 			headers, targetIndex, badIndex, fType,
 		)
-		require.NoError(t, err)
+		require.NoError(t, err, test.name)
 
-		err = assertBadPeers(expBad, badPeers)
-		require.NoError(t, err)
+		require.NoError(
+			t, assertBadPeers(test.expInvalid, invalidPeers),
+			test.name,
+		)
+		require.NoError(
+			t, assertBadPeers(test.expUnresponsive, unresponsivePeers),
+			test.name,
+		)
 	}
 }
 

--- a/neutrino.go
+++ b/neutrino.go
@@ -852,6 +852,7 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		TimeSource:       s.timeSource,
 		QueryDispatcher:  s.workManager,
 		BanPeer:          s.BanPeer,
+		DisconnectPeer:   s.DisconnectPeer,
 		GetBlock:         s.GetBlock,
 		firstPeerSignal:  s.firstPeerConnect,
 		queryAllPeers:    s.queryAllPeers,
@@ -1123,6 +1124,20 @@ func (s *ChainService) BanPeer(addr string, reason banman.Reason) error {
 			addr, err)
 	}
 	return s.banStore.BanIPNet(ipNet, reason, BanDuration)
+}
+
+// DisconnectPeer disconnects the given peer without recording a ban. We use
+// this when a peer fails to respond to a follow-up query. A missing response
+// is not proof that the peer served invalid data, so we drop the connection
+// but do not apply a ban.
+func (s *ChainService) DisconnectPeer(addr string) error {
+	log.Warnf("Disconnecting peer %v without ban", addr)
+
+	if sp := s.PeerByAddr(addr); sp != nil {
+		sp.Disconnect()
+	}
+
+	return nil
 }
 
 // UnbanPeer connects and unbans a previously banned peer.


### PR DESCRIPTION
### Fixes #349

Compact-filter sync could ban honest peers for not answering a follow-up query, even when there was no proof they served invalid data. A timeout, a disconnect, or the local node being offline was treated the same as serving bad filter data, which led to a 24 hour ban.

This splits the handling into two cases:

- Peers we can verify served invalid data (a filter that does not match its hashes, or that loses the block-based reconciliation) are still banned with `InvalidFilterHeader` or `InvalidFilterHeaderCheckpoint`.
- Peers that did not respond are disconnected and dropped from the current round, but no ban record is written.

The anti-stall behavior is kept: a peer that answers headers or checkpoints but withholds the follow-up filter is still removed from the active round, it just is not banned.

### Changes

- `detectBadPeers` now returns the invalid peers and the unresponsive peers as separate sets.
- Added a `DisconnectPeer` callback, similar to `BanPeer`, that drops the connection without writing a ban. A disconnect for a peer that is already gone is a no-op and does not fail sync.
- The checkpoint conflict path in `resolveConflict` now disconnects non-responders instead of banning them.
- Updated `TestBlockManagerDetectBadPeers` to cover both cases: non-responders are reported as unresponsive (disconnected, not banned), and peers serving invalid filters are still banned.
