### PR TITLE
protofsm+p-models: specify sync schedulers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ coverage.txt
 
 # go workspace
 go.work
+
+# P model generated artifacts.
+/PGenerated/
+/PCheckerOutput/

--- a/p-models/README.md
+++ b/p-models/README.md
@@ -1,0 +1,22 @@
+# P Models
+
+This tree contains executable P models for neutrino concurrency and scheduling
+logic. The models should describe the desired distributed-systems contract first,
+then let the implementation follow that contract.
+
+## Layout
+
+- `neutrinoquery/` models query scheduling, timeouts, cancellation, and work
+  stealing.
+- `neutrinoheadersync/` models checkpoint-backed header range assignment,
+  range stealing, out-of-order completion, and ordered commit.
+- `scripts/` contains shared model check entrypoints.
+- `PGenerated/` and `PCheckerOutput/` are generated at repo root and ignored.
+
+## Rules
+
+- Keep ideal invariants separate from implementation shortcuts.
+- Keep known-bad behavior in explicit counterexample test cases so the default
+  suite remains green.
+- As the Go packages land in later PRs, add bridge or trace replay tests that
+  exercise the real implementation against the same model stories.

--- a/p-models/neutrinoheadersync/README.md
+++ b/p-models/neutrinoheadersync/README.md
@@ -1,0 +1,24 @@
+# Neutrino Header Sync Model
+
+This model captures the intended parallel block header sync contract before the
+production `blockmanager` path is migrated away from a single active sync peer.
+
+The model currently covers:
+
+- checkpoint/trusted anchors and discovered anchor confirmation;
+- range planning only between confirmed anchors;
+- peer-owned local range queues and active range leases;
+- work stealing that bumps a range lease epoch;
+- stale completions that cannot overwrite the current owner or staged result;
+- invalid completions that do not advance the committed tip;
+- out-of-order range completion with strictly ordered commit.
+
+The central design is a reorder buffer: peers may complete validated ranges in
+any order, but the visible committed header tip only advances through the next
+contiguous staged range.
+
+## Run
+
+```shell
+./p-models/scripts/check.sh
+```

--- a/p-models/neutrinoheadersync/bridge/scenarios.json
+++ b/p-models/neutrinoheadersync/bridge/scenarios.json
@@ -1,0 +1,274 @@
+{
+  "scenarios": [
+    {
+      "name": "unconfirmed_anchor_blocks_then_confirmed_anchor_plans",
+      "committed_tip": 0,
+      "committed_hash": 100,
+      "anchors": [
+        {"height": 0, "hash": 100, "trusted": true},
+        {"height": 100, "hash": 200, "trusted": false}
+      ],
+      "peers": [],
+      "steps": [
+        {"op": "plan", "range_id": 1, "start_height": 0, "stop_height": 100},
+        {"op": "anchor", "height": 100, "hash": 200, "trusted": false},
+        {"op": "plan", "range_id": 1, "start_height": 0, "stop_height": 100}
+      ],
+      "expect": {
+        "committed_tip": 0,
+        "committed_hash": 100,
+        "ranges": [
+          {"id": 1, "state": "queued"}
+        ],
+        "metrics": {}
+      }
+    },
+    {
+      "name": "oversized_span_requires_intermediate_anchor",
+      "committed_tip": 0,
+      "committed_hash": 100,
+      "anchors": [
+        {"height": 0, "hash": 100, "trusted": true},
+        {"height": 2001, "hash": 300, "trusted": true}
+      ],
+      "peers": [],
+      "steps": [
+        {"op": "plan", "range_id": 1, "start_height": 0, "stop_height": 2001},
+        {"op": "anchor", "height": 2000, "hash": 299, "trusted": false},
+        {"op": "anchor", "height": 2000, "hash": 299, "trusted": false},
+        {"op": "plan", "range_id": 1, "start_height": 0, "stop_height": 2000},
+        {"op": "plan", "range_id": 2, "start_height": 2000, "stop_height": 2001}
+      ],
+      "expect": {
+        "committed_tip": 0,
+        "committed_hash": 100,
+        "ranges": [
+          {"id": 1, "state": "queued"},
+          {"id": 2, "state": "queued"}
+        ],
+        "metrics": {}
+      }
+    },
+    {
+      "name": "out_of_order_completion_stages_until_gap_fills",
+      "committed_tip": 0,
+      "committed_hash": 100,
+      "anchors": [
+        {"height": 0, "hash": 100, "trusted": true},
+        {"height": 10, "hash": 110, "trusted": true},
+        {"height": 20, "hash": 120, "trusted": true}
+      ],
+      "peers": [
+        {"id": "peer1", "state": "ready"},
+        {"id": "peer2", "state": "ready"}
+      ],
+      "steps": [
+        {"op": "plan", "range_id": 1, "start_height": 0, "stop_height": 10},
+        {"op": "plan", "range_id": 2, "start_height": 10, "stop_height": 20},
+        {"op": "assign"},
+        {"op": "assign"},
+        {"op": "start", "peer_id": "peer1"},
+        {"op": "start", "peer_id": "peer2"},
+        {"op": "complete", "peer_id": "peer2", "range_id": 2, "lease_epoch": 1, "valid": true, "at_unix": 100},
+        {"op": "commit"},
+        {"op": "complete", "peer_id": "peer1", "range_id": 1, "lease_epoch": 1, "valid": true, "at_unix": 101},
+        {"op": "commit"}
+      ],
+      "expect": {
+        "committed_tip": 20,
+        "committed_hash": 120,
+        "commit_log": [1, 2],
+        "ranges": [
+          {"id": 1, "state": "committed", "owner_peer": "peer1", "lease_epoch": 1, "valid": true},
+          {"id": 2, "state": "committed", "owner_peer": "peer2", "lease_epoch": 1, "valid": true}
+        ],
+        "peers": [
+          {"id": "peer1", "state": "ready"},
+          {"id": "peer2", "state": "ready"}
+        ],
+        "metrics": {
+          "ranges_committed": 2
+        }
+      }
+    },
+    {
+      "name": "ready_ranges_preflight_does_not_commit",
+      "committed_tip": 0,
+      "committed_hash": 100,
+      "anchors": [
+        {"height": 0, "hash": 100, "trusted": true},
+        {"height": 10, "hash": 110, "trusted": true}
+      ],
+      "peers": [
+        {"id": "peer", "state": "ready"}
+      ],
+      "steps": [
+        {"op": "plan", "range_id": 1, "start_height": 0, "stop_height": 10},
+        {"op": "assign"},
+        {"op": "start", "peer_id": "peer"},
+        {"op": "complete", "peer_id": "peer", "range_id": 1, "lease_epoch": 1, "valid": true, "at_unix": 100}
+      ],
+      "expect": {
+        "committed_tip": 0,
+        "committed_hash": 100,
+        "ready_ranges": [1],
+        "ranges": [
+          {"id": 1, "state": "staged", "owner_peer": "peer", "lease_epoch": 1, "valid": true}
+        ],
+        "peers": [
+          {"id": "peer", "state": "ready"}
+        ],
+        "metrics": {}
+      }
+    },
+    {
+      "name": "external_tip_advance_plans_gap_before_staged_frontier",
+      "committed_tip": 0,
+      "committed_hash": 100,
+      "anchors": [
+        {"height": 0, "hash": 100, "trusted": true},
+        {"height": 20, "hash": 120, "trusted": true},
+        {"height": 30, "hash": 130, "trusted": true}
+      ],
+      "peers": [
+        {"id": "peer", "state": "ready"}
+      ],
+      "steps": [
+        {"op": "plan", "range_id": 1, "start_height": 20, "stop_height": 30},
+        {"op": "assign"},
+        {"op": "start", "peer_id": "peer"},
+        {"op": "complete", "peer_id": "peer", "range_id": 1, "lease_epoch": 1, "valid": true, "at_unix": 100},
+        {"op": "commit"},
+        {"op": "advance_tip", "height": 10, "hash": 110},
+        {"op": "plan", "range_id": 2, "start_height": 10, "stop_height": 20},
+        {"op": "assign"},
+        {"op": "start", "peer_id": "peer"},
+        {"op": "complete", "peer_id": "peer", "range_id": 2, "lease_epoch": 1, "valid": true, "at_unix": 101},
+        {"op": "commit"}
+      ],
+      "expect": {
+        "committed_tip": 30,
+        "committed_hash": 130,
+        "commit_log": [2, 1],
+        "ranges": [
+          {"id": 2, "state": "committed", "owner_peer": "peer", "lease_epoch": 1, "valid": true},
+          {"id": 1, "state": "committed", "owner_peer": "peer", "lease_epoch": 1, "valid": true}
+        ],
+        "peers": [
+          {"id": "peer", "state": "ready"}
+        ],
+        "metrics": {
+          "ranges_committed": 2
+        }
+      }
+    },
+    {
+      "name": "commit_prunes_obsolete_anchor_requests",
+      "committed_tip": 0,
+      "committed_hash": 100,
+      "anchors": [
+        {"height": 0, "hash": 100, "trusted": true},
+        {"height": 10, "hash": 110, "trusted": true},
+        {"height": 20, "hash": 120, "trusted": true}
+      ],
+      "peers": [
+        {"id": "peer", "state": "ready"}
+      ],
+      "steps": [
+        {"op": "track_anchor", "peer_id": "obsolete", "start_height": 0, "stop_height": 10},
+        {"op": "track_anchor", "peer_id": "future", "start_height": 10, "stop_height": 20},
+        {"op": "plan", "range_id": 1, "start_height": 0, "stop_height": 10},
+        {"op": "assign"},
+        {"op": "start", "peer_id": "peer"},
+        {"op": "complete", "peer_id": "peer", "range_id": 1, "lease_epoch": 1, "valid": true, "at_unix": 100},
+        {"op": "commit_and_prune"}
+      ],
+      "expect": {
+        "committed_tip": 10,
+        "committed_hash": 110,
+        "commit_log": [1],
+        "active_anchor_count": 1,
+        "pruned_anchors": 1,
+        "ranges": [
+          {"id": 1, "state": "committed", "owner_peer": "peer", "lease_epoch": 1, "valid": true}
+        ],
+        "peers": [
+          {"id": "peer", "state": "ready"}
+        ],
+        "metrics": {
+          "ranges_committed": 1
+        }
+      }
+    },
+    {
+      "name": "stale_completion_cannot_overwrite_stolen_lease",
+      "committed_tip": 0,
+      "committed_hash": 100,
+      "anchors": [
+        {"height": 0, "hash": 100, "trusted": true},
+        {"height": 10, "hash": 110, "trusted": true}
+      ],
+      "peers": [
+        {"id": "peer1", "state": "ready"},
+        {"id": "peer2", "state": "ready"}
+      ],
+      "steps": [
+        {"op": "plan", "range_id": 1, "start_height": 0, "stop_height": 10},
+        {"op": "assign"},
+        {"op": "start", "peer_id": "peer1"},
+        {"op": "steal", "thief_id": "peer2", "range_id": 1},
+        {"op": "complete", "peer_id": "peer1", "range_id": 1, "lease_epoch": 1, "valid": false, "at_unix": 100},
+        {"op": "start", "peer_id": "peer2"},
+        {"op": "complete", "peer_id": "peer2", "range_id": 1, "lease_epoch": 2, "valid": true, "at_unix": 101},
+        {"op": "commit"}
+      ],
+      "expect": {
+        "committed_tip": 10,
+        "committed_hash": 110,
+        "commit_log": [1],
+        "ranges": [
+          {"id": 1, "state": "committed", "owner_peer": "peer2", "lease_epoch": 2, "valid": true}
+        ],
+        "peers": [
+          {"id": "peer1", "state": "ready"},
+          {"id": "peer2", "state": "ready"}
+        ],
+        "metrics": {
+          "ranges_stolen": 1,
+          "ranges_committed": 1,
+          "stale_completions": 1
+        }
+      }
+    },
+    {
+      "name": "invalid_completion_fails_without_commit",
+      "committed_tip": 0,
+      "committed_hash": 100,
+      "anchors": [
+        {"height": 0, "hash": 100, "trusted": true},
+        {"height": 10, "hash": 110, "trusted": true}
+      ],
+      "peers": [
+        {"id": "peer", "state": "ready"}
+      ],
+      "steps": [
+        {"op": "plan", "range_id": 1, "start_height": 0, "stop_height": 10},
+        {"op": "assign"},
+        {"op": "start", "peer_id": "peer"},
+        {"op": "complete", "peer_id": "peer", "range_id": 1, "lease_epoch": 1, "valid": false, "at_unix": 100},
+        {"op": "commit"}
+      ],
+      "expect": {
+        "committed_tip": 0,
+        "committed_hash": 100,
+        "ranges": [
+          {"id": 1, "state": "failed", "owner_peer": "peer", "lease_epoch": 1}
+        ],
+        "peers": [
+          {"id": "peer", "state": "ready"}
+        ],
+        "metrics": {}
+      }
+    }
+  ]
+}

--- a/p-models/neutrinoheadersync/infra.pproj
+++ b/p-models/neutrinoheadersync/infra.pproj
@@ -1,0 +1,8 @@
+<Project>
+<ProjectName>NeutrinoHeaderSyncModels</ProjectName>
+<InputFiles>
+<PFile>src/header_sync.p</PFile>
+<PFile>test/header_sync_test.p</PFile>
+</InputFiles>
+<OutputDir>PGenerated</OutputDir>
+</Project>

