### PR TITLE
neutrino: add SQL import follow-up fixes

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -282,6 +282,49 @@ func newBlockManager(cfg *blockManagerCfg) (*blockManager, error) {
 	return &bm, nil
 }
 
+// ResetHeaderState re-reads the chain tips from the header stores and
+// reinitializes the block manager's internal tracking state. This must be
+// called after headers have been imported into the stores outside of the
+// block manager (e.g., via chainimport) but before the block manager is
+// started, so that it begins syncing from the correct chain tip rather
+// than the stale state captured at construction time.
+func (b *blockManager) ResetHeaderState() error {
+	// Re-read the block header chain tip from the store.
+	header, height, err := b.cfg.BlockHeaders.ChainTip()
+	if err != nil {
+		return fmt.Errorf("failed to read block header chain "+
+			"tip: %w", err)
+	}
+	b.nextCheckpoint = b.findNextHeaderCheckpoint(int32(height))
+	b.headerList.ResetHeaderState(headerlist.Node{
+		Header: *header,
+		Height: int32(height),
+	})
+	b.headerTip = height
+	b.headerTipHash = header.BlockHash()
+
+	// Re-read the filter header chain tip from the store.
+	_, b.filterHeaderTip, err = b.cfg.RegFilterHeaders.ChainTip()
+	if err != nil {
+		return fmt.Errorf("failed to read filter header chain "+
+			"tip: %w", err)
+	}
+
+	// Ensure the filter header tip hash is set to the block hash at the
+	// filter tip height.
+	fh, err := b.cfg.BlockHeaders.FetchHeaderByHeight(b.filterHeaderTip)
+	if err != nil {
+		return fmt.Errorf("failed to fetch block header at filter "+
+			"tip height %d: %w", b.filterHeaderTip, err)
+	}
+	b.filterHeaderTipHash = fh.BlockHash()
+
+	log.Infof("Block manager header state reset: block tip=%d, "+
+		"filter tip=%d", height, b.filterHeaderTip)
+
+	return nil
+}
+
 // Start begins the core block handler which processes block and inv messages.
 func (b *blockManager) Start() {
 	// Already started?

--- a/filterdb/db.go
+++ b/filterdb/db.go
@@ -168,7 +168,7 @@ func putFilter(bucket walletdb.ReadWriteBucket, hash *chainhash.Hash,
 // NOTE: This method is a part of the FilterDatabase interface.
 func (f *FilterStore) PutFilters(filterList ...*FilterData) error {
 	var updateErr error
-	err := walletdb.Batch(f.db, func(tx walletdb.ReadWriteTx) error {
+	putFilters := func(tx walletdb.ReadWriteTx) error {
 		filters := tx.ReadWriteBucket(filterBucket)
 		regularFilterBkt := filters.NestedReadWriteBucket(regBucket)
 
@@ -197,7 +197,19 @@ func (f *FilterStore) PutFilters(filterList ...*FilterData) error {
 		}
 
 		return nil
-	})
+	}
+
+	var err error
+
+	// Batch is an optimization that some walletdb backends, such as bdb,
+	// implement to coalesce concurrent write transactions. Other backends
+	// only satisfy the base walletdb.DB interface, so fall back to a normal
+	// write transaction when batching is unavailable.
+	if _, ok := f.db.(walletdb.BatchDB); ok {
+		err = walletdb.Batch(f.db, putFilters)
+	} else {
+		err = walletdb.Update(f.db, putFilters)
+	}
 	if err != nil {
 		return err
 	}

--- a/filterdb/db_test.go
+++ b/filterdb/db_test.go
@@ -14,7 +14,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createTestDatabase(t *testing.T) FilterDatabase {
+// nonBatchDB embeds a walletdb.DB while shadowing any Batch method on the
+// underlying value. It lets tests exercise the PutFilters fallback path used
+// by backends that satisfy walletdb.DB but not walletdb.BatchDB.
+type nonBatchDB struct {
+	walletdb.DB
+}
+
+// createTestWalletDB creates a temporary bdb-backed walletdb.DB that is
+// cleaned up when the test finishes.
+func createTestWalletDB(t *testing.T) walletdb.DB {
 	tempDir := t.TempDir()
 
 	db, err := walletdb.Create(
@@ -25,6 +34,19 @@ func createTestDatabase(t *testing.T) FilterDatabase {
 		require.NoError(t, db.Close())
 	})
 
+	return db
+}
+
+// createTestDatabase creates a FilterDatabase backed by a fresh temporary
+// bdb walletdb instance for use in tests.
+func createTestDatabase(t *testing.T) FilterDatabase {
+	return createTestDatabaseWithDB(t, createTestWalletDB(t))
+}
+
+// createTestDatabaseWithDB wraps the given walletdb.DB in a FilterDatabase so
+// that tests can supply a custom backend, for example one that hides
+// optional interfaces such as walletdb.BatchDB.
+func createTestDatabaseWithDB(t *testing.T, db walletdb.DB) FilterDatabase {
 	filterDB, err := New(db, chaincfg.SimNetParams)
 	require.NoError(t, err)
 
@@ -75,7 +97,24 @@ func genRandFilter(t *testing.T, numElements uint32) *gcs.Filter {
 // TestFilterStorage test writing to and reading from the filter DB.
 func TestFilterStorage(t *testing.T) {
 	database := createTestDatabase(t)
+	assertFilterStorage(t, database)
+}
 
+// TestFilterStorageWithoutBatch tests writing filters to a database that
+// supports normal read/write transactions, but not batched transactions.
+func TestFilterStorageWithoutBatch(t *testing.T) {
+	db := createTestWalletDB(t)
+
+	// Wrapping the bdb handle hides its Batch method and gives us the same
+	// interface shape as walletdb backends that do not implement BatchDB.
+	database := createTestDatabaseWithDB(t, &nonBatchDB{DB: db})
+	assertFilterStorage(t, database)
+}
+
+// assertFilterStorage runs the filter store round-trip assertions against
+// the provided FilterDatabase: it generates random regular filters, writes
+// them via PutFilters, and verifies they can be read back.
+func assertFilterStorage(t *testing.T, database FilterDatabase) {
 	// We'll generate a random block hash to create our test filters
 	// against.
 	var randHash chainhash.Hash

--- a/neutrino.go
+++ b/neutrino.go
@@ -1748,6 +1748,17 @@ func (s *ChainService) Start(ctx context.Context) error {
 		if _, err := importer.Import(ctx); err != nil {
 			return err
 		}
+
+		// The block manager was constructed before the import ran,
+		// so its internal header tracking state (headerList,
+		// headerTip, filterHeaderTip, etc.) reflects the
+		// pre-import chain tips. Re-read the now-updated stores
+		// so the block manager starts syncing from the correct
+		// height rather than from genesis.
+		if err := s.blockManager.ResetHeaderState(); err != nil {
+			return fmt.Errorf("failed to reset block manager "+
+				"state after headers import: %w", err)
+		}
 	}
 
 	// Start the address manager and block manager, both of which are

--- a/sync_test.go
+++ b/sync_test.go
@@ -1249,6 +1249,139 @@ func TestNeutrinoSyncWithHeadersImport(t *testing.T) {
 	testInitialSync(testHarness, t)
 }
 
+// TestNeutrinoImportThenP2PSync verifies that a single ChainService that
+// imports headers from files can also continue syncing new blocks via P2P
+// in the same session. This exercises the ResetHeaderState path: the block
+// manager is constructed (with an empty store) before Start() runs the
+// import, so its internal tracking state must be refreshed after import to
+// build correct P2P locators for the remaining chain.
+func TestNeutrinoImportThenP2PSync(t *testing.T) {
+	rootCtx := context.Background()
+
+	// Create a btcd SimNet node and generate an initial chain.
+	h1, err := rpctest.New(
+		&chaincfg.SimNetParams, nil, []string{"--txindex"}, "",
+	)
+	require.NoError(t, err)
+	defer h1.TearDown()
+
+	err = h1.SetUp(false, 0)
+	require.NoError(t, err)
+
+	const initialBlocks = 800
+	_, err = h1.Client.Generate(initialBlocks)
+	require.NoError(t, err)
+
+	// Sync an export service to obtain header files.
+	exportDir := t.TempDir()
+	defer os.RemoveAll(exportDir)
+
+	exportDB, err := walletdb.Create(
+		"bdb", exportDir+"/filters.db", true, dbOpenTimeout,
+	)
+	require.NoError(t, err)
+
+	neutrino.MaxPeers = 1
+	neutrino.BanDuration = 5 * time.Second
+	neutrino.QueryPeerConnectTimeout = 10 * time.Second
+
+	exportSvc, err := neutrino.NewChainService(neutrino.Config{
+		DataDir:     exportDir,
+		Database:    exportDB,
+		ChainParams: chaincfg.SimNetParams,
+		AddPeers:    []string{h1.P2PAddress()},
+	})
+	require.NoError(t, err)
+	exportSvc.Start(rootCtx)
+
+	err = waitForSync(t, exportSvc, h1)
+	require.NoError(t, err, "export service failed to sync")
+
+	// Copy the header files and add import metadata.
+	importDir := t.TempDir()
+	defer os.RemoveAll(importDir)
+
+	blockSrc := filepath.Join(exportDir, "block_headers.bin")
+	filterSrc := filepath.Join(exportDir, "reg_filter_headers.bin")
+	blockDst := filepath.Join(importDir, "block_headers.bin")
+	filterDst := filepath.Join(importDir, "reg_filter_headers.bin")
+
+	err = copyFile(blockSrc, blockDst)
+	require.NoError(t, err)
+	err = copyFile(filterSrc, filterDst)
+	require.NoError(t, err)
+
+	err = chainimport.AddHeadersImportMetadata(
+		blockDst, chaincfg.SimNetParams.Net, 0,
+		headerfs.Block, 0,
+	)
+	require.NoError(t, err)
+	err = chainimport.AddHeadersImportMetadata(
+		filterDst, chaincfg.SimNetParams.Net, 0,
+		headerfs.RegularFilter, 0,
+	)
+	require.NoError(t, err)
+
+	exportSvc.Stop()
+	require.NoError(t, exportDB.Close())
+
+	// Mine additional blocks AFTER the export, so the import files only
+	// cover [0, initialBlocks]. The service must fetch the rest via P2P.
+	const extraBlocks = 50
+	_, err = h1.Client.Generate(extraBlocks)
+	require.NoError(t, err)
+
+	// Create a fresh service with BOTH headers import AND a peer
+	// connection. This is the critical setup: the block manager is
+	// constructed in NewChainService (reading the empty store), then
+	// Start() runs the import (populating the store), then the block
+	// manager begins P2P sync. Without ResetHeaderState, the block
+	// manager would use a genesis locator and fail to fetch the
+	// remaining blocks.
+	svcDir := t.TempDir()
+	defer os.RemoveAll(svcDir)
+
+	svcDB, err := walletdb.Create(
+		"bdb", svcDir+"/filters.db", true, dbOpenTimeout,
+	)
+	require.NoError(t, err)
+	defer svcDB.Close()
+
+	svc, err := neutrino.NewChainService(neutrino.Config{
+		DataDir:     svcDir,
+		Database:    svcDB,
+		ChainParams: chaincfg.SimNetParams,
+		AddPeers:    []string{h1.P2PAddress()},
+		HeadersImport: &neutrino.HeadersImportConfig{
+			BlockHeadersSource:      blockDst,
+			FilterHeadersSource:     filterDst,
+			ValidationFlags:         blockchain.BFFastAdd,
+			WriteBatchSizePerRegion: 64,
+		},
+	})
+	require.NoError(t, err)
+
+	svc.Start(rootCtx)
+	defer svc.Stop()
+
+	// The service should sync all the way to initialBlocks + extraBlocks
+	// by importing the first batch from file and fetching the rest via
+	// P2P.
+	err = waitForSync(t, svc, h1)
+	require.NoError(t, err, "service failed to sync after import + P2P")
+
+	// Verify the service reached the expected height.
+	best, err := svc.BestBlock()
+	require.NoError(t, err)
+
+	_, expectedHeight, err := h1.Client.GetBestBlock()
+	require.NoError(t, err)
+	require.Equal(
+		t, expectedHeight, best.Height,
+		"service height should match btcd tip",
+	)
+}
+
 // TestNeutrinoSyncWithoutHeadersImport tests the standard synchronization
 // behavior of Neutrino without using the headers import feature.
 func TestNeutrinoSyncWithoutHeadersImport(t *testing.T) {


### PR DESCRIPTION
In this PR, we add a small set of follow-up fixes on top of the SQL backend stack. The main fix is around the handoff from the legacy chain importer into normal P2P sync: after `ChainService.Start` imports headers into the backing store, the block manager needs to refresh its in-memory tip state before building locators. Without that refresh, the backing store can be at the imported tip while the block manager still thinks it is at genesis.

We also make filter writes tolerate walletdb backends that don't expose `walletdb.BatchDB`. The optimized batch path is still used when the backend supports it, while simpler backends fall back to a normal `walletdb.Update` transaction.

## Stack

This stacks on #357, a.k.a `roasbeef/sql-06-wiring-and-ci`.

## Details

In `filterdb`, we check whether the underlying walletdb backend supports `BatchDB` before calling `walletdb.Batch`. This keeps the existing fast path for backends that can coalesce writes, but avoids failing with `need batch` for backends that only satisfy the base `walletdb.DB` interface.

In the block manager, we add a `ResetHeaderState` method that re-reads the block header and filter header tips from their stores. `ChainService.Start` calls it immediately after a successful chain import, before the block manager starts network sync.

The new sync test covers the complete handoff: import an exported header snapshot, mine more blocks, start the service with both `HeadersImport` and `AddPeers`, then verify the service catches up over P2P.

## Tests

```bash
go test ./filterdb -count=1
go test . -run 'TestNeutrinoImportThenP2PSync|TestNewChainServiceSQLPath|TestNewChainServiceSQLValidation' -count=1
go test ./... -count=1
```

The full default suite passed locally, with the root package taking about 205s.