### PR TITLE
sqldb+headerfs: tune sqlite header storage

### DIFF
--- a/headerfs/sql_store.go
+++ b/headerfs/sql_store.go
@@ -28,6 +28,26 @@ type SQLBlockHeaderStore struct {
 	// blockmanager rely on: a ChainTip immediately following a
 	// successful WriteHeaders must observe the new tip.
 	mtx sync.RWMutex
+
+	// The SQL store backs lnd's ChainConn methods. During notifier startup
+	// lnd replays missed block epochs with sequential height/hash lookups,
+	// so keep a bounded read-through cache to collapse that scan into
+	// occasional range reads instead of one sqlite tx per height.
+	cacheMtx         sync.Mutex
+	headerCache      map[chainhash.Hash]cachedSQLBlockHeader
+	heightCache      map[uint32]chainhash.Hash
+	headerCacheOrder []chainhash.Hash
+	headerCacheNext  int
+}
+
+const (
+	sqlBlockHeaderReadCacheSize     = 8192
+	sqlBlockHeaderReadCachePrefetch = 2048
+)
+
+type cachedSQLBlockHeader struct {
+	header wire.BlockHeader
+	height uint32
 }
 
 // A compile-time check to ensure SQLBlockHeaderStore satisfies the
@@ -53,6 +73,114 @@ func NewSQLBlockHeaderStore(ctx context.Context, db sqldb.HeaderTx,
 	}
 
 	return store, nil
+}
+
+func (s *SQLBlockHeaderStore) cachedBlockHeader(hash *chainhash.Hash) (
+	*wire.BlockHeader, uint32, bool) {
+
+	s.cacheMtx.Lock()
+	defer s.cacheMtx.Unlock()
+
+	cachedHeader, ok := s.headerCache[*hash]
+	if !ok {
+		return nil, 0, false
+	}
+
+	header := cachedHeader.header
+	return &header, cachedHeader.height, true
+}
+
+func (s *SQLBlockHeaderStore) cachedBlockHeaderByHeight(height uint32) (
+	*wire.BlockHeader, bool) {
+
+	s.cacheMtx.Lock()
+	defer s.cacheMtx.Unlock()
+
+	hash, ok := s.heightCache[height]
+	if !ok {
+		return nil, false
+	}
+
+	cachedHeader, ok := s.headerCache[hash]
+	if !ok {
+		delete(s.heightCache, height)
+		return nil, false
+	}
+
+	header := cachedHeader.header
+	return &header, true
+}
+
+func (s *SQLBlockHeaderStore) rememberBlockHeader(height uint32,
+	header *wire.BlockHeader) {
+
+	hash := header.BlockHash()
+
+	s.cacheMtx.Lock()
+	defer s.cacheMtx.Unlock()
+
+	if s.headerCache == nil {
+		s.headerCache = make(
+			map[chainhash.Hash]cachedSQLBlockHeader,
+			sqlBlockHeaderReadCacheSize,
+		)
+		s.heightCache = make(
+			map[uint32]chainhash.Hash,
+			sqlBlockHeaderReadCacheSize,
+		)
+	}
+
+	cachedHeader := cachedSQLBlockHeader{
+		header: *header,
+		height: height,
+	}
+
+	if oldHash, ok := s.heightCache[height]; ok && oldHash != hash {
+		delete(s.headerCache, oldHash)
+	}
+
+	if _, ok := s.headerCache[hash]; ok {
+		s.headerCache[hash] = cachedHeader
+		s.heightCache[height] = hash
+		return
+	}
+
+	if len(s.headerCacheOrder) < sqlBlockHeaderReadCacheSize {
+		s.headerCacheOrder = append(s.headerCacheOrder, hash)
+	} else {
+		evictedHash := s.headerCacheOrder[s.headerCacheNext]
+		if evictedHeader, ok := s.headerCache[evictedHash]; ok {
+			delete(s.heightCache, evictedHeader.height)
+		}
+		delete(s.headerCache, evictedHash)
+
+		s.headerCacheOrder[s.headerCacheNext] = hash
+		s.headerCacheNext = (s.headerCacheNext + 1) %
+			sqlBlockHeaderReadCacheSize
+	}
+
+	s.headerCache[hash] = cachedHeader
+	s.heightCache[height] = hash
+}
+
+func (s *SQLBlockHeaderStore) clearBlockHeaderCache() {
+	s.cacheMtx.Lock()
+	defer s.cacheMtx.Unlock()
+
+	clear(s.headerCache)
+	clear(s.heightCache)
+	s.headerCacheOrder = s.headerCacheOrder[:0]
+	s.headerCacheNext = 0
+}
+
+func sqlBlockHeaderReadCachePrefetchEnd(height uint32) uint32 {
+	const maxUint32 = ^uint32(0)
+
+	if maxUint32-height < sqlBlockHeaderReadCachePrefetch-1 {
+		return maxUint32
+	}
+
+	return height + sqlBlockHeaderReadCachePrefetch - 1
 }
 
 // ensureGenesis writes the genesis block header row into block_headers if