--- a/p-models/neutrinoheadersync/src/header_sync.p
+++ b/p-models/neutrinoheadersync/src/header_sync.p
@@ -1,0 +1,982 @@
+// header_sync.p - Neutrino parallel header sync executable specification.
+//
+// This file is intentionally written in a literate style. The goal is to make
+// the design readable to engineers who do not use P every day while still
+// keeping the rules executable. The model focuses on the safety properties that
+// matter when block header sync moves from one active peer to parallel ranges:
+//
+//   * ranges are only planned between confirmed anchors;
+//   * a range lease has one current owner/epoch;
+//   * stealing increments the epoch so old responses become stale;
+//   * peers may complete ranges out of order;
+//   * completed ranges are staged before commit;
+//   * commits advance only through the next contiguous staged range;
+//   * if a legacy/fallback writer already persisted headers, the model can
+//     reconcile the visible tip before planning more frontier work.
+
+enum HeaderPeerState {
+    HeaderPeerReady,
+    HeaderPeerBusy,
+    HeaderPeerBlocked,
+    HeaderPeerQuarantined,
+    HeaderPeerDown
+}
+
+enum HeaderRangeState {
+    RangeQueued,
+    RangeOwned,
+    RangeActive,
+    RangeStaged,
+    RangeCommitted,
+    RangeFailed,
+    RangeStale
+}
+
+type HeaderAnchor = (
+    height: int,
+    hash: int,
+    trusted: bool,
+    confirmations: int,
+    rejected: bool
+);
+
+type ActiveAnchorRequest = (
+    peer_id: int,
+    start_height: int,
+    stop_height: int
+);
+
+type HeaderRange = (
+    id: int,
+    start_height: int,
+    start_hash: int,
+    stop_height: int,
+    stop_hash: int,
+    lease_epoch: int,
+    owner_peer: int,
+    range_state: HeaderRangeState,
+    valid: bool
+);
+
+type HeaderPeer = (
+    id: int,
+    rank: int,
+    rtt_ms: int,
+    peer_state: HeaderPeerState,
+    local_ranges: seq[int],
+    active_range: int
+);
+
+type HeaderSyncModel = (
+    committed_tip: int,
+    committed_hash: int,
+    anchors: seq[HeaderAnchor],
+    active_anchor_requests: seq[ActiveAnchorRequest],
+    ranges: seq[HeaderRange],
+    peers: seq[HeaderPeer],
+    commit_log: seq[int]
+);
+
+fun NoPeer(): int { return 0; }
+fun NoRange(): int { return 0; }
+fun AnchorConfirmationsRequired(): int { return 2; }
+fun MaxPeerOutstandingRanges(): int { return 4; }
+fun MaxRangeHeaders(): int { return 2000; }
+
+fun NewAnchor(height: int, hash: int, trusted: bool): HeaderAnchor {
+    var confirmations: int;
+
+    confirmations = 1;
+    if (trusted) {
+        confirmations = AnchorConfirmationsRequired();
+    }
+
+    return (
+        height = height,
+        hash = hash,
+        trusted = trusted,
+        confirmations = confirmations,
+        rejected = false
+    );
+}
+
+fun NewRange(id: int, start_height: int, start_hash: int,
+    stop_height: int, stop_hash: int): HeaderRange {
+
+    return (
+        id = id,
+        start_height = start_height,
+        start_hash = start_hash,
+        stop_height = stop_height,
+        stop_hash = stop_hash,
+        lease_epoch = 0,
+        owner_peer = NoPeer(),
+        range_state = RangeQueued,
+        valid = false
+    );
+}
+
+fun NewPeer(id: int, rank: int, rtt_ms: int,
+    peer_state: HeaderPeerState): HeaderPeer {
+
+    return (
+        id = id,
+        rank = rank,
+        rtt_ms = rtt_ms,
+        peer_state = peer_state,
+        local_ranges = default(seq[int]),
+        active_range = NoRange()
+    );
+}
+
+fun NewModel(committed_tip: int, committed_hash: int): HeaderSyncModel {
+    return (
+        committed_tip = committed_tip,
+        committed_hash = committed_hash,
+        anchors = default(seq[HeaderAnchor]),
+        active_anchor_requests = default(seq[ActiveAnchorRequest]),
+        ranges = default(seq[HeaderRange]),
+        peers = default(seq[HeaderPeer]),
+        commit_log = default(seq[int])
+    );
+}
+
+// AdvanceCommittedTip models the production reconciliation path between the
+// pure scheduler and the durable block-header store. Most progress should come
+// from CommitReadyRanges, but during migration the block manager can still
+// persist a short serial fallback span. Once storage says the tip is already
+// ahead, the scheduler must not keep planning from its stale in-memory tip or
+// it can skip the newly persisted boundary and strand staged frontier ranges.
+fun AdvanceCommittedTip(model: HeaderSyncModel, height: int,
+    hash: int): HeaderSyncModel {
+
+    var i: int;
+    var range: HeaderRange;
+
+    if (height < model.committed_tip) {
+        return model;
+    }
+
+    model.anchors = AddOrConfirmAnchor(model.anchors, height, hash, true);
+    if (height == model.committed_tip) {
+        model.committed_hash = hash;
+        return model;
+    }
+
+    model.committed_tip = height;
+    model.committed_hash = hash;
+
+    i = 0;
+    while (i < sizeof(model.ranges)) {
+        range = model.ranges[i];
+        if (range.stop_height <= height) {
+            range = (
+                id = range.id,
+                start_height = range.start_height,
+                start_hash = range.start_hash,
+                stop_height = range.stop_height,
+                stop_hash = range.stop_hash,
+                lease_epoch = range.lease_epoch,
+                owner_peer = NoPeer(),
+                range_state = RangeCommitted,
+                valid = true
+            );
+            model.ranges = ReplaceRange(model.ranges, range);
+        } else if (range.start_height < height) {
+            range = (
+                id = range.id,
+                start_height = range.start_height,
+                start_hash = range.start_hash,
+                stop_height = range.stop_height,
+                stop_hash = range.stop_hash,
+                lease_epoch = range.lease_epoch,
+                owner_peer = NoPeer(),
+                range_state = RangeStale,
+                valid = false
+            );
+            model.ranges = ReplaceRange(model.ranges, range);
+        }
+
+        i = i + 1;
+    }
+
+    return model;
+}
+
+// AddOrConfirmAnchor is the anchor-discovery rule. Trusted checkpoints are
+// immediately confirmed. Discovered anchors require independent matching
+// observations. Conflicting discovered anchors for the same height are marked
+// rejected so the range planner cannot fan out work across an ambiguous
+// boundary. Trusted checkpoints can replace a discovered conflict because they
+// are a local chain parameter, not a peer claim.
+fun AddOrConfirmAnchor(anchors: seq[HeaderAnchor], height: int, hash: int,
+    trusted: bool): seq[HeaderAnchor] {
+
+    var result: seq[HeaderAnchor];
+    var i: int;
+    var anchor: HeaderAnchor;
+    var found: bool;
+
+    i = 0;
+    while (i < sizeof(anchors)) {
+        anchor = anchors[i];
+        if (anchor.height == height) {
+            found = true;
+            if (anchor.hash == hash) {
+                if (trusted) {
+                    anchor = NewAnchor(height, hash, true);
+                } else if (!anchor.rejected && anchor.confirmations <
+                    AnchorConfirmationsRequired()) {
+
+                    anchor = (
+                        height = anchor.height,
+                        hash = anchor.hash,
+                        trusted = anchor.trusted,
+                        confirmations = anchor.confirmations + 1,
+                        rejected = anchor.rejected
+                    );
+                }
+            } else if (trusted) {
+                anchor = NewAnchor(height, hash, true);
+            } else if (!anchor.trusted) {
+                anchor = (
+                    height = anchor.height,
+                    hash = anchor.hash,
+                    trusted = anchor.trusted,
+                    confirmations = anchor.confirmations,
+                    rejected = true
+                );
+            }
+        }
+
+        result += (sizeof(result), anchor);
+        i = i + 1;
+    }
+
+    if (!found) {
+        result += (sizeof(result), NewAnchor(height, hash, trusted));
+    }
+
+    return result;
+}
+
+fun AnchorByHeight(anchors: seq[HeaderAnchor], height: int): HeaderAnchor {
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(anchors)) {
+        if (anchors[i].height == height) {
+            return anchors[i];
+        }
+
+        i = i + 1;
+    }
+
+    return NewAnchor(0, 0, false);
+}
+
+fun AnchorConfirmed(anchor: HeaderAnchor): bool {
+    return !anchor.rejected && (
+        anchor.trusted ||
+        anchor.confirmations >= AnchorConfirmationsRequired()
+    );
+}
+
+// Active anchor requests are in-flight getheaders messages used to discover or
+// hedge a future boundary. They are not chain state. Once ordered commit reaches
+// or passes their stop height, any late response for that request cannot unlock
+// new work; keeping it active would only block the scheduler until timeout.
+fun AddActiveAnchorRequest(model: HeaderSyncModel, peer_id: int,
+    start_height: int, stop_height: int): HeaderSyncModel {
+
+    model.active_anchor_requests += (
+        sizeof(model.active_anchor_requests),
+        (peer_id = peer_id, start_height = start_height,
+            stop_height = stop_height)
+    );
+
+    return model;
+}
+
+fun PruneObsoleteAnchorRequests(model: HeaderSyncModel,
+    committed_tip: int): HeaderSyncModel {
+
+    var kept: seq[ActiveAnchorRequest];
+    var i: int;
+    var request: ActiveAnchorRequest;
+
+    i = 0;
+    while (i < sizeof(model.active_anchor_requests)) {
+        request = model.active_anchor_requests[i];
+        if (request.stop_height > committed_tip) {
+            kept += (sizeof(kept), request);
+        }
+
+        i = i + 1;
+    }
+
+    model.active_anchor_requests = kept;
+
+    return model;
+}
+
+// NextAnchorDiscoveryStart is the fanout-window rule. The visible chain tip may
+// still be waiting for an earlier range to commit, but anchor discovery is
+// allowed to run ahead from the furthest confirmed anchor we already know. This
+// keeps future range boundaries warming while earlier peer actors are still
+// downloading or committing their ranges.
+fun NextAnchorDiscoveryStart(model: HeaderSyncModel, committed_tip: int,
+    committed_hash: int, stop_height: int): HeaderAnchor {
+
+    var i: int;
+    var frontier: HeaderAnchor;
+    var anchor: HeaderAnchor;
+
+    frontier = NewAnchor(committed_tip, committed_hash, true);
+    i = 0;
+    while (i < sizeof(model.anchors)) {
+        anchor = model.anchors[i];
+        if (anchor.height >= committed_tip &&
+            anchor.height < stop_height &&
+            AnchorConfirmed(anchor) &&
+            anchor.height > frontier.height) {
+
+            frontier = anchor;
+        }
+
+        i = i + 1;
+    }
+
+    return frontier;
+}
+
+fun ShouldDiscoverAnchorAhead(model: HeaderSyncModel, committed_tip: int,
+    committed_hash: int, stop_height: int): bool {
+
+    var frontier: HeaderAnchor;
+
+    frontier = NextAnchorDiscoveryStart(
+        model, committed_tip, committed_hash, stop_height
+    );
+
+    return stop_height - frontier.height > MaxRangeHeaders();
+}
+
+// NextFrontierDiscoveryStop is the post-checkpoint lane. Once there is no
+// trusted checkpoint hash ahead, getheaders uses a zero stop hash and peers
+// return up to the protocol cap. The manager still bounds the expected height
+// window so two matching peer responses can confirm the newly discovered
+// boundary and stage the exact headers already downloaded.
+fun NextFrontierDiscoveryStop(frontier_height: int,
+    best_height: int): int {
+
+    if (best_height - frontier_height > MaxRangeHeaders()) {
+        return frontier_height + MaxRangeHeaders();
+    }
+
+    return best_height;
+}
+
+fun RangeByID(ranges: seq[HeaderRange], id: int): HeaderRange {
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(ranges)) {
+        if (ranges[i].id == id) {
+            return ranges[i];
+        }
+
+        i = i + 1;
+    }
+
+    return NewRange(NoRange(), 0, 0, 0, 0);
+}
+
+fun RangeBySpan(ranges: seq[HeaderRange], start_height: int,
+    stop_height: int): HeaderRange {
+
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(ranges)) {
+        if (ranges[i].start_height == start_height &&
+            ranges[i].stop_height == stop_height &&
+            !(ranges[i].range_state == RangeFailed ||
+                ranges[i].range_state == RangeStale)) {
+
+            return ranges[i];
+        }
+
+        i = i + 1;
+    }
+
+    return NewRange(NoRange(), 0, 0, 0, 0);
+}
+
+fun PeerByID(peers: seq[HeaderPeer], id: int): HeaderPeer {
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(peers)) {
+        if (peers[i].id == id) {
+            return peers[i];
+        }
+
+        i = i + 1;
+    }
+
+    return NewPeer(NoPeer(), 0, 0, HeaderPeerDown);
+}
+
+fun ReplaceRange(ranges: seq[HeaderRange],
+    next: HeaderRange): seq[HeaderRange] {
+
+    var result: seq[HeaderRange];
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(ranges)) {
+        if (ranges[i].id == next.id) {
+            result += (sizeof(result), next);
+        } else {
+            result += (sizeof(result), ranges[i]);
+        }
+
+        i = i + 1;
+    }
+
+    return result;
+}
+
+fun ReplacePeer(peers: seq[HeaderPeer], next: HeaderPeer): seq[HeaderPeer] {
+    var result: seq[HeaderPeer];
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(peers)) {
+        if (peers[i].id == next.id) {
+            result += (sizeof(result), next);
+        } else {
+            result += (sizeof(result), peers[i]);
+        }
+
+        i = i + 1;
+    }
+
+    return result;
+}
+
+fun AppendID(ids: seq[int], id: int): seq[int] {
+    ids += (sizeof(ids), id);
+    return ids;
+}
+
+fun DropFirstID(ids: seq[int]): seq[int] {
+    var result: seq[int];
+    var i: int;
+
+    i = 1;
+    while (i < sizeof(ids)) {
+        result += (sizeof(result), ids[i]);
+        i = i + 1;
+    }
+
+    return result;
+}
+
+fun RemoveID(ids: seq[int], id: int): seq[int] {
+    var result: seq[int];
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(ids)) {
+        if (ids[i] != id) {
+            result += (sizeof(result), ids[i]);
+        }
+
+        i = i + 1;
+    }
+
+    return result;
+}
+
+fun PeerOutstandingRanges(peer: HeaderPeer): int {
+    var count: int;
+
+    count = sizeof(peer.local_ranges);
+    if (peer.active_range != NoRange()) {
+        count = count + 1;
+    }
+
+    return count;
+}
+
+fun PeerCanOwnRange(peer: HeaderPeer): bool {
+    if (!(peer.peer_state == HeaderPeerReady ||
+        peer.peer_state == HeaderPeerBusy)) {
+
+        return false;
+    }
+
+    return PeerOutstandingRanges(peer) < MaxPeerOutstandingRanges();
+}
+
+fun PeerCanStartRange(peer: HeaderPeer): bool {
+    return peer.peer_state == HeaderPeerReady &&
+        peer.active_range == NoRange() &&
+        sizeof(peer.local_ranges) > 0;
+}
+
+fun PeerOrdersBefore(peer: HeaderPeer, candidate: HeaderPeer): bool {
+    if (peer.rank < candidate.rank) { return true; }
+    if (peer.rank > candidate.rank) { return false; }
+    if (peer.rtt_ms < candidate.rtt_ms) { return true; }
+    if (peer.rtt_ms > candidate.rtt_ms) { return false; }
+
+    return peer.id < candidate.id;
+}
+
+fun SelectRangeOwner(peers: seq[HeaderPeer]): int {
+    var i: int;
+    var found: bool;
+    var candidate: HeaderPeer;
+
+    i = 0;
+    while (i < sizeof(peers)) {
+        if (PeerCanOwnRange(peers[i])) {
+            if (!found ||
+                PeerOutstandingRanges(peers[i]) <
+                    PeerOutstandingRanges(candidate) ||
+                (PeerOutstandingRanges(peers[i]) ==
+                    PeerOutstandingRanges(candidate) &&
+                    PeerOrdersBefore(peers[i], candidate))) {
+
+                found = true;
+                candidate = peers[i];
+            }
+        }
+
+        i = i + 1;
+    }
+
+    if (!found) {
+        return NoPeer();
+    }
+
+    return candidate.id;
+}
+
+fun CanPlanRange(model: HeaderSyncModel, start_height: int,
+    stop_height: int): bool {
+
+    var start_anchor: HeaderAnchor;
+    var stop_anchor: HeaderAnchor;
+
+    if (start_height >= stop_height) {
+        return false;
+    }
+    // Bitcoin getheaders replies are capped at 2000 headers. A larger span may
+    // still be safe eventually, but only after anchor discovery creates an
+    // intermediate confirmed boundary. Until then, planning it as one range would
+    // silently turn the parallel scheduler back into a partial serial download.
+    if (stop_height - start_height > MaxRangeHeaders()) {
+        return false;
+    }
+
+    start_anchor = AnchorByHeight(model.anchors, start_height);
+    stop_anchor = AnchorByHeight(model.anchors, stop_height);
+
+    return AnchorConfirmed(start_anchor) && AnchorConfirmed(stop_anchor);
+}
+
+fun PlanRange(model: HeaderSyncModel, id: int, start_height: int,
+    stop_height: int): HeaderSyncModel {
+
+    var start_anchor: HeaderAnchor;
+    var stop_anchor: HeaderAnchor;
+
+    if (!CanPlanRange(model, start_height, stop_height)) {
+        return model;
+    }
+
+    start_anchor = AnchorByHeight(model.anchors, start_height);
+    stop_anchor = AnchorByHeight(model.anchors, stop_height);
+    model.ranges += (sizeof(model.ranges), NewRange(
+        id, start_height, start_anchor.hash, stop_height, stop_anchor.hash
+    ));
+
+    return model;
+}
+
+// StageDiscoveredRange is the key pipelining rule for wide checkpoint gaps.
+// Anchor discovery already downloads the headers from the current frontier to
+// the next 2000-header boundary. Once that boundary is confirmed, those same
+// headers are not just metadata: they are a valid completed range. Staging the
+// discovery response keeps the frontier moving without a second getheaders
+// round trip for the same span.
+fun StageDiscoveredRange(model: HeaderSyncModel, id: int, peer_id: int,
+    start_height: int, stop_height: int): HeaderSyncModel {
+
+    var start_anchor: HeaderAnchor;
+    var stop_anchor: HeaderAnchor;
+    var existing: HeaderRange;
+    var staged: HeaderRange;
+
+    existing = RangeBySpan(model.ranges, start_height, stop_height);
+    if (existing.id != NoRange()) {
+        return model;
+    }
+
+    if (!CanPlanRange(model, start_height, stop_height)) {
+        return model;
+    }
+
+    start_anchor = AnchorByHeight(model.anchors, start_height);
+    stop_anchor = AnchorByHeight(model.anchors, stop_height);
+    staged = NewRange(
+        id, start_height, start_anchor.hash, stop_height, stop_anchor.hash
+    );
+    staged = (
+        id = staged.id,
+        start_height = staged.start_height,
+        start_hash = staged.start_hash,
+        stop_height = staged.stop_height,
+        stop_hash = staged.stop_hash,
+        lease_epoch = staged.lease_epoch + 1,
+        owner_peer = peer_id,
+        range_state = RangeStaged,
+        valid = true
+    );
+    model.ranges += (sizeof(model.ranges), staged);
+
+    return model;
+}
+
+fun AddPeer(model: HeaderSyncModel, peer: HeaderPeer): HeaderSyncModel {
+    model.peers += (sizeof(model.peers), peer);
+    return model;
+}
+
+// SetPeerState models the production cooldown/recovery boundary. The timer
+// itself lives outside the pure model; once cooldown expires, the manager emits
+// an explicit ready event and the peer can be considered for ownership again.
+fun SetPeerState(model: HeaderSyncModel, peer_id: int,
+    peer_state: HeaderPeerState): HeaderSyncModel {
+
+    var peer: HeaderPeer;
+
+    peer = PeerByID(model.peers, peer_id);
+    peer = (
+        id = peer.id,
+        rank = peer.rank,
+        rtt_ms = peer.rtt_ms,
+        peer_state = peer_state,
+        local_ranges = peer.local_ranges,
+        active_range = peer.active_range
+    );
+    model.peers = ReplacePeer(model.peers, peer);
+
+    return model;
+}
+
+fun AssignNextQueuedRange(model: HeaderSyncModel): HeaderSyncModel {
+    var i: int;
+    var owner_id: int;
+    var owner: HeaderPeer;
+    var range: HeaderRange;
+
+    owner_id = SelectRangeOwner(model.peers);
+    if (owner_id == NoPeer()) {
+        return model;
+    }
+
+    i = 0;
+    while (i < sizeof(model.ranges)) {
+        if (model.ranges[i].range_state == RangeQueued) {
+            owner = PeerByID(model.peers, owner_id);
+            range = model.ranges[i];
+            range = (
+                id = range.id,
+                start_height = range.start_height,
+                start_hash = range.start_hash,
+                stop_height = range.stop_height,
+                stop_hash = range.stop_hash,
+                lease_epoch = range.lease_epoch + 1,
+                owner_peer = owner_id,
+                range_state = RangeOwned,
+                valid = false
+            );
+            owner = (
+                id = owner.id,
+                rank = owner.rank,
+                rtt_ms = owner.rtt_ms,
+                peer_state = owner.peer_state,
+                local_ranges = AppendID(owner.local_ranges, range.id),
+                active_range = owner.active_range
+            );
+
+            model.ranges = ReplaceRange(model.ranges, range);
+            model.peers = ReplacePeer(model.peers, owner);
+
+            return model;
+        }
+
+        i = i + 1;
+    }
+
+    return model;
+}
+
+fun StartPeerRange(model: HeaderSyncModel,
+    peer_id: int): HeaderSyncModel {
+
+    var peer: HeaderPeer;
+    var range_id: int;
+    var range: HeaderRange;
+
+    peer = PeerByID(model.peers, peer_id);
+    if (!PeerCanStartRange(peer)) {
+        return model;
+    }
+
+    range_id = peer.local_ranges[0];
+    range = RangeByID(model.ranges, range_id);
+    if (range.range_state != RangeOwned || range.owner_peer != peer_id) {
+        return model;
+    }
+
+    peer = (
+        id = peer.id,
+        rank = peer.rank,
+        rtt_ms = peer.rtt_ms,
+        peer_state = HeaderPeerBusy,
+        local_ranges = DropFirstID(peer.local_ranges),
+        active_range = range_id
+    );
+    range = (
+        id = range.id,
+        start_height = range.start_height,
+        start_hash = range.start_hash,
+        stop_height = range.stop_height,
+        stop_hash = range.stop_hash,
+        lease_epoch = range.lease_epoch,
+        owner_peer = peer_id,
+        range_state = RangeActive,
+        valid = false
+    );
+
+    model.peers = ReplacePeer(model.peers, peer);
+    model.ranges = ReplaceRange(model.ranges, range);
+
+    return model;
+}
+
+// StealRange moves either unstarted owned work or an expired active range to a
+// ready thief. The caller models the timeout/expiry decision. The key safety
+// action is the lease epoch bump: any response from the old owner is now stale.
+fun StealRange(model: HeaderSyncModel, thief_id: int,
+    range_id: int): HeaderSyncModel {
+
+    var thief: HeaderPeer;
+    var donor: HeaderPeer;
+    var range: HeaderRange;
+
+    thief = PeerByID(model.peers, thief_id);
+    range = RangeByID(model.ranges, range_id);
+    if (!PeerCanOwnRange(thief) || range.owner_peer == NoPeer() ||
+        range.owner_peer == thief_id ||
+        !(range.range_state == RangeOwned ||
+            range.range_state == RangeActive)) {
+
+        return model;
+    }
+
+    donor = PeerByID(model.peers, range.owner_peer);
+    donor = (
+        id = donor.id,
+        rank = donor.rank,
+        rtt_ms = donor.rtt_ms,
+        peer_state = HeaderPeerReady,
+        local_ranges = RemoveID(donor.local_ranges, range_id),
+        active_range = NoRange()
+    );
+    thief = (
+        id = thief.id,
+        rank = thief.rank,
+        rtt_ms = thief.rtt_ms,
+        peer_state = thief.peer_state,
+        local_ranges = AppendID(thief.local_ranges, range_id),
+        active_range = thief.active_range
+    );
+    range = (
+        id = range.id,
+        start_height = range.start_height,
+        start_hash = range.start_hash,
+        stop_height = range.stop_height,
+        stop_hash = range.stop_hash,
+        lease_epoch = range.lease_epoch + 1,
+        owner_peer = thief_id,
+        range_state = RangeOwned,
+        valid = false
+    );
+
+    model.peers = ReplacePeer(model.peers, donor);
+    model.peers = ReplacePeer(model.peers, thief);
+    model.ranges = ReplaceRange(model.ranges, range);
+
+    return model;
+}
+
+fun CompleteRange(model: HeaderSyncModel, peer_id: int, range_id: int,
+    lease_epoch: int, valid: bool): HeaderSyncModel {
+
+    var peer: HeaderPeer;
+    var range: HeaderRange;
+    var next_peer_state: HeaderPeerState;
+
+    range = RangeByID(model.ranges, range_id);
+    if (range.owner_peer != peer_id || range.lease_epoch != lease_epoch ||
+        range.range_state != RangeActive) {
+
+        return model;
+    }
+
+    peer = PeerByID(model.peers, peer_id);
+    next_peer_state = peer.peer_state;
+    if (next_peer_state == HeaderPeerBusy) {
+        next_peer_state = HeaderPeerReady;
+    }
+    peer = (
+        id = peer.id,
+        rank = peer.rank,
+        rtt_ms = peer.rtt_ms,
+        peer_state = next_peer_state,
+        local_ranges = peer.local_ranges,
+        active_range = NoRange()
+    );
+
+    if (valid) {
+        range = (
+            id = range.id,
+            start_height = range.start_height,
+            start_hash = range.start_hash,
+            stop_height = range.stop_height,
+            stop_hash = range.stop_hash,
+            lease_epoch = range.lease_epoch,
+            owner_peer = peer_id,
+            range_state = RangeStaged,
+            valid = true
+        );
+    } else {
+        range = (
+            id = range.id,
+            start_height = range.start_height,
+            start_hash = range.start_hash,
+            stop_height = range.stop_height,
+            stop_hash = range.stop_hash,
+            lease_epoch = range.lease_epoch,
+            owner_peer = peer_id,
+            range_state = RangeFailed,
+            valid = false
+        );
+    }
+
+    model.peers = ReplacePeer(model.peers, peer);
+    model.ranges = ReplaceRange(model.ranges, range);
+
+    return model;
+}
+
+fun NextCommittableRangeAt(model: HeaderSyncModel, tip_height: int,
+    tip_hash: int): HeaderRange {
+
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(model.ranges)) {
+        if (model.ranges[i].range_state == RangeStaged &&
+            model.ranges[i].valid &&
+            model.ranges[i].start_height == tip_height &&
+            model.ranges[i].start_hash == tip_hash) {
+
+            return model.ranges[i];
+        }
+
+        i = i + 1;
+    }
+
+    return NewRange(NoRange(), 0, 0, 0, 0);
+}
+
+fun NextCommittableRange(model: HeaderSyncModel): HeaderRange {
+    return NextCommittableRangeAt(
+        model, model.committed_tip, model.committed_hash
+    );
+}
+
+// ReadyRanges is the model equivalent of the production preflight used by the
+// blockmanager. It tells the implementation which staged ranges are safe to
+// persist to disk, but it deliberately does not advance committed_tip. That
+// separation is what lets side-effectful storage writes happen before the FSM
+// exposes a newer visible chain tip.
+fun ReadyRanges(model: HeaderSyncModel): seq[int] {
+    var ready: seq[int];
+    var tip_height: int;
+    var tip_hash: int;
+    var next: HeaderRange;
+
+    tip_height = model.committed_tip;
+    tip_hash = model.committed_hash;
+    next = NextCommittableRangeAt(model, tip_height, tip_hash);
+
+    while (next.id != NoRange()) {
+        ready += (sizeof(ready), next.id);
+        tip_height = next.stop_height;
+        tip_hash = next.stop_hash;
+        next = NextCommittableRangeAt(model, tip_height, tip_hash);
+    }
+
+    return ready;
+}
+
+fun CommitReadyRanges(model: HeaderSyncModel): HeaderSyncModel {
+    var next: HeaderRange;
+
+    next = NextCommittableRange(model);
+    while (next.id != NoRange()) {
+        next = (
+            id = next.id,
+            start_height = next.start_height,
+            start_hash = next.start_hash,
+            stop_height = next.stop_height,
+            stop_hash = next.stop_hash,
+            lease_epoch = next.lease_epoch,
+            owner_peer = next.owner_peer,
+            range_state = RangeCommitted,
+            valid = true
+        );
+
+        model.ranges = ReplaceRange(model.ranges, next);
+        model.committed_tip = next.stop_height;
+        model.committed_hash = next.stop_hash;
+        model.commit_log += (sizeof(model.commit_log), next.id);
+
+        next = NextCommittableRange(model);
+    }
+
+    return model;
+}
+
+// CommitReadyRangesAndPruneObsoleteAnchors is the controller-level production
+// rule. The manager first advances visible chain state through contiguous
+// staged ranges. Only after that state transition is durable may the controller
+// remove obsolete hedged anchor requests whose stop height is no longer ahead
+// of the visible tip.
+fun CommitReadyRangesAndPruneObsoleteAnchors(
+    model: HeaderSyncModel): HeaderSyncModel {
+
+    model = CommitReadyRanges(model);
+    model = PruneObsoleteAnchorRequests(model, model.committed_tip);
+
+    return model;
+}