@@ -146,24 +274,51 @@ func (s *SQLBlockHeaderStore) FetchHeaderByHeight(height uint32) (
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 
+	if header, ok := s.cachedBlockHeaderByHeight(height); ok {
+		return header, nil
+	}
+
 	var (
 		header *wire.BlockHeader
 		ctx    = context.Background()
 	)
 	err := s.db.ExecTx(ctx, sqldbv2.ReadTxOpt(),
 		func(q sqldb.HeaderQueries) error {
-			raw, err := q.GetBlockHeaderByHeight(
-				ctx, int64(height),
+			rows, err := q.GetBlockHeaderRange(
+				ctx, sqlc.GetBlockHeaderRangeParams{
+					StartHeight: int64(height),
+					EndHeight: int64(
+						sqlBlockHeaderReadCachePrefetchEnd(
+							height,
+						),
+					),
+				},
 			)
-			if err != nil {
-				return mapHeaderNotFound(err)
-			}
-
-			h, err := decodeBlockHeader(raw)
 			if err != nil {
 				return err
 			}
-			header = h
+			if len(rows) == 0 {
+				return mapHeaderNotFound(sql.ErrNoRows)
+			}
+
+			for _, row := range rows {
+				h, err := decodeBlockHeader(row.RawHeader)
+				if err != nil {
+					return err
+				}
+
+				rowHeight := uint32(row.Height)
+				s.rememberBlockHeader(rowHeight, h)
+
+				if rowHeight == height {
+					header = h
+				}
+			}
+
+			if header == nil {
+				return mapHeaderNotFound(sql.ErrNoRows)
+			}
+
 			return nil
 		}, sqldbv2.NoOpReset)
 	if err != nil {
@@ -183,6 +338,10 @@ func (s *SQLBlockHeaderStore) FetchHeader(hash *chainhash.Hash) (
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 
+	if header, height, ok := s.cachedBlockHeader(hash); ok {
+		return header, height, nil
+	}
+
 	var (
 		header *wire.BlockHeader
 		height uint32
@@ -201,6 +360,7 @@ func (s *SQLBlockHeaderStore) FetchHeader(hash *chainhash.Hash) (
 			}
 			header = h
 			height = uint32(row.Height)
+			s.rememberBlockHeader(height, h)
 			return nil
 		}, sqldbv2.NoOpReset)
 	if err != nil {
@@ -373,10 +533,12 @@ func (s *SQLBlockHeaderStore) WriteHeaders(hdrs ...BlockHeader) error {
 	defer s.mtx.Unlock()
 
 	ctx := context.Background()
-	return s.db.ExecTx(ctx, sqldbv2.WriteTxOpt(),
+	err := s.db.ExecTx(ctx, sqldbv2.WriteTxOpt(),
 		func(q sqldb.HeaderQueries) error {
-			var lastHash chainhash.Hash
-			var lastHeight uint32
+			var (
+				lastHash   chainhash.Hash
+				lastHeight uint32
+			)
 
 			for _, hdr := range hdrs {
 				var raw bytes.Buffer
@@ -408,6 +570,15 @@ func (s *SQLBlockHeaderStore) WriteHeaders(hdrs ...BlockHeader) error {
 				},
 			)
 		}, sqldbv2.NoOpReset)
+	if err != nil {
+		return err
+	}
+
+	for _, hdr := range hdrs {
+		s.rememberBlockHeader(hdr.Height, hdr.BlockHeader)
+	}
+
+	return nil
 }
 
 // RollbackBlockHeaders deletes the n most recent headers and resets the
@@ -484,6 +655,9 @@ func (s *SQLBlockHeaderStore) RollbackBlockHeaders(n uint32) (*BlockStamp,
 	if err != nil {
 		return nil, err
 	}
+
+	s.clearBlockHeaderCache()
+
 	return &stamp, nil
 }
 
@@ -856,6 +1030,7 @@ func (s *SQLFilterHeaderStore) WriteHeaders(hdrs ...FilterHeader) error {
 				if err != nil {
 					return err
 				}
+
 				tipHash = hdr.FilterHash
 				tipHeight = hdr.Height
 			}

--- a/headerfs/sql_store_test.go
+++ b/headerfs/sql_store_test.go
@@ -122,6 +122,109 @@ func TestSQLBlockHeaderRollbackAtomic(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestSQLBlockHeaderReadThroughCache verifies the SQL-backed header store
+// caches the decoded header after a height lookup. lnd's missed-block scan
+// calls GetBlockHash(height) followed by GetBlockHeader(hash), so this keeps
+// the second lookup off the sqlite read path.
+func TestSQLBlockHeaderReadThroughCache(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLBlockHeaderStore(t)
+
+	chain := createTestBlockHeaderChain(10)
+	require.NoError(t, store.WriteHeaders(chain...))
+	store.clearBlockHeaderCache()
+
+	target := chain[5]
+	targetHash := target.BlockHash()
+
+	_, _, ok := store.cachedBlockHeader(&targetHash)
+	require.False(t, ok)
+
+	header, err := store.FetchHeaderByHeight(target.Height)
+	require.NoError(t, err)
+	require.True(t, reflect.DeepEqual(*target.BlockHeader, *header))
+
+	next := chain[6]
+	nextHash := next.BlockHash()
+	nextHeader, ok := store.cachedBlockHeaderByHeight(next.Height)
+	require.True(t, ok)
+	require.True(t, reflect.DeepEqual(*next.BlockHeader, *nextHeader))
+
+	cachedNextHeader, cachedNextHeight, ok := store.cachedBlockHeader(
+		&nextHash,
+	)
+	require.True(t, ok)
+	require.Equal(t, next.Height, cachedNextHeight)
+	require.True(t, reflect.DeepEqual(*next.BlockHeader, *cachedNextHeader))
+
+	cachedHeader, cachedHeight, ok := store.cachedBlockHeader(&targetHash)
+	require.True(t, ok)
+	require.Equal(t, target.Height, cachedHeight)
+	require.True(t, reflect.DeepEqual(*target.BlockHeader, *cachedHeader))
+
+	header, height, err := store.FetchHeader(&targetHash)
+	require.NoError(t, err)
+	require.Equal(t, target.Height, height)
+	require.True(t, reflect.DeepEqual(*target.BlockHeader, *header))
+}
+
+// TestSQLBlockHeaderReadCacheClearedOnRollback verifies rollback never leaves
+// stale cached headers available after the SQL rows have been removed.
+func TestSQLBlockHeaderReadCacheClearedOnRollback(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLBlockHeaderStore(t)
+
+	chain := createTestBlockHeaderChain(10)
+	require.NoError(t, store.WriteHeaders(chain...))
+	store.clearBlockHeaderCache()
+
+	tip := chain[len(chain)-1]
+	tipHash := tip.BlockHash()
+
+	_, err := store.FetchHeaderByHeight(tip.Height)
+	require.NoError(t, err)
+
+	_, _, ok := store.cachedBlockHeader(&tipHash)
+	require.True(t, ok)
+
+	_, err = store.RollbackLastBlock()
+	require.NoError(t, err)
+
+	_, _, ok = store.cachedBlockHeader(&tipHash)
+	require.False(t, ok)
+
+	_, _, err = store.FetchHeader(&tipHash)
+	require.Error(t, err)
+}
+
+// TestSQLFilterHeaderRollbackAtomic verifies that a failed filter header
+// batch does not leave any rows behind.
+func TestSQLFilterHeaderRollbackAtomic(t *testing.T) {
+	t.Parallel()
+
+	store := newSQLFilterHeaderStore(t, nil)
+
+	chain := createTestFilterHeaderChain(10)
+	require.NoError(t, store.WriteHeaders(chain[:5]...))
+
+	collide := chain[3] // header hash already inserted at height 4.
+	collide.Height = chain[7].Height
+	bad := []FilterHeader{chain[5], collide}
+
+	err := store.WriteHeaders(bad...)
+	require.Error(t, err)
+
+	tip, height, err := store.ChainTip()
+	require.NoError(t, err)
+	require.Equal(t, chain[4].Height, height)
+	require.Equal(t, chain[4].FilterHash, *tip)
+
+	_, err = store.FetchHeaderByHeight(chain[5].Height)
+	require.Error(t, err)
+}
+
 // TestSQLBlockHeaderGenesisIdempotent verifies that constructing the SQL
 // block header store twice against the same database leaves a single
 // genesis row.
@@ -164,7 +267,7 @@ func TestSQLBlockHeaderFetchAncestors(t *testing.T) {
 	stop := chain[40].BlockHash()
 	headers, startHeight, err := store.FetchHeaderAncestors(10, &stop)
 	require.NoError(t, err)
-	require.Len(t, headers, 11)            // 10 ancestors + stop
+	require.Len(t, headers, 11) // 10 ancestors + stop
 	require.Equal(t, uint32(31), startHeight)
 	for i, h := range headers {
 		require.True(t, reflect.DeepEqual(*chain[31+i-1].BlockHeader,

--- a/sqldb/backend.go
+++ b/sqldb/backend.go
@@ -54,7 +54,7 @@ func NewBackend(dataDir string, cfg *Config,
 	switch cfg.Backend {
 	case BackendSqlite:
 		dbPath := filepath.Join(dataDir, cfg.sqliteFilename())
-		s, err := sqldbv2.NewSqliteStore(cfg.Sqlite, dbPath)
+		s, err := sqldbv2.NewSqliteStore(cfg.sqliteConfig(), dbPath)
 		if err != nil {
 			return nil, fmt.Errorf("sqldb: open sqlite: %w", err)
 		}
@@ -77,7 +77,6 @@ func NewBackend(dataDir string, cfg *Config,
 	}
 
 	baseDB := store.GetBaseDB()
-
 	headerExec := sqldbv2.NewTransactionExecutor[HeaderQueries](
 		baseDB,
 		func(tx *sql.Tx) HeaderQueries {

--- a/sqldb/backend_test.go
+++ b/sqldb/backend_test.go
@@ -85,4 +85,86 @@ func TestNewBackendSqlite(t *testing.T) {
 			return nil
 		}, sqldbv2.NoOpReset,
 	))
+
+	assertNoDuplicateHeaderHashIndex(t, backend, "block_headers")
+	assertNoDuplicateHeaderHashIndex(t, backend, "filter_headers")
+	assertSqliteChainPragmas(t, backend)
+}
+
+func assertNoDuplicateHeaderHashIndex(t *testing.T, backend *Backend,
+	tableName string) {
+
+	t.Helper()
+
+	db := backend.store.GetBaseDB().DB
+	rows, err := db.Query("PRAGMA index_list('" + tableName + "')")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var indexNames []string
+	for rows.Next() {
+		var (
+			seq     int
+			name    string
+			unique  int
+			origin  string
+			partial int
+		)
+		require.NoError(
+			t, rows.Scan(&seq, &name, &unique, &origin, &partial),
+		)
+		indexNames = append(indexNames, name)
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+
+	var hashIndexes []string
+	for _, name := range indexNames {
+		cols, err := db.Query("PRAGMA index_info('" + name + "')")
+		require.NoError(t, err)
+
+		var columns []string
+		for cols.Next() {
+			var (
+				cid     int
+				seqno   int
+				colName string
+			)
+			require.NoError(
+				t, cols.Scan(&seqno, &cid, &colName),
+			)
+			columns = append(columns, colName)
+		}
+		require.NoError(t, cols.Err())
+		require.NoError(t, cols.Close())
+
+		if len(columns) == 1 && columns[0] == "block_hash" {
+			hashIndexes = append(hashIndexes, name)
+		}
+	}
+
+	require.Len(t, hashIndexes, 1)
+	require.NotContains(t, hashIndexes, tableName+"_hash_idx")
+}
+
+func assertSqliteChainPragmas(t *testing.T, backend *Backend) {
+	t.Helper()
+
+	db := backend.store.GetBaseDB().DB
+	for pragma, expected := range map[string]int64{
+		"synchronous":          1,
+		"checkpoint_fullfsync": 0,
+		"wal_autocheckpoint":   50000,
+		"journal_size_limit":   268435456,
+		"temp_store":           2,
+		"cache_size":           -131072,
+		"mmap_size":            268435456,
+	} {
+		var got int64
+		require.NoError(
+			t, db.QueryRow("PRAGMA "+pragma).Scan(&got),
+			"pragma=%v", pragma,
+		)
+		require.Equal(t, expected, got, "pragma=%v", pragma)
+	}
 }

--- a/sqldb/config.go
+++ b/sqldb/config.go
@@ -31,8 +31,9 @@ type Config struct {
 	// Backend selects which SQL engine to instantiate.
 	Backend BackendType
 
-	// Sqlite must be populated when Backend == BackendSqlite. It is
-	// passed verbatim to the lnd sqldb/v2 SQLite store factory.
+	// Sqlite must be populated when Backend == BackendSqlite. Neutrino
+	// appends chain-store pragma defaults before passing it to the lnd
+	// sqldb/v2 SQLite store factory unless SkipSqliteChainPragmas is set.
 	Sqlite *sqldbv2.SqliteConfig
 
 	// Postgres must be populated when Backend == BackendPostgres. It is
@@ -48,6 +49,12 @@ type Config struct {
 	// from the legacy walletdb + flat-file state into the SQL backend.
 	// Useful for tests and for callers that have already migrated.
 	SkipLegacyMigration bool
+
+	// SkipSqliteChainPragmas leaves the supplied SQLite pragma options
+	// untouched. By default, neutrino applies a chain-data profile that
+	// favors fast, consistent rebuildable sync state over wallet-grade
+	// power-loss durability.
+	SkipSqliteChainPragmas bool
 }
 
 // Validate sanity-checks the SQL configuration. It returns a non-nil error if
@@ -90,4 +97,51 @@ func (c *Config) sqliteFilename() string {
 	}
 
 	return DefaultSqliteFilename
+}
+
+func (c *Config) sqliteConfig() *sqldbv2.SqliteConfig {
+	if c.SkipSqliteChainPragmas {
+		return c.Sqlite
+	}
+
+	cfg := *c.Sqlite
+	if cfg.MaxConnections == 0 {
+		cfg.MaxConnections = 1
+	}
+	if cfg.MaxIdleConnections == 0 {
+		cfg.MaxIdleConnections = 1
+	}
+	cfg.PragmaOptions = append(
+		append([]string(nil), c.Sqlite.PragmaOptions...),
+		defaultSqliteChainPragmas()...,
+	)
+
+	return &cfg
+}
+
+func defaultSqliteChainPragmas() []string {
+	return []string{
+		// WAL+NORMAL remains atomic and consistent and is safe across
+		// application crashes. A power loss may lose recent commits, but
+		// header/filter state can be redownloaded from peers.
+		"synchronous=NORMAL",
+
+		// sqldb/v2 currently hardcodes fullfsync=true in the SQLite DSN.
+		// Keep checkpoint_fullfsync disabled here so the chain profile is
+		// ready once sqldb/v2 grows a typed no-fullfsync knob.
+		"checkpoint_fullfsync=false",
+
+		// Keep WAL growth bounded without forcing tiny 1,000-page
+		// checkpoints during header/cfheader ingest.
+		"wal_autocheckpoint=50000",
+		"journal_size_limit=268435456",
+
+		// Initial sync is an append-heavy workload with frequent header
+		// lookups. Keep sqlite's temporary structures in memory and give
+		// the connection enough cache/mmap room to avoid unnecessary pager
+		// churn while preserving the on-disk format.
+		"temp_store=MEMORY",
+		"cache_size=-131072",
+		"mmap_size=268435456",
+	}
 }

--- a/sqldb/migrations.go
+++ b/sqldb/migrations.go
@@ -20,13 +20,13 @@ const trackingTable = "neutrino_migrations"
 
 // LatestSchemaVersion is the highest schema_version applied by an SQL
 // migration file under sqlc/migrations.
-const LatestSchemaVersion = 1
+const LatestSchemaVersion = 3
 
 // LatestMigrationVersion is the highest global migration version (the union
 // of SQL and programmatic migrations). Each entry in MigrationSet.Descriptors
 // counts toward this bound; downgrade protection refuses to start when the
 // on-disk version exceeds this constant.
-const LatestMigrationVersion = 2
+const LatestMigrationVersion = 3
 
 // MigrationSet returns the canonical migration set for the neutrino SQL
 // backend. The optional makeProgrammatic argument lets callers register
@@ -52,6 +52,11 @@ func MigrationSet(makeProgrammatic func(*sqldbv2.BaseDB) (
 				Name:          "legacy_import",
 				Version:       2,
 				SchemaVersion: 2,
+			},
+			{
+				Name:          "drop_duplicate_hash_indexes",
+				Version:       3,
+				SchemaVersion: 3,
 			},
 		},
 	}

--- a/sqldb/sqlc/migrations/000001_init.up.sql
+++ b/sqldb/sqlc/migrations/000001_init.up.sql
@@ -17,9 +17,6 @@ CREATE TABLE IF NOT EXISTS block_headers (
     CONSTRAINT block_headers_hash_uniq UNIQUE (block_hash)
 );
 
-CREATE INDEX IF NOT EXISTS block_headers_hash_idx
-    ON block_headers (block_hash);
-
 -- filter_headers stores 32-byte filter header hashes keyed by height. The
 -- block_hash column is the bitcoin block hash this filter header corresponds
 -- to. There is no foreign key to block_headers because the two chains drift
@@ -30,9 +27,6 @@ CREATE TABLE IF NOT EXISTS filter_headers (
     filter_hash  BLOB   NOT NULL,
     CONSTRAINT filter_headers_block_hash_uniq UNIQUE (block_hash)
 );
-
-CREATE INDEX IF NOT EXISTS filter_headers_block_hash_idx
-    ON filter_headers (block_hash);
 
 -- regular_filters stores GCS regular filters keyed by block hash. A
 -- zero-length filter_bytes value is the legacy "nil filter" sentinel and is

--- a/sqldb/sqlc/migrations/000003_drop_duplicate_hash_indexes.up.sql
+++ b/sqldb/sqlc/migrations/000003_drop_duplicate_hash_indexes.up.sql
@@ -1,0 +1,6 @@
+-- The UNIQUE constraints on block_headers.block_hash and
+-- filter_headers.block_hash already create sqlite autoindexes. The explicit
+-- non-unique indexes duplicated every header insert and inflated WAL/checkpoint
+-- work on the hottest initial-sync tables.
+DROP INDEX IF EXISTS block_headers_hash_idx;
+DROP INDEX IF EXISTS filter_headers_block_hash_idx;

--- a/sqldb/test_helpers.go
+++ b/sqldb/test_helpers.go
@@ -25,7 +25,6 @@ func NewTestBackend(t *testing.T) *Backend {
 	})
 
 	baseDB := store.GetBaseDB()
-
 	headerExec := sqldbv2.NewTransactionExecutor[HeaderQueries](
 		baseDB,
 		func(tx *sql.Tx) HeaderQueries { return sqlc.New(tx) },


### PR DESCRIPTION
In this PR, we tune the SQLite-backed header stores that landed in the SQL stack. The main observation from the clean lnd sync runs was that once peer/query scheduling stopped being the obvious bottleneck, the remaining hot path was reading long runs of block headers from SQLite and paying conservative SQLite defaults during rebuildable chain sync.

We keep this PR scoped to storage behavior. There are no querysync or headersync actor changes here, and header writes continue to use generated sqlc methods inside the existing sqldb/v2 `ExecTx` transaction.

## Stack

This stacks on #366, a.k.a `roasbeef/sql-07-followups`.

## SQLite profile

Neutrino's chain database is rebuildable from peers, so we don't need every chain-store knob to match wallet-grade durability. We apply the chain-data profile through sqldb/v2's SQLite config before opening the DB, matching the shape used by lnd-style SQLite openers: `synchronous=NORMAL`, a larger WAL checkpoint threshold, bounded WAL size, in-memory temp storage, and larger cache/mmap limits.

One important detail: current sqldb/v2 still hardcodes `fullfsync=true` in its SQLite DSN. We don't use a post-open raw `PRAGMA` loop to override that here; disabling macOS fullfsync should be a typed sqldb/v2 option, similar to darepo-client's `NoFullfsync`, so callers can see the durability tradeoff in config.

Callers can set `SkipSqliteChainPragmas` if they want the supplied SQLite config passed through untouched.

## Schema cleanup

We drop redundant hash indexes from fresh schemas and add a migration for existing DBs. The unique constraints already give us the lookup indexes, so the second indexes only add write cost during sync.

## Header reads

The SQL block header store now keeps a bounded read-through cache keyed by height and hash. This matches lnd's common ChainConn access pattern during notifier startup: fetch hash by height, then fetch the header by hash, repeated over a long range. `FetchHeaderByHeight` prefetches a contiguous range and fills the cache, which collapses that scan into fewer SQLite transactions.

Rollback clears the cache before returning, so stale headers can't be served after rows are removed.

## Tests

```bash
go test ./sqldb ./headerfs -count=1
go test . -run 'TestNewChainServiceSQLPath|TestNewChainServiceSQLValidation' -count=1
go test ./banman -count=1
go test ./... -count=1
```

The full default suite passed locally after restacking the PRAGMA path. An earlier full pass hit a transient `banman` kvdb assertion, and `go test ./banman -count=1` passed immediately on retry.