--- a/p-models/neutrinoheadersync/test/header_sync_test.p
+++ b/p-models/neutrinoheadersync/test/header_sync_test.p
@@ -1,0 +1,702 @@
+machine TestPlansOnlyConfirmedAnchors {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 100, 200, false);
+
+            model = PlanRange(model, 1, 0, 100);
+            assert sizeof(model.ranges) == 0,
+                "unconfirmed discovered anchor must not create range work";
+
+            model.anchors = AddOrConfirmAnchor(model.anchors, 100, 200, false);
+            model = PlanRange(model, 1, 0, 100);
+            assert sizeof(model.ranges) == 1,
+                "confirmed discovered anchor should create range work";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestOversizedSpanRequiresIntermediateAnchor {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, MaxRangeHeaders() + 1, 200, true
+            );
+
+            model = PlanRange(model, 1, 0, MaxRangeHeaders() + 1);
+            assert sizeof(model.ranges) == 0,
+                "oversized checkpoint span needs a confirmed intermediate anchor";
+
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, MaxRangeHeaders(), 199, false
+            );
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, MaxRangeHeaders(), 199, false
+            );
+
+            model = PlanRange(model, 1, 0, MaxRangeHeaders());
+            model = PlanRange(
+                model, 2, MaxRangeHeaders(), MaxRangeHeaders() + 1
+            );
+            assert sizeof(model.ranges) == 2,
+                "confirmed intermediate anchor should split the large span";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestAnchorDiscoveryPipelinesAheadOfActiveRange {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var frontier: HeaderAnchor;
+            var range: HeaderRange;
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, MaxRangeHeaders(), 200, false
+            );
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, MaxRangeHeaders(), 200, false
+            );
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, MaxRangeHeaders() * 3, 400, true
+            );
+            model = AddPeer(model, NewPeer(1, 0, 10, HeaderPeerReady));
+            model = PlanRange(model, 1, 0, MaxRangeHeaders());
+            model = AssignNextQueuedRange(model);
+            model = StartPeerRange(model, 1);
+
+            range = RangeByID(model.ranges, 1);
+            assert range.range_state == RangeActive,
+                "earlier range should still be active";
+
+            frontier = NextAnchorDiscoveryStart(
+                model, model.committed_tip, model.committed_hash,
+                MaxRangeHeaders() * 3
+            );
+            assert frontier.height == MaxRangeHeaders(),
+                "discovery should advance from furthest confirmed anchor";
+            assert ShouldDiscoverAnchorAhead(
+                model, model.committed_tip, model.committed_hash,
+                MaxRangeHeaders() * 3
+            ),
+                "active range must not block ahead-of-tip discovery";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestConfirmedDiscoveryResponseStagesRange {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var staged: HeaderRange;
+            var ready: seq[int];
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, MaxRangeHeaders(), 200, false
+            );
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, MaxRangeHeaders(), 200, false
+            );
+
+            // Discovery has already fetched the exact headers for this span.
+            // The production implementation should stage them immediately
+            // instead of scheduling the same range for another peer request.
+            model = StageDiscoveredRange(
+                model, 1, 7, 0, MaxRangeHeaders()
+            );
+
+            staged = RangeByID(model.ranges, 1);
+            assert staged.range_state == RangeStaged,
+                "confirmed discovery response should become staged work";
+            assert staged.owner_peer == 7,
+                "staged discovery range should retain source peer";
+            assert staged.lease_epoch == 1,
+                "staged discovery range should have a concrete lease";
+
+            ready = ReadyRanges(model);
+            assert sizeof(ready) == 1,
+                "staged discovery range should be ready to commit";
+            assert ready[0] == 1,
+                "ready staged discovery range should preserve range id";
+
+            model = CommitReadyRanges(model);
+            assert model.committed_tip == MaxRangeHeaders(),
+                "committing staged discovery range should advance tip";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestPostCheckpointFrontierDiscoveryStagesRange {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var frontier: HeaderAnchor;
+            var stop_height: int;
+            var staged: HeaderRange;
+
+            model = NewModel(100000, 500);
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, 100000, 500, true
+            );
+
+            frontier = NextAnchorDiscoveryStart(
+                model, model.committed_tip, model.committed_hash,
+                110000
+            );
+            stop_height = NextFrontierDiscoveryStop(
+                frontier.height, 110000
+            );
+            assert stop_height == 102000,
+                "post-checkpoint discovery should use one bounded window";
+
+            // The first peer response discovers the post-checkpoint boundary.
+            // The second matching response confirms it, after which the exact
+            // headers can be staged even though the boundary was not a static
+            // chaincfg checkpoint.
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, stop_height, 700, false
+            );
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, stop_height, 700, false
+            );
+            model = StageDiscoveredRange(
+                model, 1, 9, frontier.height, stop_height
+            );
+
+            staged = RangeByID(model.ranges, 1);
+            assert staged.range_state == RangeStaged,
+                "confirmed frontier boundary should stage downloaded headers";
+
+            model = CommitReadyRanges(model);
+            assert model.committed_tip == stop_height,
+                "post-checkpoint staged range should advance committed tip";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestFrontierLookaheadStagesBeforeCommit {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var frontier: HeaderAnchor;
+            var first_stop: int;
+            var second_stop: int;
+            var ready: seq[int];
+
+            model = NewModel(100000, 500);
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, 100000, 500, true
+            );
+
+            frontier = NextAnchorDiscoveryStart(
+                model, model.committed_tip, model.committed_hash,
+                110000
+            );
+            first_stop = NextFrontierDiscoveryStop(
+                frontier.height, 110000
+            );
+
+            // The first frontier response gives us both data to stage and the
+            // boundary hash needed to ask for the next frontier window. The
+            // production manager should not wait for disk commit before sending
+            // that next getheaders; doing so would serialize the entire
+            // post-checkpoint lane behind local validation/write work.
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, first_stop, 700, false
+            );
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, first_stop, 700, false
+            );
+            model = StageDiscoveredRange(
+                model, 1, 9, frontier.height, first_stop
+            );
+
+            second_stop = NextFrontierDiscoveryStop(first_stop, 110000);
+            assert second_stop == 104000,
+                "lookahead should move to the next bounded frontier window";
+
+            // This second staged range models the next peer response arriving
+            // before the first staged range has been committed. Ordered commit
+            // must still be the only thing that advances the visible tip.
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, second_stop, 900, false
+            );
+            model.anchors = AddOrConfirmAnchor(
+                model.anchors, second_stop, 900, false
+            );
+            model = StageDiscoveredRange(
+                model, 2, 10, first_stop, second_stop
+            );
+            assert model.committed_tip == 100000,
+                "lookahead staging must not advance visible chain tip";
+
+            ready = ReadyRanges(model);
+            assert sizeof(ready) == 2,
+                "contiguous lookahead ranges should be ready together";
+            assert ready[0] == 1 && ready[1] == 2,
+                "lookahead ranges should preserve ordered commit sequence";
+
+            model = CommitReadyRanges(model);
+            assert model.committed_tip == second_stop,
+                "ordered commit should drain pipelined frontier ranges";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestOutOfOrderCompletionStagesUntilGapFilled {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var first: HeaderRange;
+            var second: HeaderRange;
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 10, 110, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 20, 120, true);
+            model = AddPeer(model, NewPeer(1, 0, 10, HeaderPeerReady));
+            model = AddPeer(model, NewPeer(2, 0, 10, HeaderPeerReady));
+            model = PlanRange(model, 1, 0, 10);
+            model = PlanRange(model, 2, 10, 20);
+            model = AssignNextQueuedRange(model);
+            model = AssignNextQueuedRange(model);
+            model = StartPeerRange(model, 1);
+            model = StartPeerRange(model, 2);
+
+            first = RangeByID(model.ranges, 1);
+            second = RangeByID(model.ranges, 2);
+            model = CompleteRange(model, 2, 2, second.lease_epoch, true);
+            model = CommitReadyRanges(model);
+            assert model.committed_tip == 0,
+                "later completed range must remain staged behind gap";
+            assert sizeof(model.commit_log) == 0,
+                "out-of-order completion must not commit";
+
+            model = CompleteRange(model, 1, 1, first.lease_epoch, true);
+            model = CommitReadyRanges(model);
+            assert model.committed_tip == 20,
+                "commit should drain all now-contiguous staged ranges";
+            assert sizeof(model.commit_log) == 2,
+                "both staged ranges should commit in order";
+            assert model.commit_log[0] == 1,
+                "first committed range should fill the gap";
+            assert model.commit_log[1] == 2,
+                "second committed range should follow";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestExternalTipAdvancePlansGapBeforeStagedFrontier {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var gap: HeaderRange;
+            var staged: HeaderRange;
+            var ready: seq[int];
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 20, 120, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 30, 130, true);
+
+            // This is the failure mode seen in the live sqlite testnet3 run:
+            // later frontier discovery responses were already staged, but a
+            // short serial/fallback write had advanced the durable tip to a
+            // boundary the FSM had not yet made visible. Reconciliation must
+            // add that boundary before the manager keeps discovering farther
+            // ahead, otherwise the staged range after the gap can never commit.
+            model = StageDiscoveredRange(model, 1, 9, 20, 30);
+            model = AdvanceCommittedTip(model, 10, 110);
+            assert model.committed_tip == 10,
+                "external durable tip should become manager-visible";
+
+            model = PlanRange(model, 2, 10, 20);
+            gap = RangeByID(model.ranges, 2);
+            assert gap.range_state == RangeQueued,
+                "known missing frontier span should become fetchable work";
+
+            ready = ReadyRanges(model);
+            assert sizeof(ready) == 0,
+                "later staged frontier range must wait for the planned gap";
+
+            model = AddPeer(model, NewPeer(1, 0, 10, HeaderPeerReady));
+            model = AssignNextQueuedRange(model);
+            model = StartPeerRange(model, 1);
+            gap = RangeByID(model.ranges, 2);
+            model = CompleteRange(model, 1, 2, gap.lease_epoch, true);
+            model = CommitReadyRanges(model);
+
+            staged = RangeByID(model.ranges, 1);
+            assert staged.range_state == RangeCommitted,
+                "committing the gap should drain the already staged range";
+            assert model.committed_tip == 30,
+                "visible tip should advance through all contiguous work";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestReadyRangesDoesNotAdvanceCommittedTip {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var range: HeaderRange;
+            var ready: seq[int];
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 10, 110, true);
+            model = AddPeer(model, NewPeer(1, 0, 10, HeaderPeerReady));
+            model = PlanRange(model, 1, 0, 10);
+            model = AssignNextQueuedRange(model);
+            model = StartPeerRange(model, 1);
+            range = RangeByID(model.ranges, 1);
+            model = CompleteRange(model, 1, 1, range.lease_epoch, true);
+
+            ready = ReadyRanges(model);
+            assert sizeof(ready) == 1,
+                "ready preflight should expose the contiguous staged range";
+            assert ready[0] == 1,
+                "ready preflight should report the staged range id";
+            assert model.committed_tip == 0,
+                "ready preflight must not advance visible committed tip";
+            assert sizeof(model.commit_log) == 0,
+                "ready preflight must not append commit log entries";
+
+            model = CommitReadyRanges(model);
+            assert model.committed_tip == 10,
+                "explicit commit should advance visible committed tip";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestCommitPrunesObsoleteAnchorRequests {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 10, 110, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 20, 120, true);
+
+            // Two peers are hedging discovery. The first request becomes
+            // obsolete when the staged range commits through height 10. The
+            // second is still useful because it can produce the next boundary.
+            model = AddActiveAnchorRequest(model, 1, 0, 10);
+            model = AddActiveAnchorRequest(model, 2, 10, 20);
+            model = StageDiscoveredRange(model, 1, 1, 0, 10);
+
+            model = CommitReadyRangesAndPruneObsoleteAnchors(model);
+
+            assert model.committed_tip == 10,
+                "commit should still advance through staged range";
+            assert sizeof(model.active_anchor_requests) == 1,
+                "obsolete hedged anchor request should be pruned";
+            assert model.active_anchor_requests[0].stop_height == 20,
+                "future anchor request must remain active";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestConflictingDiscoveredAnchorRejected {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var anchor: HeaderAnchor;
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 100, 200, false);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 100, 201, false);
+
+            anchor = AnchorByHeight(model.anchors, 100);
+            assert anchor.rejected,
+                "conflicting discovered anchors should reject the boundary";
+
+            model.anchors = AddOrConfirmAnchor(model.anchors, 100, 200, false);
+            model = PlanRange(model, 1, 0, 100);
+            assert sizeof(model.ranges) == 0,
+                "rejected anchor must not create range work";
+
+            model.anchors = AddOrConfirmAnchor(model.anchors, 100, 200, true);
+            model = PlanRange(model, 1, 0, 100);
+            assert sizeof(model.ranges) == 1,
+                "trusted checkpoint should recover a rejected boundary";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestStaleCompletionCannotOverwriteLease {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var old_epoch: int;
+            var current: HeaderRange;
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 10, 110, true);
+            model = AddPeer(model, NewPeer(1, 0, 10, HeaderPeerReady));
+            model = AddPeer(model, NewPeer(2, 0, 10, HeaderPeerReady));
+            model = PlanRange(model, 1, 0, 10);
+            model = AssignNextQueuedRange(model);
+            model = StartPeerRange(model, 1);
+
+            old_epoch = RangeByID(model.ranges, 1).lease_epoch;
+            model = StealRange(model, 2, 1);
+
+            // The old owner reports a failure after the lease was stolen.
+            // That response is stale and must not poison the current range.
+            model = CompleteRange(model, 1, 1, old_epoch, false);
+            current = RangeByID(model.ranges, 1);
+            assert current.owner_peer == 2,
+                "stale completion must not change current owner";
+            assert current.range_state == RangeOwned,
+                "stale completion must not fail or stage current range";
+
+            model = StartPeerRange(model, 2);
+            current = RangeByID(model.ranges, 1);
+            model = CompleteRange(model, 2, 1, current.lease_epoch, true);
+            model = CommitReadyRanges(model);
+            assert model.committed_tip == 10,
+                "current lease completion should still commit";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestInvalidCompletionDoesNotCommit {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var range: HeaderRange;
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 10, 110, true);
+            model = AddPeer(model, NewPeer(1, 0, 10, HeaderPeerReady));
+            model = PlanRange(model, 1, 0, 10);
+            model = AssignNextQueuedRange(model);
+            model = StartPeerRange(model, 1);
+            range = RangeByID(model.ranges, 1);
+
+            model = CompleteRange(model, 1, 1, range.lease_epoch, false);
+            model = CommitReadyRanges(model);
+            assert model.committed_tip == 0,
+                "invalid range must not advance committed tip";
+            assert RangeByID(model.ranges, 1).range_state == RangeFailed,
+                "invalid completion should fail the range";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestCompletionPreservesPeerPenalty {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var range: HeaderRange;
+            var peer: HeaderPeer;
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 10, 110, true);
+            model = AddPeer(model, NewPeer(1, 0, 10, HeaderPeerReady));
+            model = PlanRange(model, 1, 0, 10);
+            model = AssignNextQueuedRange(model);
+            model = StartPeerRange(model, 1);
+            range = RangeByID(model.ranges, 1);
+
+            model = SetPeerState(model, 1, HeaderPeerQuarantined);
+            model = CompleteRange(model, 1, 1, range.lease_epoch, false);
+            peer = PeerByID(model.peers, 1);
+
+            assert peer.peer_state == HeaderPeerQuarantined,
+                "completion must not clear an explicit peer penalty";
+            assert peer.active_range == NoRange(),
+                "completion should still clear the active range";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestRecoveredPeerCanOwnRangeAgain {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var range: HeaderRange;
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 10, 110, true);
+            model = AddPeer(model, NewPeer(1, 0, 10, HeaderPeerReady));
+            model = PlanRange(model, 1, 0, 10);
+
+            model = SetPeerState(model, 1, HeaderPeerBlocked);
+            model = AssignNextQueuedRange(model);
+            range = RangeByID(model.ranges, 1);
+            assert range.range_state == RangeQueued,
+                "blocked peer must not receive new range ownership";
+
+            model = SetPeerState(model, 1, HeaderPeerReady);
+            model = AssignNextQueuedRange(model);
+            range = RangeByID(model.ranges, 1);
+            assert range.owner_peer == 1,
+                "recovered peer should become schedulable again";
+            assert range.range_state == RangeOwned,
+                "recovered peer should own queued work";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestActiveRangeCanBeStolen {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var before: HeaderRange;
+            var after: HeaderRange;
+            var donor: HeaderPeer;
+            var thief: HeaderPeer;
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 10, 110, true);
+            model = AddPeer(model, NewPeer(1, 0, 10, HeaderPeerReady));
+            model = AddPeer(model, NewPeer(2, 0, 10, HeaderPeerReady));
+            model = PlanRange(model, 1, 0, 10);
+            model = AssignNextQueuedRange(model);
+            model = StartPeerRange(model, 1);
+            before = RangeByID(model.ranges, 1);
+
+            model = StealRange(model, 2, 1);
+            after = RangeByID(model.ranges, 1);
+            donor = PeerByID(model.peers, 1);
+            thief = PeerByID(model.peers, 2);
+
+            assert after.owner_peer == 2,
+                "stolen range should move to thief";
+            assert after.lease_epoch == before.lease_epoch + 1,
+                "steal should bump lease epoch";
+            assert donor.active_range == NoRange(),
+                "donor should no longer own active range";
+            assert sizeof(thief.local_ranges) == 1,
+                "thief should queue stolen range";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine HeaderSyncTestDriver {
+    start state RunTests {
+        entry {
+            new TestPlansOnlyConfirmedAnchors();
+            new TestOversizedSpanRequiresIntermediateAnchor();
+            new TestAnchorDiscoveryPipelinesAheadOfActiveRange();
+            new TestConfirmedDiscoveryResponseStagesRange();
+            new TestPostCheckpointFrontierDiscoveryStagesRange();
+            new TestFrontierLookaheadStagesBeforeCommit();
+            new TestOutOfOrderCompletionStagesUntilGapFilled();
+            new TestReadyRangesDoesNotAdvanceCommittedTip();
+            new TestCommitPrunesObsoleteAnchorRequests();
+            new TestConflictingDiscoveredAnchorRejected();
+            new TestStaleCompletionCannotOverwriteLease();
+            new TestInvalidCompletionDoesNotCommit();
+            new TestCompletionPreservesPeerPenalty();
+            new TestRecoveredPeerCanOwnRangeAgain();
+            new TestActiveRangeCanBeStolen();
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+test tcHeaderSync [main=HeaderSyncTestDriver]:
+  { TestPlansOnlyConfirmedAnchors,
+    TestOversizedSpanRequiresIntermediateAnchor,
+    TestAnchorDiscoveryPipelinesAheadOfActiveRange,
+    TestConfirmedDiscoveryResponseStagesRange,
+    TestPostCheckpointFrontierDiscoveryStagesRange,
+    TestFrontierLookaheadStagesBeforeCommit,
+    TestOutOfOrderCompletionStagesUntilGapFilled,
+    TestReadyRangesDoesNotAdvanceCommittedTip,
+    TestCommitPrunesObsoleteAnchorRequests,
+    TestConflictingDiscoveredAnchorRejected,
+    TestStaleCompletionCannotOverwriteLease,
+    TestInvalidCompletionDoesNotCommit,
+    TestCompletionPreservesPeerPenalty,
+    TestRecoveredPeerCanOwnRangeAgain,
+    TestActiveRangeCanBeStolen,
+    HeaderSyncTestDriver };

--- a/p-models/neutrinoquery/README.md
+++ b/p-models/neutrinoquery/README.md
@@ -1,0 +1,36 @@
+# Neutrino Query Scheduler Model
+
+This model captures the intended query scheduler contract before the production
+code grows a full actor/FSM or deterministic simulation harness.
+
+The model currently covers:
+
+- canceled queued work is not dispatched to peers;
+- a blocked or full high-ranked peer must not prevent another capable peer from
+  receiving work;
+- a quarantined high-ranked peer must not receive work until it recovers;
+- ping RTT raises the per-peer timeout floor and remains clamped;
+- queued work is assigned into bounded, balanced peer-local owned queues before
+  active dispatch;
+- an idle peer can steal a bounded batch of unclaimed work from an overloaded
+  peer;
+- work stealing does not drain ready or busy donors below their last local task;
+- a busy donor with only one queued local task is not stealable until its active
+  request finishes or fails;
+- work stealing can drain a blocked donor whose work would otherwise be
+  stranded.
+
+These are deliberately small, executable invariants. The bridge fixtures in
+`bridge/scenarios.json` describe the same stories the later Go `querysync`
+bridge will replay against the implementation. Once the actor/FSM package lands,
+manager actor traces can be checked against the same scheduler decisions as the
+implementation evolves.
+
+## Run
+
+```shell
+./p-models/scripts/check.sh
+```
+
+The Go-side bridge and actor/FSM tests land with the `querysync` package in a
+later PR.

--- a/p-models/neutrinoquery/bridge/scenarios.json
+++ b/p-models/neutrinoquery/bridge/scenarios.json
@@ -1,0 +1,369 @@
+{
+  "dispatch": [
+    {
+      "name": "skips_blocked_ranked_peer",
+      "base_timeout_ms": 2000,
+      "peers": [
+        {
+          "id": "1",
+          "rank": 0,
+          "rtt_ms": 20,
+          "state": "blocked",
+          "local_work": []
+        },
+        {
+          "id": "2",
+          "rank": 10,
+          "rtt_ms": 50,
+          "state": "ready",
+          "local_work": []
+        }
+      ],
+      "tasks": [
+        {
+          "id": 100,
+          "batch_id": 1,
+          "canceled": false
+        }
+      ],
+      "expect": {
+        "ok": true,
+        "peer_id": "2",
+        "task_id": 100,
+        "timeout_ms": 2000
+      }
+    },
+    {
+      "name": "drops_canceled_queued_work",
+      "base_timeout_ms": 2000,
+      "peers": [
+        {
+          "id": "1",
+          "rank": 0,
+          "rtt_ms": 20,
+          "state": "ready",
+          "local_work": []
+        }
+      ],
+      "tasks": [
+        {
+          "id": 100,
+          "batch_id": 1,
+          "canceled": true
+        }
+      ],
+      "expect": {
+        "ok": false,
+        "peer_id": "",
+        "task_id": 0,
+        "timeout_ms": 0
+      }
+    },
+    {
+      "name": "skips_busy_ranked_peer",
+      "base_timeout_ms": 2000,
+      "peers": [
+        {
+          "id": "1",
+          "rank": 0,
+          "rtt_ms": 20,
+          "state": "busy",
+          "local_work": []
+        },
+        {
+          "id": "2",
+          "rank": 10,
+          "rtt_ms": 50,
+          "state": "ready",
+          "local_work": []
+        }
+      ],
+      "tasks": [
+        {
+          "id": 100,
+          "batch_id": 1,
+          "canceled": false
+        }
+      ],
+      "expect": {
+        "ok": true,
+        "peer_id": "2",
+        "task_id": 100,
+        "timeout_ms": 2000
+      }
+    },
+    {
+      "name": "uses_rtt_as_rank_tie_breaker",
+      "base_timeout_ms": 2000,
+      "peers": [
+        {
+          "id": "1",
+          "rank": 4,
+          "rtt_ms": 800,
+          "state": "ready",
+          "local_work": []
+        },
+        {
+          "id": "2",
+          "rank": 4,
+          "rtt_ms": 50,
+          "state": "ready",
+          "local_work": []
+        }
+      ],
+      "tasks": [
+        {
+          "id": 100,
+          "batch_id": 1,
+          "canceled": false
+        }
+      ],
+      "expect": {
+        "ok": true,
+        "peer_id": "2",
+        "task_id": 100,
+        "timeout_ms": 2000
+      }
+    },
+    {
+      "name": "skips_quarantined_ranked_peer",
+      "base_timeout_ms": 2000,
+      "peers": [
+        {
+          "id": "1",
+          "rank": 0,
+          "rtt_ms": 20,
+          "state": "quarantined",
+          "local_work": []
+        },
+        {
+          "id": "2",
+          "rank": 10,
+          "rtt_ms": 50,
+          "state": "ready",
+          "local_work": []
+        }
+      ],
+      "tasks": [
+        {
+          "id": 100,
+          "batch_id": 1,
+          "canceled": false
+        }
+      ],
+      "expect": {
+        "ok": true,
+        "peer_id": "2",
+        "task_id": 100,
+        "timeout_ms": 2000
+      }
+    },
+    {
+      "name": "rtt_timeout_floor",
+      "base_timeout_ms": 2000,
+      "peers": [
+        {
+          "id": "1",
+          "rank": 0,
+          "rtt_ms": 750,
+          "state": "ready",
+          "local_work": []
+        }
+      ],
+      "tasks": [
+        {
+          "id": 200,
+          "batch_id": 1,
+          "canceled": false
+        }
+      ],
+      "expect": {
+        "ok": true,
+        "peer_id": "1",
+        "task_id": 200,
+        "timeout_ms": 6000
+      }
+    }
+  ],
+  "steal": [
+    {
+      "name": "moves_unclaimed_work_to_idle_peer",
+      "peers": [
+        {
+          "id": "1",
+          "rank": 0,
+          "rtt_ms": 20,
+          "state": "ready",
+          "local_work": [10, 11, 12]
+        },
+        {
+          "id": "2",
+          "rank": 10,
+          "rtt_ms": 10,
+          "state": "ready",
+          "local_work": []
+        }
+      ],
+      "thief": "2",
+      "expect": {
+        "ok": true,
+        "thief_id": "2",
+        "donor_id": "1",
+        "task_id": 10,
+        "task_ids": [10, 11],
+        "donor_remaining": 1,
+        "thief_work_len": 2
+      }
+    },
+    {
+      "name": "does_not_steal_singleton",
+      "peers": [
+        {
+          "id": "1",
+          "rank": 0,
+          "rtt_ms": 20,
+          "state": "ready",
+          "local_work": [10]
+        },
+        {
+          "id": "2",
+          "rank": 10,
+          "rtt_ms": 10,
+          "state": "ready",
+          "local_work": []
+        }
+      ],
+      "thief": "2",
+      "expect": {
+        "ok": false,
+        "thief_id": "",
+        "donor_id": "",
+        "task_id": 0,
+        "donor_remaining": 0,
+        "thief_work_len": 0
+      }
+    },
+    {
+      "name": "does_not_steal_busy_singleton",
+      "peers": [
+        {
+          "id": "1",
+          "rank": 0,
+          "rtt_ms": 20,
+          "state": "busy",
+          "local_work": [10]
+        },
+        {
+          "id": "2",
+          "rank": 10,
+          "rtt_ms": 10,
+          "state": "ready",
+          "local_work": []
+        }
+      ],
+      "thief": "2",
+      "expect": {
+        "ok": false,
+        "thief_id": "",
+        "donor_id": "",
+        "task_id": 0,
+        "donor_remaining": 0,
+        "thief_work_len": 0
+      }
+    },
+    {
+      "name": "busy_donor_retains_one_local_task",
+      "peers": [
+        {
+          "id": "1",
+          "rank": 0,
+          "rtt_ms": 20,
+          "state": "busy",
+          "local_work": [10, 11, 12]
+        },
+        {
+          "id": "2",
+          "rank": 10,
+          "rtt_ms": 10,
+          "state": "ready",
+          "local_work": []
+        }
+      ],
+      "thief": "2",
+      "expect": {
+        "ok": true,
+        "thief_id": "2",
+        "donor_id": "1",
+        "task_id": 10,
+        "task_ids": [10, 11],
+        "donor_remaining": 1,
+        "thief_work_len": 2
+      }
+    },
+    {
+      "name": "ignores_busy_singleton_donor",
+      "peers": [
+        {
+          "id": "1",
+          "rank": 100,
+          "rtt_ms": 20,
+          "state": "busy",
+          "local_work": [10]
+        },
+        {
+          "id": "2",
+          "rank": 0,
+          "rtt_ms": 20,
+          "state": "ready",
+          "local_work": [20, 21]
+        },
+        {
+          "id": "3",
+          "rank": 10,
+          "rtt_ms": 10,
+          "state": "ready",
+          "local_work": []
+        }
+      ],
+      "thief": "3",
+      "expect": {
+        "ok": true,
+        "thief_id": "3",
+        "donor_id": "2",
+        "task_id": 20,
+        "task_ids": [20],
+        "donor_remaining": 1,
+        "thief_work_len": 1
+      }
+    },
+    {
+      "name": "drains_blocked_singleton",
+      "peers": [
+        {
+          "id": "1",
+          "rank": 0,
+          "rtt_ms": 20,
+          "state": "blocked",
+          "local_work": [10]
+        },
+        {
+          "id": "2",
+          "rank": 10,
+          "rtt_ms": 10,
+          "state": "ready",
+          "local_work": []
+        }
+      ],
+      "thief": "2",
+      "expect": {
+        "ok": true,
+        "thief_id": "2",
+        "donor_id": "1",
+        "task_id": 10,
+        "task_ids": [10],
+        "donor_remaining": 0,
+        "thief_work_len": 1
+      }
+    }
+  ]
+}

--- a/p-models/neutrinoquery/infra.pproj
+++ b/p-models/neutrinoquery/infra.pproj
@@ -1,0 +1,8 @@
+<Project>
+<ProjectName>NeutrinoQueryModels</ProjectName>
+<InputFiles>
+<PFile>src/query_scheduler.p</PFile>
+<PFile>test/query_scheduler_test.p</PFile>
+</InputFiles>
+<OutputDir>PGenerated</OutputDir>
+</Project>

--- a/p-models/neutrinoquery/src/query_scheduler.p
+++ b/p-models/neutrinoquery/src/query_scheduler.p
@@ -1,0 +1,608 @@
+// query_scheduler.p - Neutrino query scheduler executable specification.
+//
+// This file is written as an executable design note. P syntax is intentionally
+// close to a small imperative language: records model state, pure functions
+// model decisions, and tests assert the invariants that must keep holding as the
+// Go scheduler evolves.
+//
+// The model is intentionally small. It captures the scheduling invariants that
+// matter for robustness under poor network conditions:
+//
+//   * canceled queued work is dropped by the scheduler, not dispatched;
+//   * a blocked peer cannot stall other capable peers;
+//   * a quarantined peer cannot receive new work until it recovers;
+//   * peer RTT raises the timeout floor used for a query attempt;
+//   * queued work can be assigned into bounded peer-local owned queues;
+//   * an idle peer may steal enough unclaimed work to fill its local capacity;
+//   * stealing leaves ready and busy donors with at least one local task;
+//   * busy singleton donors are left alone until their active request finishes
+//     or fails, while blocked/quarantined donors can be drained because they
+//     are not making progress.
+
+enum PeerState {
+    // PeerReady means the peer has no active query and its mailbox can accept a
+    // new assignment immediately.
+    PeerReady,
+
+    // PeerBusy means the peer owns an active query. The global scheduler should
+    // wait for a result or cancellation before giving it more work.
+    PeerBusy,
+
+    // PeerBlocked is the important production failure mode: the peer looks
+    // connected, but its worker queue cannot accept a send right now, or the
+    // manager is temporarily avoiding it for the current task because it just
+    // failed that task. A blocked high-ranked peer must not stall the entire
+    // dispatcher.
+    PeerBlocked,
+
+    // PeerQuarantined is stronger than blocked. The manager has seen enough
+    // repeated non-responses that production should stop assigning new work and
+    // hand the peer to the expiring ban/quarantine path. This state is still
+    // recoverable: when the ban decays and the peer reconnects it can re-enter
+    // PeerReady.
+    PeerQuarantined,
+
+    // PeerDown means the peer is disconnected or otherwise unavailable.
+    PeerDown
+}
+
+// QueryTask is the global work item. The model keeps only the fields needed for
+// scheduling safety: a stable identity and whether the enclosing batch has
+// canceled it.
+type QueryTask = (
+    id: int,
+    canceled: bool
+);
+
+// PeerModel abstracts one neutrino worker. rank is lower-is-better, rtt_ms is
+// the latest ping RTT sample, and local_work is the peer-owned queue used by the
+// work-stealing portion of the model.
+type PeerModel = (
+    id: int,
+    rank: int,
+    rtt_ms: int,
+    peer_state: PeerState,
+    local_work: seq[int]
+);
+
+// DispatchResult is what the scheduler decided for one attempt. NoPeer/NoTask
+// means the scheduler intentionally did not dispatch.
+type DispatchResult = (
+    peer_id: int,
+    task_id: int,
+    timeout_ms: int
+);
+
+fun NoPeer(): int {
+    return 0;
+}
+
+fun NoTask(): int {
+    return 0;
+}
+
+fun MinQueryTimeoutMs(): int {
+    return 2000;
+}
+
+fun MaxQueryTimeoutMs(): int {
+    return 32000;
+}
+
+fun RTTMultiplier(): int {
+    return 8;
+}
+
+// Constructors keep tests readable and make it explicit when future fields are
+// added to the model. That matters because P records are positional enough that
+// ad hoc literals become hard to audit.
+fun NewTask(id: int, canceled: bool): QueryTask {
+    return (id = id, canceled = canceled);
+}
+
+fun NewPeer(id: int, rank: int, rtt_ms: int, peer_state: PeerState,
+    local_work: seq[int]): PeerModel {
+
+    return (
+        id = id,
+        rank = rank,
+        rtt_ms = rtt_ms,
+        peer_state = peer_state,
+        local_work = local_work
+    );
+}
+
+// EmptyDispatch is an explicit no-op decision. The Go scheduler should reach
+// this shape when all queued work is canceled, no peer can accept work, or no
+// live work exists.
+fun EmptyDispatch(): DispatchResult {
+    return (
+        peer_id = NoPeer(),
+        task_id = NoTask(),
+        timeout_ms = 0
+    );
+}
+
+// PeerCanAccept is the model equivalent of a non-blocking worker send. This is
+// the key distinction from the old behavior: connected is not enough; the peer
+// must be ready to accept work without blocking the dispatcher.
+fun PeerCanAccept(peer: PeerModel): bool {
+    return peer.peer_state == PeerReady;
+}
+
+// MaxPeerOutstandingWork is a bounded queue policy, not a protocol constant.
+// The important invariant is the cap: local ownership can be deeper than one
+// item, but a peer cannot hide an unbounded backlog from the manager. The count
+// includes the active query slot for busy peers.
+fun MaxPeerOutstandingWork(): int {
+    return 4;
+}
+
+// PeerOutstandingLoad counts unstarted local work plus the active query slot.
+// This is the unit the scheduler uses to decide if a peer has room for more
+// ownership.
+fun PeerOutstandingLoad(peer: PeerModel): int {
+    var load: int;
+
+    load = sizeof(peer.local_work);
+    if (peer.peer_state == PeerBusy) {
+        load = load + 1;
+    }
+
+    return load;
+}
+
+// PeerLocalSpare returns the number of additional unstarted tasks this peer can
+// own. Ready and busy peers can own local work; blocked, quarantined, and down
+// peers must not receive new ownership from the global queue.
+fun PeerLocalSpare(peer: PeerModel): int {
+    var spare: int;
+
+    if (!(peer.peer_state == PeerReady || peer.peer_state == PeerBusy)) {
+        return 0;
+    }
+
+    spare = MaxPeerOutstandingWork() - PeerOutstandingLoad(peer);
+    if (spare < 0) {
+        return 0;
+    }
+
+    return spare;
+}
+
+// PeerCanOwnLocalWork is intentionally broader than PeerCanAccept. A busy peer
+// can own queued follow-up tasks even though it cannot start them immediately.
+// The bounded cap keeps global work visible to the manager instead of parking a
+// deep backlog behind one lagging peer.
+fun PeerCanOwnLocalWork(peer: PeerModel): bool {
+    return PeerLocalSpare(peer) > 0;
+}
+
+// PeerOrdersBefore models ranking plus RTT tie-breaking. The current Go patch
+// only uses RTT for timeout floors, but keeping RTT in the model selection order
+// documents the intended next step: fast peers should become more likely to get
+// work when peers are otherwise equivalent.
+fun PeerOrdersBefore(peer: PeerModel, candidate: PeerModel): bool {
+    if (peer.rank < candidate.rank) {
+        return true;
+    }
+
+    if (peer.rank > candidate.rank) {
+        return false;
+    }
+
+    if (peer.rtt_ms < candidate.rtt_ms) {
+        return true;
+    }
+
+    if (peer.rtt_ms > candidate.rtt_ms) {
+        return false;
+    }
+
+    return peer.id < candidate.id;
+}
+
+// QueryTimeoutForPeer is the formal version of the dynamic timeout rule:
+//
+//   timeout = clamp(max(base_timeout, latest_rtt * multiplier), min, max)
+//
+// A zero RTT sample means "unknown", so the base timeout remains in force.
+fun QueryTimeoutForPeer(base_timeout_ms: int, peer: PeerModel): int {
+    var timeout_ms: int;
+    var rtt_timeout_ms: int;
+
+    timeout_ms = base_timeout_ms;
+    if (timeout_ms < MinQueryTimeoutMs()) {
+        timeout_ms = MinQueryTimeoutMs();
+    }
+
+    if (peer.rtt_ms > 0) {
+        rtt_timeout_ms = peer.rtt_ms * RTTMultiplier();
+        if (rtt_timeout_ms > timeout_ms) {
+            timeout_ms = rtt_timeout_ms;
+        }
+    }
+
+    if (timeout_ms > MaxQueryTimeoutMs()) {
+        timeout_ms = MaxQueryTimeoutMs();
+    }
+
+    return timeout_ms;
+}
+
+// FirstLiveTask captures the cancellation invariant. A canceled queued task is
+// dead scheduler state; it should be discarded in the dispatcher instead of
+// being handed to a worker just to produce a canceled result later.
+fun FirstLiveTask(tasks: seq[QueryTask]): int {
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(tasks)) {
+        if (!tasks[i].canceled) {
+            return tasks[i].id;
+        }
+
+        i = i + 1;
+    }
+
+    return NoTask();
+}
+
+// SelectPeer chooses the best peer that can accept work now. A blocked
+// high-ranked peer is skipped, which is the load-awareness property missing
+// from a scheduler that blindly blocks on the first ranked worker.
+fun SelectPeer(peers: seq[PeerModel]): int {
+    var i: int;
+    var found: bool;
+    var candidate: PeerModel;
+
+    i = 0;
+    while (i < sizeof(peers)) {
+        if (PeerCanAccept(peers[i])) {
+            if (!found || PeerOrdersBefore(peers[i], candidate)) {
+                found = true;
+                candidate = peers[i];
+            }
+        }
+
+        i = i + 1;
+    }
+
+    if (!found) {
+        return NoPeer();
+    }
+
+    return candidate.id;
+}
+
+// PeerByID is total because P functions must return something for every input.
+// Callers treat id=NoPeer as the sentinel miss.
+fun PeerByID(peers: seq[PeerModel], id: int): PeerModel {
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(peers)) {
+        if (peers[i].id == id) {
+            return peers[i];
+        }
+
+        i = i + 1;
+    }
+
+    return NewPeer(NoPeer(), 0, 0, PeerDown, default(seq[int]));
+}
+
+// LocalOwnerOrdersBefore chooses the peer with the most spare local capacity,
+// then falls back to lower outstanding load, then to the same rank/RTT ordering
+// used for immediate dispatch. This lets fast peers build a useful queue while
+// still spreading ownership before anyone reaches the cap.
+fun LocalOwnerOrdersBefore(peer: PeerModel, candidate: PeerModel): bool {
+    if (PeerLocalSpare(peer) > PeerLocalSpare(candidate)) {
+        return true;
+    }
+
+    if (PeerLocalSpare(peer) < PeerLocalSpare(candidate)) {
+        return false;
+    }
+
+    if (PeerOutstandingLoad(peer) < PeerOutstandingLoad(candidate)) {
+        return true;
+    }
+
+    if (PeerOutstandingLoad(peer) > PeerOutstandingLoad(candidate)) {
+        return false;
+    }
+
+    return PeerOrdersBefore(peer, candidate);
+}
+
+// SelectLocalOwner chooses the peer that should own the next queued task. This
+// is separate from SelectPeer because ownership and active dispatch are distinct
+// phases in production: a peer can own future work without blocking the manager
+// on its mailbox right now.
+fun SelectLocalOwner(peers: seq[PeerModel]): int {
+    var i: int;
+    var found: bool;
+    var candidate: PeerModel;
+
+    i = 0;
+    while (i < sizeof(peers)) {
+        if (PeerCanOwnLocalWork(peers[i])) {
+            if (!found || LocalOwnerOrdersBefore(peers[i], candidate)) {
+                found = true;
+                candidate = peers[i];
+            }
+        }
+
+        i = i + 1;
+    }
+
+    if (!found) {
+        return NoPeer();
+    }
+
+    return candidate.id;
+}
+
+// DispatchNext is the core global scheduling rule. It first drops canceled
+// queued work, then picks a peer that can accept now, then derives the timeout
+// for the selected peer. The returned tuple is the contract the Go dispatcher
+// should implement for one assignment attempt.
+fun DispatchNext(peers: seq[PeerModel], tasks: seq[QueryTask],
+    base_timeout_ms: int): DispatchResult {
+
+    var peer_id: int;
+    var task_id: int;
+    var peer: PeerModel;
+
+    task_id = FirstLiveTask(tasks);
+    if (task_id == NoTask()) {
+        return EmptyDispatch();
+    }
+
+    peer_id = SelectPeer(peers);
+    if (peer_id == NoPeer()) {
+        return EmptyDispatch();
+    }
+
+    peer = PeerByID(peers, peer_id);
+
+    return (
+        peer_id = peer_id,
+        task_id = task_id,
+        timeout_ms = QueryTimeoutForPeer(base_timeout_ms, peer)
+    );
+}
+
+// The helpers below model peer-local queues. These queues are the foundation for
+// work stealing: fast idle peers should be able to pull unclaimed work away from
+// overloaded peers without violating local queue order.
+fun AppendWork(work: seq[int], task_id: int): seq[int] {
+    work += (sizeof(work), task_id);
+    return work;
+}
+
+fun DropFirstWork(work: seq[int]): seq[int] {
+    var result: seq[int];
+    var i: int;
+
+    i = 1;
+    while (i < sizeof(work)) {
+        result += (sizeof(result), work[i]);
+        i = i + 1;
+    }
+
+    return result;
+}
+
+fun ReplacePeer(peers: seq[PeerModel], peer: PeerModel): seq[PeerModel] {
+    var result: seq[PeerModel];
+    var i: int;
+
+    i = 0;
+    while (i < sizeof(peers)) {
+        if (peers[i].id == peer.id) {
+            result += (sizeof(result), peer);
+        } else {
+            result += (sizeof(result), peers[i]);
+        }
+
+        i = i + 1;
+    }
+
+    return result;
+}
+
+// AssignLocalTask moves a queued task into a peer-owned local queue without
+// marking the peer busy. This is the model form of the production manager's
+// owned-work transition: ownership is visible to stealing, while active network
+// dispatch remains a separate peer event.
+fun AssignLocalTask(peers: seq[PeerModel], task: QueryTask): seq[PeerModel] {
+    var owner_id: int;
+    var owner: PeerModel;
+
+    if (task.canceled) {
+        return peers;
+    }
+
+    owner_id = SelectLocalOwner(peers);
+    if (owner_id == NoPeer()) {
+        return peers;
+    }
+
+    owner = PeerByID(peers, owner_id);
+    owner = NewPeer(
+        owner.id, owner.rank, owner.rtt_ms, owner.peer_state,
+        AppendWork(owner.local_work, task.id)
+    );
+
+    return ReplacePeer(peers, owner);
+}
+
+// StealableWork returns how many local tasks can be moved away from a donor.
+// Ready and busy donors keep one local task to avoid starvation and avoid
+// steal ping-pong: if a peer just stole a small queue and started its first
+// task, another idle peer should not immediately drain that last queued task.
+// Blocked and quarantined donors may be drained because they are not accepting
+// sends.
+fun StealableWork(peer: PeerModel): int {
+    if (peer.peer_state == PeerReady) {
+        if (sizeof(peer.local_work) <= 1) {
+            return 0;
+        }
+
+        return sizeof(peer.local_work) - 1;
+    }
+
+    if (peer.peer_state == PeerBusy) {
+        if (sizeof(peer.local_work) <= 1) {
+            return 0;
+        }
+
+        return sizeof(peer.local_work) - 1;
+    }
+
+    if (peer.peer_state == PeerBlocked ||
+        peer.peer_state == PeerQuarantined) {
+
+        return sizeof(peer.local_work);
+    }
+
+    return 0;
+}
+
+// StealDonorPriority separates work that is truly stranded from work that is
+// merely queued behind an active peer. Blocked/quarantined donors are best
+// because stealing from them directly heals a stall. Ready or busy donors with
+// surplus local work are next. Busy singletons are not stealable; the active
+// request should get a chance to finish or fail before the last queued task is
+// considered stranded.
+fun StealDonorPriority(peer: PeerModel): int {
+    if (peer.peer_state == PeerBlocked ||
+        peer.peer_state == PeerQuarantined) {
+
+        return 3;
+    }
+
+    if (peer.peer_state == PeerReady && sizeof(peer.local_work) > 1) {
+        return 2;
+    }
+
+    if (peer.peer_state == PeerBusy && sizeof(peer.local_work) > 1) {
+        return 2;
+    }
+
+    return 0;
+}
+
+// StealDonorOrdersBefore chooses the donor whose work is most useful to move.
+// Priority is considered before raw work count so stranded work on blocked
+// peers is healed before merely balancing surplus ready or busy donors.
+fun StealDonorOrdersBefore(peer: PeerModel, candidate: PeerModel): bool {
+    if (StealDonorPriority(peer) > StealDonorPriority(candidate)) {
+        return true;
+    }
+
+    if (StealDonorPriority(peer) < StealDonorPriority(candidate)) {
+        return false;
+    }
+
+    if (StealableWork(peer) > StealableWork(candidate)) {
+        return true;
+    }
+
+    if (StealableWork(peer) < StealableWork(candidate)) {
+        return false;
+    }
+
+    if (peer.rank > candidate.rank) {
+        return true;
+    }
+
+    if (peer.rank < candidate.rank) {
+        return false;
+    }
+
+    return peer.id < candidate.id;
+}
+
+// SelectStealDonor chooses the best donor with stealable unclaimed work.
+fun SelectStealDonor(peers: seq[PeerModel], thief_id: int): int {
+    var i: int;
+    var found: bool;
+    var candidate: PeerModel;
+
+    i = 0;
+    while (i < sizeof(peers)) {
+        if (peers[i].id != thief_id && StealableWork(peers[i]) > 0) {
+
+            if (!found || StealDonorOrdersBefore(peers[i], candidate)) {
+
+                found = true;
+                candidate = peers[i];
+            }
+        }
+
+        i = i + 1;
+    }
+
+    if (!found) {
+        return NoPeer();
+    }
+
+    return candidate.id;
+}
+
+// StealOne is the work-stealing transition. An idle thief with an empty local
+// queue can move the oldest unclaimed tasks from the most-loaded donor into its
+// own local queue until the thief reaches capacity or the donor runs out of
+// stealable work. The safety invariant remains: stealing never loses,
+// duplicates, or reorders stolen tasks.
+fun StealOne(peers: seq[PeerModel], thief_id: int): seq[PeerModel] {
+    var thief: PeerModel;
+    var donor: PeerModel;
+    var donor_id: int;
+    var stolen_task: int;
+    var steal_count: int;
+    var i: int;
+
+    thief = PeerByID(peers, thief_id);
+    if (!PeerCanAccept(thief) || sizeof(thief.local_work) != 0) {
+        return peers;
+    }
+
+    donor_id = SelectStealDonor(peers, thief_id);
+    if (donor_id == NoPeer()) {
+        return peers;
+    }
+
+    donor = PeerByID(peers, donor_id);
+    steal_count = StealableWork(donor);
+    if (steal_count > PeerLocalSpare(thief)) {
+        steal_count = PeerLocalSpare(thief);
+    }
+
+    if (steal_count == 0) {
+        return peers;
+    }
+
+    i = 0;
+    while (i < steal_count) {
+        stolen_task = donor.local_work[0];
+        donor = NewPeer(
+            donor.id, donor.rank, donor.rtt_ms, donor.peer_state,
+            DropFirstWork(donor.local_work)
+        );
+        thief = NewPeer(
+            thief.id, thief.rank, thief.rtt_ms, thief.peer_state,
+            AppendWork(thief.local_work, stolen_task)
+        );
+
+        i = i + 1;
+    }
+
+    peers = ReplacePeer(peers, donor);
+    peers = ReplacePeer(peers, thief);
+
+    return peers;
+}

--- a/p-models/neutrinoquery/test/query_scheduler_test.p
+++ b/p-models/neutrinoquery/test/query_scheduler_test.p
@@ -1,0 +1,601 @@
+// query_scheduler_test.p - Neutrino query scheduler model checks.
+//
+// Each test machine is a small executable story. It constructs a scheduler
+// state, applies one model transition, and asserts the property we want the Go
+// implementation to preserve. Keeping these as short stories makes the model
+// useful to contributors who know neutrino but are new to P.
+
+machine TestSchedulerSkipsBlockedRankedPeer {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var tasks: seq[QueryTask];
+            var empty: seq[int];
+            var result: DispatchResult;
+
+            peers += (sizeof(peers), NewPeer(
+                1, 0, 20, PeerBlocked, empty
+            ));
+            peers += (sizeof(peers), NewPeer(
+                2, 10, 50, PeerReady, empty
+            ));
+            tasks += (sizeof(tasks), NewTask(100, false));
+
+            // Peer 1 has the best rank but is blocked. The scheduler must not
+            // wait on it while peer 2 can accept the work immediately.
+            result = DispatchNext(peers, tasks, MinQueryTimeoutMs());
+
+            assert result.peer_id == 2,
+                "blocked best-ranked peer must not stall capable peer";
+            assert result.task_id == 100,
+                "live task must be dispatched to capable peer";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestSchedulerSkipsBusyRankedPeer {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var tasks: seq[QueryTask];
+            var empty: seq[int];
+            var result: DispatchResult;
+
+            peers += (sizeof(peers), NewPeer(
+                1, 0, 20, PeerBusy, empty
+            ));
+            peers += (sizeof(peers), NewPeer(
+                2, 10, 50, PeerReady, empty
+            ));
+            tasks += (sizeof(tasks), NewTask(100, false));
+
+            // Busy means the peer already owns a query. Even if it has the
+            // best rank, assigning another task would violate the one-active
+            // query invariant used by the production worker today.
+            result = DispatchNext(peers, tasks, MinQueryTimeoutMs());
+
+            assert result.peer_id == 2,
+                "busy best-ranked peer must not receive additional work";
+            assert result.task_id == 100,
+                "live task must be dispatched to capable peer";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestSchedulerSkipsQuarantinedRankedPeer {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var tasks: seq[QueryTask];
+            var empty: seq[int];
+            var result: DispatchResult;
+
+            peers += (sizeof(peers), NewPeer(
+                1, 0, 20, PeerQuarantined, empty
+            ));
+            peers += (sizeof(peers), NewPeer(
+                2, 10, 50, PeerReady, empty
+            ));
+            tasks += (sizeof(tasks), NewTask(100, false));
+
+            // Quarantine is stronger than a transient blocked mailbox: the
+            // peer has repeatedly failed to respond and must not receive more
+            // work until the external ban/quarantine path lets it recover.
+            result = DispatchNext(peers, tasks, MinQueryTimeoutMs());
+
+            assert result.peer_id == 2,
+                "quarantined best-ranked peer must not receive work";
+            assert result.task_id == 100,
+                "live task must be dispatched to recoverable peer";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestSchedulerUsesRTTAsRankTieBreaker {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var tasks: seq[QueryTask];
+            var empty: seq[int];
+            var result: DispatchResult;
+
+            peers += (sizeof(peers), NewPeer(
+                1, 4, 800, PeerReady, empty
+            ));
+            peers += (sizeof(peers), NewPeer(
+                2, 4, 50, PeerReady, empty
+            ));
+            tasks += (sizeof(tasks), NewTask(100, false));
+
+            // Ranking history remains the primary signal, but when two peers
+            // have the same score the lower RTT peer should get the next query.
+            // This gives the production scheduler an immediate latency signal
+            // without discarding punishment/reward history.
+            result = DispatchNext(peers, tasks, MinQueryTimeoutMs());
+
+            assert result.peer_id == 2,
+                "equal-ranked lower RTT peer should be preferred";
+            assert result.task_id == 100,
+                "live task must be dispatched to selected peer";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestSchedulerDropsCanceledQueuedWork {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var tasks: seq[QueryTask];
+            var empty: seq[int];
+            var result: DispatchResult;
+
+            peers += (sizeof(peers), NewPeer(
+                1, 0, 20, PeerReady, empty
+            ));
+            tasks += (sizeof(tasks), NewTask(100, true));
+
+            // A canceled queued task should be consumed by scheduler cleanup,
+            // not by a worker round trip.
+            result = DispatchNext(peers, tasks, MinQueryTimeoutMs());
+
+            assert result.task_id == NoTask(),
+                "canceled queued task must not be dispatched";
+            assert result.peer_id == NoPeer(),
+                "canceled queued task must not consume peer capacity";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestSchedulerRTTTimeoutFloor {
+    start state Init {
+        entry {
+            var empty: seq[int];
+            var peer: PeerModel;
+
+            // Poor links need a timeout floor based on observed RTT. A 750ms
+            // RTT is too close to the old 2s fixed timeout once jitter and
+            // multi-message responses are included, so the model expects the
+            // multiplier rule to raise it.
+            peer = NewPeer(1, 0, 750, PeerReady, empty);
+            assert QueryTimeoutForPeer(MinQueryTimeoutMs(), peer) == 6000,
+                "750ms RTT with multiplier 8 should produce 6s timeout";
+
+            peer = NewPeer(1, 0, 9000, PeerReady, empty);
+            assert QueryTimeoutForPeer(MinQueryTimeoutMs(), peer) ==
+                MaxQueryTimeoutMs(),
+                "RTT-derived timeout must be capped";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestWorkStealingMovesUnclaimedWorkToIdlePeer {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var donor_work: seq[int];
+            var empty: seq[int];
+            var donor: PeerModel;
+            var thief: PeerModel;
+
+            donor_work += (sizeof(donor_work), 10);
+            donor_work += (sizeof(donor_work), 11);
+            donor_work += (sizeof(donor_work), 12);
+
+            peers += (sizeof(peers), NewPeer(
+                1, 0, 20, PeerReady, donor_work
+            ));
+            peers += (sizeof(peers), NewPeer(
+                2, 10, 10, PeerReady, empty
+            ));
+
+            // Peer 2 is idle and peer 1 has spare local work. Stealing fills
+            // the thief up to capacity from the oldest donor tasks, while
+            // leaving a ready donor with one local task so it is not starved.
+            peers = StealOne(peers, 2);
+            donor = PeerByID(peers, 1);
+            thief = PeerByID(peers, 2);
+
+            assert sizeof(donor.local_work) == 1,
+                "work stealing should leave ready donor one local task";
+            assert sizeof(thief.local_work) == 2,
+                "idle thief should receive a bounded stolen batch";
+            assert thief.local_work[0] == 10,
+                "stealing should preserve first donor task order";
+            assert thief.local_work[1] == 11,
+                "stealing should preserve second donor task order";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestWorkStealingLeavesBusyDonorQueuedWork {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var donor_work: seq[int];
+            var empty: seq[int];
+            var donor: PeerModel;
+            var thief: PeerModel;
+
+            donor_work += (sizeof(donor_work), 10);
+            donor_work += (sizeof(donor_work), 11);
+            donor_work += (sizeof(donor_work), 12);
+
+            peers += (sizeof(peers), NewPeer(
+                1, 0, 20, PeerBusy, donor_work
+            ));
+            peers += (sizeof(peers), NewPeer(
+                2, 10, 10, PeerReady, empty
+            ));
+
+            // A busy donor may contribute surplus queued work, but it should
+            // keep one local task. This prevents a peer that just stole a
+            // small queue and started work from being drained again before it
+            // has a chance to make progress.
+            peers = StealOne(peers, 2);
+            donor = PeerByID(peers, 1);
+            thief = PeerByID(peers, 2);
+
+            assert sizeof(donor.local_work) == 1,
+                "busy donor should retain one queued local task";
+            assert donor.local_work[0] == 12,
+                "busy donor should retain newest local task";
+            assert sizeof(thief.local_work) == 2,
+                "idle thief should receive busy donor surplus";
+            assert thief.local_work[0] == 10,
+                "stealing should preserve busy donor first task order";
+            assert thief.local_work[1] == 11,
+                "stealing should preserve busy donor second task order";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestWorkStealingIgnoresBusySingletonDonor {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var busy_work: seq[int];
+            var ready_work: seq[int];
+            var empty: seq[int];
+            var busy: PeerModel;
+            var ready: PeerModel;
+            var thief: PeerModel;
+
+            busy_work += (sizeof(busy_work), 10);
+            ready_work += (sizeof(ready_work), 20);
+            ready_work += (sizeof(ready_work), 21);
+
+            peers += (sizeof(peers), NewPeer(
+                1, 100, 20, PeerBusy, busy_work
+            ));
+            peers += (sizeof(peers), NewPeer(
+                2, 0, 20, PeerReady, ready_work
+            ));
+            peers += (sizeof(peers), NewPeer(
+                3, 10, 10, PeerReady, empty
+            ));
+
+            // A busy singleton is not stealable. The active request should
+            // get a chance to finish or fail before the final queued task is
+            // treated as stranded, so the thief takes ready surplus instead.
+            peers = StealOne(peers, 3);
+            busy = PeerByID(peers, 1);
+            ready = PeerByID(peers, 2);
+            thief = PeerByID(peers, 3);
+
+            assert sizeof(busy.local_work) == 1,
+                "busy singleton should be left alone when surplus exists";
+            assert busy.local_work[0] == 10,
+                "busy singleton task should be preserved";
+            assert sizeof(ready.local_work) == 1,
+                "ready surplus donor should retain one local task";
+            assert ready.local_work[0] == 21,
+                "ready donor should retain newest local task";
+            assert sizeof(thief.local_work) == 1,
+                "thief should receive one surplus task";
+            assert thief.local_work[0] == 20,
+                "thief should receive oldest surplus task";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestAssignLocalTaskBalancesOwnedWork {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var loaded_work: seq[int];
+            var empty: seq[int];
+            var loaded: PeerModel;
+            var selected: PeerModel;
+
+            loaded_work += (sizeof(loaded_work), 10);
+            loaded_work += (sizeof(loaded_work), 11);
+
+            peers += (sizeof(peers), NewPeer(
+                1, 0, 20, PeerReady, loaded_work
+            ));
+            peers += (sizeof(peers), NewPeer(
+                2, 10, 50, PeerReady, empty
+            ));
+
+            // Ownership is not the same thing as active dispatch. The
+            // lower-ranked peer already owns two unstarted tasks, so the next
+            // queued task should be assigned to the empty peer instead of
+            // deepening the backlog on peer 1.
+            peers = AssignLocalTask(peers, NewTask(12, false));
+            loaded = PeerByID(peers, 1);
+            selected = PeerByID(peers, 2);
+
+            assert sizeof(loaded.local_work) == 2,
+                "owned-work assignment must not overload the donor";
+            assert sizeof(selected.local_work) == 1,
+                "empty peer should own the next queued task";
+            assert selected.local_work[0] == 12,
+                "owned-work assignment should preserve task identity";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestAssignLocalTaskBuildsBoundedPeerQueue {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var local_work: seq[int];
+            var peer: PeerModel;
+
+            local_work += (sizeof(local_work), 10);
+            peers += (sizeof(peers), NewPeer(
+                1, 0, 20, PeerReady, local_work
+            ));
+
+            // Local ownership should be deeper than one item so a good peer
+            // can stay fed without round-tripping through the global queue for
+            // every task. The cap still keeps ownership bounded and visible.
+            peers = AssignLocalTask(peers, NewTask(11, false));
+            peer = PeerByID(peers, 1);
+
+            assert sizeof(peer.local_work) == 2,
+                "owned-work assignment should build a bounded local queue";
+            assert peer.local_work[0] == 10,
+                "existing local work should be preserved";
+            assert peer.local_work[1] == 11,
+                "new local work should be appended in FIFO order";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestAssignLocalTaskDoesNotExceedPeerCapacity {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var local_work: seq[int];
+            var peer: PeerModel;
+
+            local_work += (sizeof(local_work), 10);
+            local_work += (sizeof(local_work), 11);
+            local_work += (sizeof(local_work), 12);
+            local_work += (sizeof(local_work), 13);
+            peers += (sizeof(peers), NewPeer(
+                1, 0, 20, PeerReady, local_work
+            ));
+
+            // The bounded queue is what prevents a fast-looking peer from
+            // hiding the whole batch behind its actor. Once capacity is full,
+            // the manager must leave later tasks globally visible.
+            peers = AssignLocalTask(peers, NewTask(14, false));
+            peer = PeerByID(peers, 1);
+
+            assert sizeof(peer.local_work) == MaxPeerOutstandingWork(),
+                "owned-work assignment must respect peer capacity";
+            assert peer.local_work[0] == 10,
+                "first queued task should be preserved at capacity";
+            assert peer.local_work[3] == 13,
+                "last queued task should be preserved at capacity";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestWorkStealingDoesNotStealSingleton {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var donor_work: seq[int];
+            var empty: seq[int];
+            var donor: PeerModel;
+            var thief: PeerModel;
+
+            donor_work += (sizeof(donor_work), 10);
+
+            peers += (sizeof(peers), NewPeer(
+                1, 0, 20, PeerReady, donor_work
+            ));
+            peers += (sizeof(peers), NewPeer(
+                2, 10, 10, PeerReady, empty
+            ));
+
+            // A donor with one task is not overloaded. The thief remains idle
+            // instead of starving the donor.
+            peers = StealOne(peers, 2);
+            donor = PeerByID(peers, 1);
+            thief = PeerByID(peers, 2);
+
+            assert sizeof(donor.local_work) == 1,
+                "stealing must not drain donor below one local task";
+            assert sizeof(thief.local_work) == 0,
+                "idle thief must remain idle when no donor has spare work";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestWorkStealingDoesNotStealBusySingleton {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var donor_work: seq[int];
+            var empty: seq[int];
+            var donor: PeerModel;
+            var thief: PeerModel;
+
+            donor_work += (sizeof(donor_work), 10);
+
+            peers += (sizeof(peers), NewPeer(
+                1, 0, 20, PeerBusy, donor_work
+            ));
+            peers += (sizeof(peers), NewPeer(
+                2, 10, 10, PeerReady, empty
+            ));
+
+            // A busy donor with one queued task is not yet stranded. Its
+            // active request should finish or fail before the final local task
+            // is made stealable.
+            peers = StealOne(peers, 2);
+            donor = PeerByID(peers, 1);
+            thief = PeerByID(peers, 2);
+
+            assert sizeof(donor.local_work) == 1,
+                "busy singleton should keep its final queued task";
+            assert sizeof(thief.local_work) == 0,
+                "idle thief must not steal from busy singleton";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine TestWorkStealingCanDrainBlockedDonor {
+    start state Init {
+        entry {
+            var peers: seq[PeerModel];
+            var blocked_work: seq[int];
+            var empty: seq[int];
+            var blocked: PeerModel;
+            var thief: PeerModel;
+
+            blocked_work += (sizeof(blocked_work), 10);
+
+            peers += (sizeof(peers), NewPeer(
+                1, 0, 20, PeerBlocked, blocked_work
+            ));
+            peers += (sizeof(peers), NewPeer(
+                2, 10, 10, PeerReady, empty
+            ));
+
+            // A blocked donor is different from a ready donor with one task:
+            // it is not accepting sends, so keeping that singleton local would
+            // strand progress. The idle peer should be allowed to drain it.
+            peers = StealOne(peers, 2);
+            blocked = PeerByID(peers, 1);
+            thief = PeerByID(peers, 2);
+
+            assert sizeof(blocked.local_work) == 0,
+                "blocked donor can be drained by work stealing";
+            assert sizeof(thief.local_work) == 1,
+                "idle thief should receive blocked donor work";
+            assert thief.local_work[0] == 10,
+                "stealing should preserve the blocked donor task";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+machine QuerySchedulerTestDriver {
+    start state RunTests {
+        entry {
+            // The driver starts each story. The checker can then explore
+            // schedules around machine creation and completion.
+            new TestSchedulerSkipsBlockedRankedPeer();
+            new TestSchedulerSkipsBusyRankedPeer();
+            new TestSchedulerSkipsQuarantinedRankedPeer();
+            new TestSchedulerUsesRTTAsRankTieBreaker();
+            new TestSchedulerDropsCanceledQueuedWork();
+            new TestSchedulerRTTTimeoutFloor();
+            new TestAssignLocalTaskBalancesOwnedWork();
+            new TestAssignLocalTaskBuildsBoundedPeerQueue();
+            new TestAssignLocalTaskDoesNotExceedPeerCapacity();
+            new TestWorkStealingMovesUnclaimedWorkToIdlePeer();
+            new TestWorkStealingLeavesBusyDonorQueuedWork();
+            new TestWorkStealingIgnoresBusySingletonDonor();
+            new TestWorkStealingDoesNotStealSingleton();
+            new TestWorkStealingDoesNotStealBusySingleton();
+            new TestWorkStealingCanDrainBlockedDonor();
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+test tcQueryScheduler [main=QuerySchedulerTestDriver]:
+  { TestSchedulerSkipsBlockedRankedPeer,
+    TestSchedulerSkipsBusyRankedPeer,
+    TestSchedulerSkipsQuarantinedRankedPeer,
+    TestSchedulerUsesRTTAsRankTieBreaker,
+    TestSchedulerDropsCanceledQueuedWork,
+    TestSchedulerRTTTimeoutFloor,
+    TestAssignLocalTaskBalancesOwnedWork,
+    TestAssignLocalTaskBuildsBoundedPeerQueue,
+    TestAssignLocalTaskDoesNotExceedPeerCapacity,
+    TestWorkStealingMovesUnclaimedWorkToIdlePeer,
+    TestWorkStealingLeavesBusyDonorQueuedWork,
+    TestWorkStealingIgnoresBusySingletonDonor,
+    TestWorkStealingDoesNotStealSingleton,
+    TestWorkStealingDoesNotStealBusySingleton,
+    TestWorkStealingCanDrainBlockedDonor,
+    QuerySchedulerTestDriver };

--- a/p-models/scripts/check.sh
+++ b/p-models/scripts/check.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Run the neutrino P models.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(dirname "$PROJECT_DIR")"
+BUILD_DIR="${REPO_ROOT}/PGenerated/PChecker/net8.0"
+
+SCHEDULES="${SCHEDULES:-50}"
+MAX_STEPS="${MAX_STEPS:-300}"
+TIMEOUT="${TIMEOUT:-120}"
+
+cd "$REPO_ROOT"
+
+echo "=== P Neutrino Model Checking ==="
+echo "Bounds:"
+echo "  SCHEDULES: $SCHEDULES"
+echo "  MAX_STEPS: $MAX_STEPS"
+echo "  TIMEOUT: ${TIMEOUT}s"
+echo ""
+
+if ! command -v p >/dev/null 2>&1; then
+    echo "Error: P compiler not found"
+    echo "Install with: dotnet tool install --global P --version 3.0.4"
+    exit 1
+fi
+
+EXPECTED_P_VERSION="3.0.4"
+P_VERSION="$(p --version 2>/dev/null | awk '{print $NF}')"
+case "$P_VERSION" in
+    "${EXPECTED_P_VERSION}"|"${EXPECTED_P_VERSION}".*)
+        ;;
+    *)
+        echo "Warning: expected P ${EXPECTED_P_VERSION}, got ${P_VERSION:-unknown}"
+        ;;
+esac
+
+run_model() {
+    local name="$1"
+    local project="$2"
+    local dll="$3"
+    local testcase="$4"
+
+    echo ""
+    echo "=== Checking ${name} ==="
+
+    rm -rf "${REPO_ROOT}/PGenerated"
+    p compile -pp "$project"
+
+    timeout "$TIMEOUT" p check "${BUILD_DIR}/${dll}" \
+        --testcase "$testcase" \
+        --schedules "$SCHEDULES" \
+        --max-steps "$MAX_STEPS"
+}
+
+run_model \
+    "query scheduler" \
+    "${PROJECT_DIR}/neutrinoquery/infra.pproj" \
+    "NeutrinoQueryModels.dll" \
+    "tcQueryScheduler"
+
+run_model \
+    "header sync" \
+    "${PROJECT_DIR}/neutrinoheadersync/infra.pproj" \
+    "NeutrinoHeaderSyncModels.dll" \
+    "tcHeaderSync"

--- a/protofsm/doc.go
+++ b/protofsm/doc.go
@@ -1,0 +1,10 @@
+// Package protofsm contains neutrino's isolated copy of the core lnd
+// protofsm state machine.
+//
+// The upstream lnd package also includes daemon adapters for peer sends,
+// transaction broadcasts, and chain notifications. Those adapters depend on
+// lnd root-module packages, so this local copy intentionally keeps only the
+// deterministic state transition engine. Neutrino callers should model network
+// and chain side effects as explicit outbox messages and let the owning actor
+// dispatch them through the actor system.
+package protofsm

--- a/protofsm/msg_mapper.go
+++ b/protofsm/msg_mapper.go
@@ -1,0 +1,21 @@
+package protofsm
+
+import "github.com/lightningnetwork/lnd/fn/v2"
+
+// MsgMapper maps an outside message into an FSM event. The upstream lnd
+// package maps msgmux.PeerMsg instances; this isolated copy accepts any
+// message so neutrino can bind its own p2p/query/test-harness message types
+// without importing lnd's msgmux package.
+type MsgMapper[Event any] interface {
+	// MapMsg maps a message into an FSM event. If the message is not
+	// meaningful for the target FSM, None should be returned.
+	MapMsg(msg any) fn.Option[Event]
+}
+
+// MsgMapperFunc adapts a function into a MsgMapper.
+type MsgMapperFunc[Event any] func(any) fn.Option[Event]
+
+// MapMsg implements MsgMapper.
+func (m MsgMapperFunc[Event]) MapMsg(msg any) fn.Option[Event] {
+	return m(msg)
+}

--- a/protofsm/state_machine.go
+++ b/protofsm/state_machine.go
@@ -1,0 +1,264 @@
+package protofsm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+)
+
+var (
+	// ErrStateMachineShutdown occurs when trying to feed an event to a
+	// StateMachine that has been asked to stop.
+	ErrStateMachineShutdown = errors.New("state machine is shutting down")
+
+	// ErrNilInitialState occurs when a StateMachine is configured without an
+	// initial state.
+	ErrNilInitialState = errors.New("initial state must not be nil")
+)
+
+// EmittedEvent is a special type that can be emitted by a state transition.
+// Internal events are routed back into the same FSM. Outbox events are returned
+// to the caller so the actor that owns the FSM can dispatch them to other
+// actors, persistence sinks, trace recorders, or test harnesses.
+type EmittedEvent[Event any, Outbox any] struct {
+	// InternalEvent is an optional set of internal events that should be
+	// routed back into the state machine. This lets one external input
+	// drive several deterministic state transitions.
+	InternalEvent []Event
+
+	// Outbox is an optional set of commands emitted by the transition. The
+	// StateMachine never dispatches these directly; its owning actor does.
+	Outbox []Outbox
+}
+
+// StateTransition denotes the next state and the set of events emitted while
+// processing an input event.
+type StateTransition[Event any, Outbox any, Env any] struct {
+	// NextState is the next state to transition to.
+	NextState State[Event, Outbox, Env]
+
+	// NewEvents is the set of events to emit.
+	NewEvents fn.Option[EmittedEvent[Event, Outbox]]
+}
+
+// State defines a state transition function that takes an event and an
+// environment and returns the next state plus any emitted events.
+type State[Event any, Outbox any, Env any] interface {
+	// ProcessEvent takes an event and an environment, then returns a state
+	// transition. The state machine will keep processing emitted internal
+	// events until it reaches a terminal state or runs out of work.
+	ProcessEvent(ctx context.Context, event Event, env Env) (
+		*StateTransition[Event, Outbox, Env], error)
+
+	// IsTerminal returns true if this state is terminal.
+	IsTerminal() bool
+
+	// String returns a human-readable representation of the state.
+	String() string
+}
+
+// ErrorReporter is used to report errors that occur during state machine
+// execution.
+type ErrorReporter interface {
+	// ReportError reports an error that occurred during state execution.
+	ReportError(err error)
+}
+
+// ErrorReporterFunc adapts a function into an ErrorReporter.
+type ErrorReporterFunc func(error)
+
+// ReportError implements ErrorReporter.
+func (e ErrorReporterFunc) ReportError(err error) {
+	e(err)
+}
+
+type noopErrorReporter struct{}
+
+func (noopErrorReporter) ReportError(error) {}
+
+// StateMachineCfg configures a StateMachine.
+type StateMachineCfg[Event any, Outbox any, Env any] struct {
+	// ErrorReporter is used to report errors that occur during state
+	// transitions. If nil, errors are ignored after stopping the machine.
+	ErrorReporter ErrorReporter
+
+	// InitialState is the initial state of the state machine.
+	InitialState State[Event, Outbox, Env]
+
+	// Env is the environment that the state machine will use to execute.
+	Env Env
+}
+
+// StateMachine is an abstract FSM that processes incoming events and drives
+// state transitions until it reaches a terminal state or is stopped. The
+// machine owns no actor-system dependencies; its caller is responsible for
+// dispatching returned outbox messages.
+type StateMachine[Event any, Outbox any, Env any] struct {
+	cfg StateMachineCfg[Event, Outbox, Env]
+
+	// newStateEvents notifies subscribers of state transitions.
+	newStateEvents *fn.EventDistributor[State[Event, Outbox, Env]]
+
+	currentState State[Event, Outbox, Env]
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+
+	mu      sync.Mutex
+	running atomic.Bool
+}
+
+// NewStateMachine creates a new state machine.
+func NewStateMachine[Event any, Outbox any, Env any](
+	cfg StateMachineCfg[Event, Outbox, Env]) (*StateMachine[
+	Event, Outbox, Env], error) {
+
+	if cfg.InitialState == nil {
+		return nil, ErrNilInitialState
+	}
+
+	if cfg.ErrorReporter == nil {
+		cfg.ErrorReporter = noopErrorReporter{}
+	}
+
+	return &StateMachine[Event, Outbox, Env]{
+		cfg:            cfg,
+		currentState:   cfg.InitialState,
+		newStateEvents: fn.NewEventDistributor[State[Event, Outbox, Env]](),
+	}, nil
+}
+
+// Start marks the state machine as live and emits the initial state to
+// subscribers. The owning actor still drives the machine synchronously through
+// ProcessEvent.
+func (s *StateMachine[Event, Outbox, Env]) Start(context.Context) {
+	s.startOnce.Do(func() {
+		s.running.Store(true)
+		s.newStateEvents.NotifySubscribers(s.currentState)
+	})
+}
+
+// Stop marks the state machine as stopped.
+func (s *StateMachine[Event, Outbox, Env]) Stop() {
+	s.stopOnce.Do(func() {
+		s.running.Store(false)
+	})
+}
+
+// ProcessEvent applies an external event and returns all outbox messages
+// emitted while processing the event and any internal follow-up events.
+func (s *StateMachine[Event, Outbox, Env]) ProcessEvent(ctx context.Context,
+	event Event) ([]Outbox, error) {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.running.Load() {
+		return nil, ErrStateMachineShutdown
+	}
+
+	newState, outbox, err := s.applyEvents(ctx, s.currentState, event)
+	if err != nil {
+		s.cfg.ErrorReporter.ReportError(err)
+
+		return nil, err
+	}
+
+	s.currentState = newState
+
+	return outbox, nil
+}
+
+// CurrentState returns the current state of the state machine.
+func (s *StateMachine[Event, Outbox, Env]) CurrentState() State[
+	Event, Outbox, Env] {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.currentState
+}
+
+// StateSubscriber represents an active state transition subscription.
+type StateSubscriber[Event any, Outbox any, Env any] *fn.EventReceiver[State[Event, Outbox, Env]]
+
+// RegisterStateEvents registers a new event listener that will be notified of
+// new state transitions.
+func (s *StateMachine[Event, Outbox, Env]) RegisterStateEvents() StateSubscriber[
+	Event, Outbox, Env] {
+
+	subscriber := fn.NewEventReceiver[State[Event, Outbox, Env]](10)
+	s.newStateEvents.RegisterSubscriber(subscriber)
+
+	return subscriber
+}
+
+// RemoveStateSub removes the target state subscriber.
+func (s *StateMachine[Event, Outbox, Env]) RemoveStateSub(sub StateSubscriber[
+	Event, Outbox, Env]) {
+
+	_ = s.newStateEvents.RemoveSubscriber(sub)
+}
+
+// IsRunning returns true if the state machine is currently running.
+func (s *StateMachine[Event, Outbox, Env]) IsRunning() bool {
+	return s.running.Load()
+}
+
+func (s *StateMachine[Event, Outbox, Env]) applyEvents(ctx context.Context,
+	currentState State[Event, Outbox, Env], newEvent Event) (
+	State[Event, Outbox, Env], []Outbox, error) {
+
+	eventQueue := fn.NewQueue(newEvent)
+	var outbox []Outbox
+
+	for nextEvent := eventQueue.Dequeue(); nextEvent.IsSome(); nextEvent = eventQueue.Dequeue() {
+		err := fn.MapOptionZ(nextEvent, func(event Event) error {
+			transition, err := currentState.ProcessEvent(
+				ctx, event, s.cfg.Env,
+			)
+			if err != nil {
+				return err
+			}
+
+			if transition == nil || transition.NextState == nil {
+				return fmt.Errorf("state %v returned nil transition",
+					currentState)
+			}
+
+			err = fn.MapOptionZ(
+				transition.NewEvents,
+				func(events EmittedEvent[Event, Outbox]) error {
+					for _, internalEvent := range events.InternalEvent {
+						eventQueue.Enqueue(internalEvent)
+					}
+
+					outbox = append(outbox, events.Outbox...)
+
+					return nil
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			currentState = transition.NextState
+			s.newStateEvents.NotifySubscribers(currentState)
+
+			return nil
+		})
+		if err != nil {
+			return currentState, nil, err
+		}
+
+		if currentState.IsTerminal() {
+			return currentState, outbox, nil
+		}
+	}
+
+	return currentState, outbox, nil
+}

--- a/protofsm/state_machine_test.go
+++ b/protofsm/state_machine_test.go
@@ -1,0 +1,187 @@
+package protofsm
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type testEvent interface {
+	testEvent()
+}
+
+type stepEvent struct{}
+
+func (stepEvent) testEvent() {}
+
+type emitEvent struct{}
+
+func (emitEvent) testEvent() {}
+
+type finishEvent struct{}
+
+func (finishEvent) testEvent() {}
+
+type errEvent struct{}
+
+func (errEvent) testEvent() {}
+
+type outboxEvent struct {
+	value string
+}
+
+type testEnv struct {
+	name string
+}
+
+type testState struct {
+	name     string
+	terminal bool
+}
+
+func (t testState) String() string {
+	return t.name
+}
+
+func (t testState) IsTerminal() bool {
+	return t.terminal
+}
+
+func (t testState) ProcessEvent(_ context.Context, event testEvent,
+	env testEnv) (*StateTransition[testEvent, outboxEvent, testEnv], error) {
+
+	switch event.(type) {
+	case stepEvent:
+		return &StateTransition[testEvent, outboxEvent, testEnv]{
+			NextState: testState{name: env.name + "-stepped"},
+			NewEvents: fn.Some(EmittedEvent[testEvent, outboxEvent]{
+				Outbox: []outboxEvent{{value: "stepped"}},
+			}),
+		}, nil
+
+	case emitEvent:
+		return &StateTransition[testEvent, outboxEvent, testEnv]{
+			NextState: testState{name: "emitting"},
+			NewEvents: fn.Some(EmittedEvent[testEvent, outboxEvent]{
+				InternalEvent: []testEvent{finishEvent{}},
+				Outbox:        []outboxEvent{{value: "emitting"}},
+			}),
+		}, nil
+
+	case finishEvent:
+		return &StateTransition[testEvent, outboxEvent, testEnv]{
+			NextState: testState{
+				name:     "done",
+				terminal: true,
+			},
+			NewEvents: fn.Some(EmittedEvent[testEvent, outboxEvent]{
+				Outbox: []outboxEvent{{value: "done"}},
+			}),
+		}, nil
+
+	case errEvent:
+		return nil, errors.New("boom")
+
+	default:
+		return &StateTransition[testEvent, outboxEvent, testEnv]{
+			NextState: t,
+		}, nil
+	}
+}
+
+func newTestStateMachine(t *testing.T) *StateMachine[
+	testEvent, outboxEvent, testEnv] {
+
+	t.Helper()
+
+	machine, err := NewStateMachine[testEvent, outboxEvent](
+		StateMachineCfg[testEvent, outboxEvent, testEnv]{
+			InitialState: testState{name: "start"},
+			Env:          testEnv{name: "env"},
+		},
+	)
+	require.NoError(t, err)
+
+	machine.Start(context.Background())
+
+	return machine
+}
+
+func TestStateMachineProcessesEvents(t *testing.T) {
+	machine := newTestStateMachine(t)
+	defer machine.Stop()
+
+	outbox, err := machine.ProcessEvent(context.Background(), stepEvent{})
+	require.NoError(t, err)
+	require.Equal(t, []outboxEvent{{value: "stepped"}}, outbox)
+
+	currentState := machine.CurrentState()
+	require.Equal(t, "env-stepped", currentState.String())
+}
+
+func TestStateMachineProcessesInternalEvents(t *testing.T) {
+	machine := newTestStateMachine(t)
+	defer machine.Stop()
+
+	sub := machine.RegisterStateEvents()
+	defer machine.RemoveStateSub(sub)
+
+	outbox, err := machine.ProcessEvent(context.Background(), emitEvent{})
+	require.NoError(t, err)
+	require.Equal(t, []outboxEvent{
+		{value: "emitting"},
+		{value: "done"},
+	}, outbox)
+
+	currentState := machine.CurrentState()
+	require.Equal(t, "done", currentState.String())
+	require.True(t, currentState.IsTerminal())
+}
+
+func TestStateMachineReportsErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errChan := make(chan error, 1)
+	machine, err := NewStateMachine[testEvent, outboxEvent](
+		StateMachineCfg[testEvent, outboxEvent, testEnv]{
+			ErrorReporter: ErrorReporterFunc(func(err error) {
+				errChan <- err
+			}),
+			InitialState: testState{name: "start"},
+			Env:          testEnv{name: "env"},
+		},
+	)
+	require.NoError(t, err)
+
+	machine.Start(ctx)
+	defer machine.Stop()
+
+	_, err = machine.ProcessEvent(ctx, errEvent{})
+	require.EqualError(t, err, "boom")
+
+	select {
+	case err := <-errChan:
+		require.EqualError(t, err, "boom")
+
+	case <-time.After(time.Second):
+		t.Fatalf("expected state machine error")
+	}
+}
+
+func TestStateMachineRejectsEventsBeforeStart(t *testing.T) {
+	machine, err := NewStateMachine[testEvent, outboxEvent](
+		StateMachineCfg[testEvent, outboxEvent, testEnv]{
+			InitialState: testState{name: "start"},
+			Env:          testEnv{name: "env"},
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = machine.ProcessEvent(context.Background(), stepEvent{})
+	require.ErrorIs(t, err, ErrStateMachineShutdown)
+}


### PR DESCRIPTION
In this PR, we add the model/spec foundation for the sync scheduler work without changing production sync behavior yet. The Go side gets a small local `protofsm` package that mirrors the actor/FSM style we want, while staying isolated from lnd daemon/msgmux dependencies.

The P side gets executable models for the two contracts we'll wire into Go in the later PRs: query work scheduling and parallel block header range sync. The model files are written as executable design notes, so reviewers can read the invariants without needing to already be fluent in P.

## Stack

This stacks on #367, a.k.a `roasbeef/sql-08-header-store-perf`.

## protofsm

The local `protofsm` package gives us a generic state machine that accepts typed events and returns typed outbox messages. Internal events are fed back into the same FSM deterministically; outbox messages are left for the owning actor to dispatch to peers, managers, trace sinks, or tests.

This keeps the useful part of the lnd pattern while avoiding an import cycle or a broad lnd root-module dependency.

## P models

The query scheduler model covers canceled work, blocked peers, quarantined peers, RTT-derived timeout floors, bounded peer-local queues, donor fairness, and work stealing.

The header sync model covers confirmed anchors, leased ranges, lease epochs, active range stealing, stale completions, invalid completions, out-of-order staging, and strictly ordered commit.

The bridge scenario JSON files are included now so the later Go packages can replay the same stories against the implementation.

## Tests

```bash
go test ./protofsm -count=1
./p-models/scripts/check.sh
```

The P checker ran both models with 50 schedules each and found 0 bugs.