### PR TITLE
querysync: add actor-backed scheduler package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,14 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c
-	github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.2.3
 	github.com/btcsuite/btcwallet/walletdb v1.3.5
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/golang-migrate/migrate/v4 v4.19.0
 	github.com/lightninglabs/neutrino/cache v1.1.2
+	github.com/lightningnetwork/lnd/actor v0.0.5
+	github.com/lightningnetwork/lnd/fn/v2 v2.0.8
 	github.com/lightningnetwork/lnd/queue v1.0.1
 	github.com/lightningnetwork/lnd/sqldb/v2 v2.0.0-20260504151100-6fd5b7bb27d7
 	github.com/stretchr/testify v1.10.0
@@ -25,6 +26,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/aead/siphash v1.0.1 // indirect
+	github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b // indirect
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.0 // indirect
 	github.com/btcsuite/btcwallet/wallet/txsizes v1.1.0 // indirect
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd // indirect
@@ -56,7 +58,6 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/kkdai/bstream v1.0.0 // indirect
 	github.com/lightningnetwork/lnd/clock v1.0.1 // indirect
-	github.com/lightningnetwork/lnd/fn/v2 v2.0.8 // indirect
 	github.com/lightningnetwork/lnd/ticker v1.0.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -88,6 +89,6 @@ require (
 	modernc.org/sqlite v1.38.2 // indirect
 )
 
-go 1.25
+go 1.25.5
 
 replace github.com/golang-migrate/migrate/v4 => github.com/lightninglabs/migrate/v4 v4.18.2-9023d66a-fork-pr-2.0.20251211093704-71c1eef09789

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/lightninglabs/migrate/v4 v4.18.2-9023d66a-fork-pr-2.0.20251211093704-
 github.com/lightninglabs/migrate/v4 v4.18.2-9023d66a-fork-pr-2.0.20251211093704-71c1eef09789/go.mod h1:99BKpIi6ruaaXRM1A77eqZ+FWPQ3cfRa+ZVy5bmWMaY=
 github.com/lightninglabs/neutrino/cache v1.1.2 h1:C9DY/DAPaPxbFC+xNNEI/z1SJY9GS3shmlu5hIQ798g=
 github.com/lightninglabs/neutrino/cache v1.1.2/go.mod h1:XJNcgdOw1LQnanGjw8Vj44CvguYA25IMKjWFZczwZuo=
+github.com/lightningnetwork/lnd/actor v0.0.5 h1:2u4VnqarPrsBCrvKWwi0F38IXZH3duM9HtE6Gcw+d1E=
+github.com/lightningnetwork/lnd/actor v0.0.5/go.mod h1:RqB1iHhxJuCpyvByIKzKFUNGLzUiGzuzyCpzhvcJEfI=
 github.com/lightningnetwork/lnd/clock v1.0.1 h1:QQod8+m3KgqHdvVMV+2DRNNZS1GRFir8mHZYA+Z2hFo=
 github.com/lightningnetwork/lnd/clock v1.0.1/go.mod h1:KnQudQ6w0IAMZi1SgvecLZQZ43ra2vpDNj7H/aasemg=
 github.com/lightningnetwork/lnd/fn/v2 v2.0.8 h1:r2SLz7gZYQPVc3IZhU82M66guz3Zk2oY+Rlj9QN5S3g=

--- a/query/interface.go
+++ b/query/interface.go
@@ -45,6 +45,29 @@ type queryOptions struct {
 	noRetryMax bool
 }
 
+// Options is an immutable snapshot of query options after applying all
+// functional options. It lets packages outside query implement the Dispatcher
+// interface without reaching into the legacy work manager internals.
+type Options struct {
+	// Timeout specifies the total time a query is allowed to be retried
+	// before it will fail.
+	Timeout time.Duration
+
+	// Encoding is the wire encoding used when queueing messages to a peer.
+	Encoding wire.MessageEncoding
+
+	// CancelChan is an optional channel that can be closed to indicate that
+	// the query should be canceled.
+	CancelChan <-chan struct{}
+
+	// NumRetries is the number of times a query should be retried before
+	// failing.
+	NumRetries uint8
+
+	// NoRetryMax disables the retry cap when set.
+	NoRetryMax bool
+}
+
 // QueryOption is a functional option argument to any of the network query
 // methods, such as GetBlock and GetCFilter (when that resorts to a network
 // query). These are always processed in order, with later options overriding
@@ -64,6 +87,21 @@ func defaultQueryOptions() *queryOptions {
 func (qo *queryOptions) applyQueryOptions(options ...QueryOption) {
 	for _, option := range options {
 		option(qo)
+	}
+}
+
+// ResolveOptions applies query options to the package defaults and returns an
+// exported snapshot for external Dispatcher implementations.
+func ResolveOptions(options ...QueryOption) Options {
+	qo := defaultQueryOptions()
+	qo.applyQueryOptions(options...)
+
+	return Options{
+		Timeout:    qo.timeout,
+		Encoding:   qo.encoding,
+		CancelChan: qo.cancelChan,
+		NumRetries: qo.numRetries,
+		NoRetryMax: qo.noRetryMax,
 	}
 }
 
@@ -119,6 +157,33 @@ type Progress struct {
 	// used for the requests types where more than one response is
 	// expected.
 	Progressed bool
+}
+
+// IsNotFoundResponse returns true when resp explicitly says that the peer does
+// not have inventory requested by req. Query workers use this as a fast
+// retryable failure instead of waiting for the full per-peer timeout.
+func IsNotFoundResponse(req, resp wire.Message) bool {
+	notFound, ok := resp.(*wire.MsgNotFound)
+	if !ok {
+		return false
+	}
+
+	getData, ok := req.(*wire.MsgGetData)
+	if !ok {
+		return false
+	}
+
+	for _, requested := range getData.InvList {
+		for _, missing := range notFound.InvList {
+			if requested.Type == missing.Type &&
+				requested.Hash == missing.Hash {
+
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // Request is the main struct that defines a bitcoin network query to be sent to
@@ -180,6 +245,10 @@ type Peer interface {
 
 	// Addr returns the address of this peer.
 	Addr() string
+
+	// LastPingMicros returns the duration of the last ping round trip in
+	// microseconds. A zero value means no RTT sample is available yet.
+	LastPingMicros() int64
 
 	// OnDisconnect returns a channel that will be closed when this peer is
 	// disconnected.

--- a/query/peer_rank.go
+++ b/query/peer_rank.go
@@ -40,17 +40,18 @@ func NewPeerRanking() PeerRanking {
 // peer has no current score given, the default will be used.
 func (p *peerRanking) Order(peers []string) {
 	sort.Slice(peers, func(i, j int) bool {
-		score1, ok := p.rank[peers[i]]
-		if !ok {
-			score1 = defaultScore
-		}
-
-		score2, ok := p.rank[peers[j]]
-		if !ok {
-			score2 = defaultScore
-		}
-		return score1 < score2
+		return p.Score(peers[i]) < p.Score(peers[j])
 	})
+}
+
+// Score returns the current rank score for a peer. A lower score is better.
+func (p *peerRanking) Score(peer string) uint64 {
+	score, ok := p.rank[peer]
+	if !ok {
+		return defaultScore
+	}
+
+	return score
 }
 
 // AddPeer adds a new peer to the ranking, starting out with the default score.

--- a/query/worker.go
+++ b/query/worker.go
@@ -16,6 +16,12 @@ var (
 	// before the query has been answered.
 	ErrPeerDisconnected = errors.New("peer disconnected")
 
+	// ErrPeerNotFound is returned if the peer explicitly reports that it
+	// does not have the requested inventory. This is retryable, but unlike a
+	// timeout it should fail fast so forked or lagging peers do not consume a
+	// full query timeout.
+	ErrPeerNotFound = errors.New("peer did not have requested data")
+
 	// ErrJobCanceled is returned if the job is canceled before the query
 	// has been answered.
 	ErrJobCanceled = errors.New("job canceled")

--- a/query/worker_test.go
+++ b/query/worker_test.go
@@ -19,11 +19,12 @@ var (
 )
 
 type mockPeer struct {
-	addr          string
-	requests      chan wire.Message
-	responses     chan<- wire.Message
-	subscriptions chan chan wire.Message
-	quit          chan struct{}
+	addr           string
+	lastPingMicros int64
+	requests       chan wire.Message
+	responses      chan<- wire.Message
+	subscriptions  chan chan wire.Message
+	quit           chan struct{}
 }
 
 var _ Peer = (*mockPeer)(nil)
@@ -47,6 +48,10 @@ func (m *mockPeer) OnDisconnect() <-chan struct{} {
 
 func (m *mockPeer) Addr() string {
 	return m.addr
+}
+
+func (m *mockPeer) LastPingMicros() int64 {
+	return m.lastPingMicros
 }
 
 // makeJob returns a new query job that will be done when it is given the

--- a/querysync/actor.go
+++ b/querysync/actor.go
@@ -1,0 +1,1337 @@
+package querysync
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/lightninglabs/neutrino/protofsm"
+	"github.com/lightningnetwork/lnd/actor"
+	"github.com/lightningnetwork/lnd/fn/v2"
+)
+
+const (
+	managerActorID = "querysync-manager"
+	peerActorKey   = "querysync-peer"
+)
+
+// ManagerMsg is the message type accepted by the scheduler manager actor.
+type ManagerMsg interface {
+	actor.Message
+
+	managerMsg()
+}
+
+type managerMessage struct {
+	actor.BaseMessage
+}
+
+func (managerMessage) managerMsg() {}
+
+func (managerMessage) MessageType() string {
+	return "querysync.ManagerMsg"
+}
+
+// ManagerResp is the response type returned by the scheduler manager actor.
+type ManagerResp interface {
+	managerResp()
+}
+
+type managerResponse struct{}
+
+func (managerResponse) managerResp() {}
+
+// ManagerAck confirms a mutating manager message was applied.
+type ManagerAck struct {
+	managerResponse
+}
+
+// AddPeerMsg asks the manager to add or replace a peer snapshot.
+type AddPeerMsg struct {
+	managerMessage
+
+	Peer PeerSnapshot
+}
+
+// EnqueueMsg asks the manager to enqueue global work.
+type EnqueueMsg struct {
+	managerMessage
+
+	Task Task
+}
+
+// UpdatePeerStateMsg asks the manager to update peer scheduling state.
+type UpdatePeerStateMsg struct {
+	managerMessage
+
+	ID    string
+	State PeerState
+}
+
+// SetPeerLocalWorkMsg asks the manager to replace a peer's local work.
+type SetPeerLocalWorkMsg struct {
+	managerMessage
+
+	ID   string
+	Work []TaskID
+}
+
+// RemovePeerMsg asks the manager to remove a peer.
+type RemovePeerMsg struct {
+	managerMessage
+
+	ID string
+}
+
+// UpdatePeerRTTMsg asks the manager to update a peer RTT sample.
+type UpdatePeerRTTMsg struct {
+	managerMessage
+
+	ID  string
+	RTT time.Duration
+}
+
+// CompletePeerWorkMsg asks the manager to mark a peer ready after completion.
+type CompletePeerWorkMsg struct {
+	managerMessage
+
+	ID string
+}
+
+// CancelBatchMsg asks the manager to mark queued work in a batch canceled.
+type CancelBatchMsg struct {
+	managerMessage
+
+	BatchID uint64
+}
+
+// SnapshotPeerMsg asks the manager for one peer snapshot.
+type SnapshotPeerMsg struct {
+	managerMessage
+
+	ID string
+}
+
+// SnapshotPeerResp is the response to SnapshotPeerMsg.
+type SnapshotPeerResp struct {
+	managerResponse
+
+	Peer PeerSnapshot
+	OK   bool
+}
+
+// MetricsMsg asks the manager for current scheduler metrics.
+type MetricsMsg struct {
+	managerMessage
+}
+
+// MetricsResp is the response to MetricsMsg.
+type MetricsResp struct {
+	managerResponse
+
+	Metrics Metrics
+}
+
+// DispatchMsg asks the manager for one scheduling decision.
+type DispatchMsg struct {
+	managerMessage
+}
+
+// DispatchTaskMsg asks the manager to dispatch one externally owned task.
+type DispatchTaskMsg struct {
+	managerMessage
+
+	Task Task
+}
+
+// AssignLocalTaskMsg asks the manager to assign an externally queued task to a
+// peer-local owned queue without marking the peer busy.
+type AssignLocalTaskMsg struct {
+	managerMessage
+
+	Task Task
+}
+
+// DispatchResp is the response to DispatchMsg.
+type DispatchResp struct {
+	managerResponse
+
+	Assignment Assignment
+	OK         bool
+}
+
+// StealMsg asks the manager to move stealable work to the thief peer.
+type StealMsg struct {
+	managerMessage
+
+	ThiefID string
+}
+
+// StealResp is the response to StealMsg.
+type StealResp struct {
+	managerResponse
+
+	Result StealResult
+	OK     bool
+}
+
+type managerOutbox interface {
+	managerOutbox()
+}
+
+type managerOutboxResponse struct {
+	Response ManagerResp
+}
+
+func (managerOutboxResponse) managerOutbox() {}
+
+type managerEnv struct {
+	fsm *SchedulerFSM
+}
+
+type managerState struct{}
+
+func (managerState) String() string {
+	return "manager"
+}
+
+func (managerState) IsTerminal() bool {
+	return false
+}
+
+func (managerState) ProcessEvent(ctx context.Context, msg ManagerMsg,
+	env *managerEnv) (*protofsm.StateTransition[
+	ManagerMsg, managerOutbox, *managerEnv], error) {
+
+	_ = ctx
+
+	respond := func(resp ManagerResp) (*protofsm.StateTransition[
+		ManagerMsg, managerOutbox, *managerEnv], error) {
+
+		return &protofsm.StateTransition[
+			ManagerMsg,
+			managerOutbox,
+			*managerEnv,
+		]{
+			NextState: managerState{},
+			NewEvents: fn.Some(protofsm.EmittedEvent[
+				ManagerMsg,
+				managerOutbox,
+			]{
+				Outbox: []managerOutbox{
+					managerOutboxResponse{Response: resp},
+				},
+			}),
+		}, nil
+	}
+
+	switch m := msg.(type) {
+	case *AddPeerMsg:
+		if err := env.fsm.AddPeer(m.Peer); err != nil {
+			return nil, err
+		}
+
+		return respond(&ManagerAck{})
+
+	case *EnqueueMsg:
+		env.fsm.Enqueue(m.Task)
+
+		return respond(&ManagerAck{})
+
+	case *UpdatePeerStateMsg:
+		if err := env.fsm.UpdatePeerState(m.ID, m.State); err != nil {
+			return nil, err
+		}
+
+		return respond(&ManagerAck{})
+
+	case *SetPeerLocalWorkMsg:
+		if err := env.fsm.SetPeerLocalWork(m.ID, m.Work); err != nil {
+			return nil, err
+		}
+
+		return respond(&ManagerAck{})
+
+	case *RemovePeerMsg:
+		env.fsm.RemovePeer(m.ID)
+
+		return respond(&ManagerAck{})
+
+	case *UpdatePeerRTTMsg:
+		if err := env.fsm.UpdatePeerRTT(m.ID, m.RTT); err != nil {
+			return nil, err
+		}
+
+		return respond(&ManagerAck{})
+
+	case *CompletePeerWorkMsg:
+		if err := env.fsm.CompletePeerWork(m.ID); err != nil {
+			return nil, err
+		}
+
+		return respond(&ManagerAck{})
+
+	case *CancelBatchMsg:
+		env.fsm.CancelBatch(m.BatchID)
+
+		return respond(&ManagerAck{})
+
+	case *SnapshotPeerMsg:
+		peer, ok := env.fsm.SnapshotPeer(m.ID)
+
+		return respond(&SnapshotPeerResp{
+			Peer: peer,
+			OK:   ok,
+		})
+
+	case *MetricsMsg:
+		return respond(&MetricsResp{Metrics: env.fsm.Metrics()})
+
+	case *DispatchMsg:
+		assignment, ok := env.fsm.DispatchNext()
+
+		return respond(&DispatchResp{
+			Assignment: assignment,
+			OK:         ok,
+		})
+
+	case *DispatchTaskMsg:
+		assignment, ok := env.fsm.DispatchTask(m.Task)
+
+		return respond(&DispatchResp{
+			Assignment: assignment,
+			OK:         ok,
+		})
+
+	case *AssignLocalTaskMsg:
+		assignment, ok := env.fsm.AssignLocalTask(m.Task)
+
+		return respond(&DispatchResp{
+			Assignment: assignment,
+			OK:         ok,
+		})
+
+	case *StealMsg:
+		result, ok := env.fsm.StealOne(m.ThiefID)
+
+		return respond(&StealResp{
+			Result: result,
+			OK:     ok,
+		})
+
+	default:
+		return nil, fmt.Errorf("unknown manager message: %T", msg)
+	}
+}
+
+// ManagerActor owns the scheduler FSM and exposes it through lnd's actor
+// system. Public helper methods below are thin ask wrappers used by existing
+// tests and integration code; peer actors communicate with the manager through
+// the same actor reference.
+type ManagerActor struct {
+	fsm         *SchedulerFSM
+	mailboxSize int
+
+	key     actor.ServiceKey[ManagerMsg, ManagerResp]
+	system  *actor.ActorSystem
+	machine *protofsm.StateMachine[ManagerMsg, managerOutbox, *managerEnv]
+	ref     actor.ActorRef[ManagerMsg, ManagerResp]
+	trace   *TraceRecorder
+	events  SchedulerEventSink
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+var _ actor.ActorBehavior[ManagerMsg, ManagerResp] = (*ManagerActor)(nil)
+
+// NewManagerActor creates an actor wrapper around a SchedulerFSM.
+func NewManagerActor(fsm *SchedulerFSM, mailboxSize int) *ManagerActor {
+	if mailboxSize <= 0 {
+		mailboxSize = 1
+	}
+
+	return &ManagerActor{
+		fsm:         fsm,
+		mailboxSize: mailboxSize,
+		key:         actor.NewServiceKey[ManagerMsg, ManagerResp](managerActorID),
+	}
+}
+
+// SetTraceRecorder enables durable actor-level scheduler traces. It should be
+// called before Start so all lifecycle messages are captured.
+func (m *ManagerActor) SetTraceRecorder(trace *TraceRecorder) {
+	m.trace = trace
+}
+
+// SetEventSink enables structured scheduler events for metrics and validation.
+// It should be called before Start so lifecycle events are captured from the
+// beginning of the actor run.
+func (m *ManagerActor) SetEventSink(events SchedulerEventSink) {
+	m.events = events
+}
+
+// Start starts the manager actor.
+func (m *ManagerActor) Start(ctx context.Context) {
+	m.startOnce.Do(func() {
+		m.system = actor.NewActorSystemWithConfig(actor.SystemConfig{
+			MailboxCapacity: m.mailboxSize,
+		})
+
+		machine, err := protofsm.NewStateMachine[
+			ManagerMsg,
+			managerOutbox,
+		](protofsm.StateMachineCfg[
+			ManagerMsg,
+			managerOutbox,
+			*managerEnv,
+		]{
+			InitialState: managerState{},
+			Env: &managerEnv{
+				fsm: m.fsm,
+			},
+		})
+		if err != nil {
+			panic(fmt.Sprintf("unable to create manager FSM: %v", err))
+		}
+
+		m.machine = machine
+		m.machine.Start(ctx)
+
+		m.key.Spawn(m.system, managerActorID, m)
+
+		refs := actor.FindInReceptionist(
+			m.system.Receptionist(), m.key,
+		)
+		if len(refs) == 0 {
+			panic("unable to spawn manager actor")
+		}
+		m.ref = refs[0]
+	})
+}
+
+// Stop stops the manager actor.
+func (m *ManagerActor) Stop() {
+	m.stopOnce.Do(func() {
+		if m.system != nil {
+			_ = m.system.Shutdown()
+		}
+		if m.machine != nil {
+			m.machine.Stop()
+		}
+	})
+}
+
+// Receive processes one manager actor message.
+func (m *ManagerActor) Receive(ctx context.Context,
+	msg ManagerMsg) fn.Result[ManagerResp] {
+
+	if m.machine == nil {
+		return fn.Err[ManagerResp](ErrActorStopped)
+	}
+
+	outbox, err := m.machine.ProcessEvent(ctx, msg)
+	if err != nil {
+		return fn.Err[ManagerResp](err)
+	}
+
+	var resp ManagerResp = &ManagerAck{}
+	for _, out := range outbox {
+		switch msg := out.(type) {
+		case managerOutboxResponse:
+			resp = msg.Response
+
+		default:
+			return fn.Err[ManagerResp](
+				fmt.Errorf("unknown manager outbox: %T", out),
+			)
+		}
+	}
+
+	if event, ok := traceEventForManagerMessage(m.fsm, msg, resp); ok {
+		m.trace.Record(event)
+	}
+	if m.events != nil {
+		if event, ok := schedulerEventForManagerMessage(
+			m.fsm, msg, resp,
+		); ok {
+			m.events.RecordSchedulerEvent(event)
+		}
+	}
+
+	return fn.Ok(resp)
+}
+
+func (m *ManagerActor) ask(ctx context.Context, msg ManagerMsg) (
+	ManagerResp, error) {
+
+	if m.ref == nil {
+		return nil, ErrActorStopped
+	}
+
+	return m.ref.Ask(ctx, msg).Await(ctx).Unpack()
+}
+
+// AddPeer asks the manager actor to add a peer.
+func (m *ManagerActor) AddPeer(ctx context.Context,
+	peer PeerSnapshot) error {
+
+	_, err := m.ask(ctx, &AddPeerMsg{Peer: peer})
+
+	return err
+}
+
+// Enqueue asks the manager actor to enqueue a task.
+func (m *ManagerActor) Enqueue(ctx context.Context, task Task) error {
+	_, err := m.ask(ctx, &EnqueueMsg{Task: task})
+
+	return err
+}
+
+// UpdatePeerState asks the manager actor to update a peer state.
+func (m *ManagerActor) UpdatePeerState(ctx context.Context, id string,
+	state PeerState) error {
+
+	_, err := m.ask(ctx, &UpdatePeerStateMsg{
+		ID:    id,
+		State: state,
+	})
+
+	return err
+}
+
+// SetPeerLocalWork asks the manager actor to set a peer's local work.
+func (m *ManagerActor) SetPeerLocalWork(ctx context.Context, id string,
+	work []TaskID) error {
+
+	_, err := m.ask(ctx, &SetPeerLocalWorkMsg{
+		ID:   id,
+		Work: work,
+	})
+
+	return err
+}
+
+// RemovePeer asks the manager actor to remove a peer.
+func (m *ManagerActor) RemovePeer(ctx context.Context, id string) error {
+	_, err := m.ask(ctx, &RemovePeerMsg{ID: id})
+
+	return err
+}
+
+// UpdatePeerRTT asks the manager actor to update the latest peer RTT sample.
+func (m *ManagerActor) UpdatePeerRTT(ctx context.Context, id string,
+	rtt time.Duration) error {
+
+	_, err := m.ask(ctx, &UpdatePeerRTTMsg{
+		ID:  id,
+		RTT: rtt,
+	})
+
+	return err
+}
+
+// CompletePeerWork asks the manager actor to mark a peer ready after its
+// active assignment finished.
+func (m *ManagerActor) CompletePeerWork(ctx context.Context,
+	id string) error {
+
+	_, err := m.ask(ctx, &CompletePeerWorkMsg{ID: id})
+
+	return err
+}
+
+// CancelBatch asks the manager actor to mark queued work in the batch canceled.
+func (m *ManagerActor) CancelBatch(ctx context.Context,
+	batchID uint64) error {
+
+	_, err := m.ask(ctx, &CancelBatchMsg{BatchID: batchID})
+
+	return err
+}
+
+// SnapshotPeer asks the manager actor for a stable copy of one peer.
+func (m *ManagerActor) SnapshotPeer(ctx context.Context,
+	id string) (PeerSnapshot, bool, error) {
+
+	resp, err := m.ask(ctx, &SnapshotPeerMsg{ID: id})
+	if err != nil {
+		return PeerSnapshot{}, false, err
+	}
+
+	snapshot, ok := resp.(*SnapshotPeerResp)
+	if !ok {
+		return PeerSnapshot{}, false, fmt.Errorf(
+			"unexpected snapshot response: %T", resp,
+		)
+	}
+
+	return snapshot.Peer, snapshot.OK, nil
+}
+
+// Metrics asks the manager actor for current scheduler counters.
+func (m *ManagerActor) Metrics(ctx context.Context) (Metrics, error) {
+	resp, err := m.ask(ctx, &MetricsMsg{})
+	if err != nil {
+		return Metrics{}, err
+	}
+
+	metrics, ok := resp.(*MetricsResp)
+	if !ok {
+		return Metrics{}, fmt.Errorf("unexpected metrics response: %T",
+			resp)
+	}
+
+	return metrics.Metrics, nil
+}
+
+// AskDispatch asks the manager actor for one scheduling decision.
+func (m *ManagerActor) AskDispatch(ctx context.Context) (Assignment, bool,
+	error) {
+
+	resp, err := m.ask(ctx, &DispatchMsg{})
+	if err != nil {
+		return Assignment{}, false, err
+	}
+
+	dispatch, ok := resp.(*DispatchResp)
+	if !ok {
+		return Assignment{}, false, fmt.Errorf(
+			"unexpected dispatch response: %T", resp,
+		)
+	}
+
+	return dispatch.Assignment, dispatch.OK, nil
+}
+
+// AskDispatchTask asks the manager actor to dispatch one externally owned task.
+func (m *ManagerActor) AskDispatchTask(ctx context.Context,
+	task Task) (Assignment, bool, error) {
+
+	resp, err := m.ask(ctx, &DispatchTaskMsg{Task: task})
+	if err != nil {
+		return Assignment{}, false, err
+	}
+
+	dispatch, ok := resp.(*DispatchResp)
+	if !ok {
+		return Assignment{}, false, fmt.Errorf(
+			"unexpected dispatch response: %T", resp,
+		)
+	}
+
+	return dispatch.Assignment, dispatch.OK, nil
+}
+
+// AskAssignLocalTask asks the manager actor to assign one externally queued
+// task to a peer-local owned queue.
+func (m *ManagerActor) AskAssignLocalTask(ctx context.Context,
+	task Task) (Assignment, bool, error) {
+
+	resp, err := m.ask(ctx, &AssignLocalTaskMsg{Task: task})
+	if err != nil {
+		return Assignment{}, false, err
+	}
+
+	dispatch, ok := resp.(*DispatchResp)
+	if !ok {
+		return Assignment{}, false, fmt.Errorf(
+			"unexpected local assignment response: %T", resp,
+		)
+	}
+
+	return dispatch.Assignment, dispatch.OK, nil
+}
+
+// AskSteal asks the manager actor to perform one work-stealing transition for
+// the thief peer.
+func (m *ManagerActor) AskSteal(ctx context.Context,
+	thiefID string) (StealResult, bool, error) {
+
+	resp, err := m.ask(ctx, &StealMsg{ThiefID: thiefID})
+	if err != nil {
+		return StealResult{}, false, err
+	}
+
+	steal, ok := resp.(*StealResp)
+	if !ok {
+		return StealResult{}, false, fmt.Errorf(
+			"unexpected steal response: %T", resp,
+		)
+	}
+
+	return steal.Result, steal.OK, nil
+}
+
+// PeerMsg is the message type accepted by peer actors.
+type PeerMsg interface {
+	actor.Message
+
+	peerMsg()
+}
+
+type peerMessage struct {
+	actor.BaseMessage
+}
+
+func (peerMessage) peerMsg() {}
+
+func (peerMessage) MessageType() string {
+	return "querysync.PeerMsg"
+}
+
+// PeerEvent is applied by PeerFSM and also sent through PeerActor.
+type PeerEvent interface {
+	PeerMsg
+
+	apply(*PeerFSM) error
+}
+
+// PeerReadyEvent marks the peer as ready for more work.
+type PeerReadyEvent struct {
+	peerMessage
+}
+
+// PeerBlockedEvent marks a connected peer as temporarily unable to accept a
+// manager assignment.
+type PeerBlockedEvent struct {
+	peerMessage
+}
+
+// PeerQuarantinedEvent marks a peer as intentionally excluded from scheduling
+// after repeated non-responses.
+type PeerQuarantinedEvent struct {
+	peerMessage
+}
+
+// PeerDownEvent marks the peer as disconnected.
+type PeerDownEvent struct {
+	peerMessage
+}
+
+// PeerRTTEvent records the latest ping RTT sample.
+type PeerRTTEvent struct {
+	peerMessage
+
+	RTT time.Duration
+}
+
+// PeerRankEvent records the latest manager rank for this peer. Production
+// ranking changes as peers succeed or fail, so the peer actor carries rank as
+// explicit state rather than treating the constructor value as permanent.
+type PeerRankEvent struct {
+	peerMessage
+
+	Rank int
+}
+
+// PeerAssignedEvent records that the peer has been assigned work.
+type PeerAssignedEvent struct {
+	peerMessage
+
+	TaskID TaskID
+}
+
+// PeerNeedWorkEvent is emitted when a ready peer has drained local work and
+// wants the manager to attempt a work-steal transition.
+type PeerNeedWorkEvent struct {
+	peerMessage
+}
+
+// PeerResp is the response type returned by peer actors.
+type PeerResp interface {
+	peerResp()
+}
+
+type peerResponse struct{}
+
+func (peerResponse) peerResp() {}
+
+// PeerAck confirms a peer event was applied.
+type PeerAck struct {
+	peerResponse
+}
+
+// PeerStealResp returns the result of a peer-initiated steal request.
+type PeerStealResp struct {
+	peerResponse
+
+	Result StealResult
+	OK     bool
+}
+
+type peerOutbox interface {
+	peerOutbox()
+}
+
+type peerSnapshotOutbox struct {
+	Peer PeerSnapshot
+}
+
+func (peerSnapshotOutbox) peerOutbox() {}
+
+type peerStealRequestOutbox struct {
+	ThiefID string
+}
+
+func (peerStealRequestOutbox) peerOutbox() {}
+
+type peerEnv struct {
+	id   string
+	rank int
+}
+
+type peerReadyState struct {
+	rtt time.Duration
+}
+
+func (s peerReadyState) String() string {
+	return "peer-ready"
+}
+
+func (s peerReadyState) IsTerminal() bool {
+	return false
+}
+
+func (s peerReadyState) ProcessEvent(_ context.Context, msg PeerMsg,
+	env *peerEnv) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	switch m := msg.(type) {
+	case PeerReadyEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerReady))
+
+	case PeerBlockedEvent:
+		next := peerBlockedState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerBlocked))
+
+	case PeerQuarantinedEvent:
+		next := peerQuarantinedState{rtt: s.rtt}
+
+		return peerTransition(
+			next, peerSnapshot(env, s.rtt, PeerQuarantined),
+		)
+
+	case PeerDownEvent:
+		next := peerDownState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerDown))
+
+	case PeerRTTEvent:
+		if m.RTT < 0 {
+			return nil, fmt.Errorf("negative RTT: %v", m.RTT)
+		}
+
+		next := peerReadyState{rtt: m.RTT}
+
+		return peerTransition(next, peerSnapshot(env, m.RTT, PeerReady))
+
+	case PeerRankEvent:
+		env.rank = m.Rank
+
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerReady))
+
+	case PeerAssignedEvent:
+		next := peerBusyState{
+			rtt:    s.rtt,
+			active: m.TaskID,
+		}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerBusy))
+
+	case PeerNeedWorkEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerReady),
+			peerStealRequestOutbox{ThiefID: env.id})
+
+	default:
+		return nil, fmt.Errorf("ready peer cannot process %T", msg)
+	}
+}
+
+type peerBusyState struct {
+	rtt    time.Duration
+	active TaskID
+}
+
+func (s peerBusyState) String() string {
+	return "peer-busy"
+}
+
+func (s peerBusyState) IsTerminal() bool {
+	return false
+}
+
+func (s peerBusyState) ProcessEvent(_ context.Context, msg PeerMsg,
+	env *peerEnv) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	switch m := msg.(type) {
+	case PeerReadyEvent:
+		next := peerReadyState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerReady))
+
+	case PeerBlockedEvent:
+		next := peerBlockedState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerBlocked))
+
+	case PeerQuarantinedEvent:
+		next := peerQuarantinedState{rtt: s.rtt}
+
+		return peerTransition(
+			next, peerSnapshot(env, s.rtt, PeerQuarantined),
+		)
+
+	case PeerDownEvent:
+		next := peerDownState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerDown))
+
+	case PeerRTTEvent:
+		if m.RTT < 0 {
+			return nil, fmt.Errorf("negative RTT: %v", m.RTT)
+		}
+
+		next := peerBusyState{
+			rtt:    m.RTT,
+			active: s.active,
+		}
+
+		return peerTransition(next, peerSnapshot(env, m.RTT, PeerBusy))
+
+	case PeerRankEvent:
+		env.rank = m.Rank
+
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerBusy))
+
+	case PeerAssignedEvent:
+		return nil, fmt.Errorf("peer %s cannot accept work while busy",
+			env.id)
+
+	case PeerNeedWorkEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerBusy))
+
+	default:
+		return nil, fmt.Errorf("busy peer cannot process %T", msg)
+	}
+}
+
+type peerBlockedState struct {
+	rtt time.Duration
+}
+
+func (s peerBlockedState) String() string {
+	return "peer-blocked"
+}
+
+func (s peerBlockedState) IsTerminal() bool {
+	return false
+}
+
+func (s peerBlockedState) ProcessEvent(_ context.Context, msg PeerMsg,
+	env *peerEnv) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	switch m := msg.(type) {
+	case PeerReadyEvent:
+		next := peerReadyState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerReady))
+
+	case PeerBlockedEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerBlocked))
+
+	case PeerQuarantinedEvent:
+		next := peerQuarantinedState{rtt: s.rtt}
+
+		return peerTransition(
+			next, peerSnapshot(env, s.rtt, PeerQuarantined),
+		)
+
+	case PeerDownEvent:
+		next := peerDownState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerDown))
+
+	case PeerRTTEvent:
+		if m.RTT < 0 {
+			return nil, fmt.Errorf("negative RTT: %v", m.RTT)
+		}
+
+		next := peerBlockedState{rtt: m.RTT}
+
+		return peerTransition(next, peerSnapshot(env, m.RTT, PeerBlocked))
+
+	case PeerRankEvent:
+		env.rank = m.Rank
+
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerBlocked))
+
+	case PeerAssignedEvent:
+		return nil, fmt.Errorf("peer %s cannot accept work while blocked",
+			env.id)
+
+	case PeerNeedWorkEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerBlocked))
+
+	default:
+		return nil, fmt.Errorf("blocked peer cannot process %T", msg)
+	}
+}
+
+type peerQuarantinedState struct {
+	rtt time.Duration
+}
+
+func (s peerQuarantinedState) String() string {
+	return "peer-quarantined"
+}
+
+func (s peerQuarantinedState) IsTerminal() bool {
+	return false
+}
+
+func (s peerQuarantinedState) ProcessEvent(_ context.Context, msg PeerMsg,
+	env *peerEnv) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	switch m := msg.(type) {
+	case PeerReadyEvent:
+		next := peerReadyState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerReady))
+
+	case PeerBlockedEvent:
+		next := peerBlockedState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerBlocked))
+
+	case PeerQuarantinedEvent:
+		return peerTransition(
+			s, peerSnapshot(env, s.rtt, PeerQuarantined),
+		)
+
+	case PeerDownEvent:
+		next := peerDownState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerDown))
+
+	case PeerRTTEvent:
+		if m.RTT < 0 {
+			return nil, fmt.Errorf("negative RTT: %v", m.RTT)
+		}
+
+		next := peerQuarantinedState{rtt: m.RTT}
+
+		return peerTransition(
+			next, peerSnapshot(env, m.RTT, PeerQuarantined),
+		)
+
+	case PeerRankEvent:
+		env.rank = m.Rank
+
+		return peerTransition(
+			s, peerSnapshot(env, s.rtt, PeerQuarantined),
+		)
+
+	case PeerAssignedEvent:
+		return nil, fmt.Errorf(
+			"peer %s cannot accept work while quarantined", env.id,
+		)
+
+	case PeerNeedWorkEvent:
+		return peerTransition(
+			s, peerSnapshot(env, s.rtt, PeerQuarantined),
+		)
+
+	default:
+		return nil, fmt.Errorf(
+			"quarantined peer cannot process %T", msg,
+		)
+	}
+}
+
+type peerDownState struct {
+	rtt time.Duration
+}
+
+func (s peerDownState) String() string {
+	return "peer-down"
+}
+
+func (s peerDownState) IsTerminal() bool {
+	return false
+}
+
+func (s peerDownState) ProcessEvent(_ context.Context, msg PeerMsg,
+	env *peerEnv) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	switch m := msg.(type) {
+	case PeerReadyEvent:
+		next := peerReadyState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerReady))
+
+	case PeerBlockedEvent:
+		next := peerBlockedState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerBlocked))
+
+	case PeerQuarantinedEvent:
+		next := peerQuarantinedState{rtt: s.rtt}
+
+		return peerTransition(
+			next, peerSnapshot(env, s.rtt, PeerQuarantined),
+		)
+
+	case PeerDownEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerDown))
+
+	case PeerRTTEvent:
+		if m.RTT < 0 {
+			return nil, fmt.Errorf("negative RTT: %v", m.RTT)
+		}
+
+		next := peerDownState{rtt: m.RTT}
+
+		return peerTransition(next, peerSnapshot(env, m.RTT, PeerDown))
+
+	case PeerRankEvent:
+		env.rank = m.Rank
+
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerDown))
+
+	case PeerAssignedEvent:
+		return nil, fmt.Errorf("peer %s cannot accept work while down",
+			env.id)
+
+	case PeerNeedWorkEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerDown))
+
+	default:
+		return nil, fmt.Errorf("down peer cannot process %T", msg)
+	}
+}
+
+func peerSnapshot(env *peerEnv, rtt time.Duration,
+	state PeerState) peerSnapshotOutbox {
+
+	return peerSnapshotOutbox{
+		Peer: PeerSnapshot{
+			ID:    env.id,
+			Rank:  env.rank,
+			RTT:   rtt,
+			State: state,
+		},
+	}
+}
+
+func peerTransition(next protofsm.State[PeerMsg, peerOutbox, *peerEnv],
+	outbox ...peerOutbox) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	return &protofsm.StateTransition[PeerMsg, peerOutbox, *peerEnv]{
+		NextState: next,
+		NewEvents: fn.Some(protofsm.EmittedEvent[PeerMsg, peerOutbox]{
+			Outbox: outbox,
+		}),
+	}, nil
+}
+
+// PeerActor owns peer-local state. When peer state changes, it emits outbox
+// messages that are delivered to the manager actor through the actor system.
+type PeerActor struct {
+	id          string
+	rank        int
+	manager     *ManagerActor
+	mailboxSize int
+
+	key     actor.ServiceKey[PeerMsg, PeerResp]
+	system  *actor.ActorSystem
+	machine *protofsm.StateMachine[PeerMsg, peerOutbox, *peerEnv]
+	ref     actor.ActorRef[PeerMsg, PeerResp]
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+var _ actor.ActorBehavior[PeerMsg, PeerResp] = (*PeerActor)(nil)
+
+// NewPeerActor creates a peer actor.
+func NewPeerActor(id string, rank int, manager *ManagerActor,
+	mailboxSize int) *PeerActor {
+
+	if mailboxSize <= 0 {
+		mailboxSize = 1
+	}
+
+	return &PeerActor{
+		id:          id,
+		rank:        rank,
+		manager:     manager,
+		mailboxSize: mailboxSize,
+		key: actor.NewServiceKey[PeerMsg, PeerResp](
+			peerActorKey + "-" + id,
+		),
+	}
+}
+
+// Start starts the peer actor and registers its initial snapshot with the
+// manager.
+func (p *PeerActor) Start(ctx context.Context) error {
+	var startErr error
+	p.startOnce.Do(func() {
+		p.system = actor.NewActorSystemWithConfig(actor.SystemConfig{
+			MailboxCapacity: p.mailboxSize,
+		})
+
+		machine, err := protofsm.NewStateMachine[PeerMsg, peerOutbox](
+			protofsm.StateMachineCfg[
+				PeerMsg,
+				peerOutbox,
+				*peerEnv,
+			]{
+				InitialState: peerReadyState{},
+				Env: &peerEnv{
+					id:   p.id,
+					rank: p.rank,
+				},
+			},
+		)
+		if err != nil {
+			startErr = err
+			return
+		}
+
+		p.machine = machine
+		p.machine.Start(ctx)
+		p.key.Spawn(p.system, p.id, p)
+
+		refs := actor.FindInReceptionist(
+			p.system.Receptionist(), p.key,
+		)
+		if len(refs) == 0 {
+			startErr = fmt.Errorf("unable to spawn peer actor %s",
+				p.id)
+			return
+		}
+		p.ref = refs[0]
+	})
+	if startErr != nil {
+		return startErr
+	}
+
+	return p.Send(ctx, PeerReadyEvent{})
+}
+
+// Stop stops the peer actor.
+func (p *PeerActor) Stop() {
+	p.stopOnce.Do(func() {
+		if p.system != nil {
+			_ = p.system.Shutdown()
+		}
+		if p.machine != nil {
+			p.machine.Stop()
+		}
+	})
+}
+
+// Receive processes one peer actor message and dispatches peer outbox messages.
+func (p *PeerActor) Receive(ctx context.Context,
+	msg PeerMsg) fn.Result[PeerResp] {
+
+	if p.machine == nil {
+		return fn.Err[PeerResp](ErrActorStopped)
+	}
+
+	outbox, err := p.machine.ProcessEvent(ctx, msg)
+	if err != nil {
+		return fn.Err[PeerResp](err)
+	}
+
+	_, needsWork := msg.(PeerNeedWorkEvent)
+	stealHandled := false
+	resp := PeerResp(&PeerAck{})
+	for _, out := range outbox {
+		switch out := out.(type) {
+		case peerSnapshotOutbox:
+			if _, err := p.manager.ask(ctx, &AddPeerMsg{
+				Peer: out.Peer,
+			}); err != nil {
+				return fn.Err[PeerResp](err)
+			}
+
+		case peerStealRequestOutbox:
+			managerResp, err := p.manager.ask(ctx, &StealMsg{
+				ThiefID: out.ThiefID,
+			})
+			if err != nil {
+				return fn.Err[PeerResp](err)
+			}
+
+			steal, ok := managerResp.(*StealResp)
+			if !ok {
+				return fn.Err[PeerResp](
+					fmt.Errorf("unexpected steal response: %T",
+						managerResp),
+				)
+			}
+
+			stealHandled = true
+			resp = &PeerStealResp{
+				Result: steal.Result,
+				OK:     steal.OK,
+			}
+
+		default:
+			return fn.Err[PeerResp](
+				fmt.Errorf("unknown peer outbox: %T", out),
+			)
+		}
+	}
+
+	if needsWork && !stealHandled {
+		resp = &PeerStealResp{}
+	}
+
+	return fn.Ok(resp)
+}
+
+// Send applies an event to the peer actor.
+func (p *PeerActor) Send(ctx context.Context, event PeerEvent) error {
+	if p.ref == nil {
+		return ErrActorStopped
+	}
+
+	_, err := p.ref.Ask(ctx, event).Await(ctx).Unpack()
+
+	return err
+}
+
+// RequestStolenWork asks this peer actor to emit a work-stealing outbox
+// request to the manager actor.
+func (p *PeerActor) RequestStolenWork(ctx context.Context) (StealResult, bool,
+	error) {
+
+	if p.ref == nil {
+		return StealResult{}, false, ErrActorStopped
+	}
+
+	resp, err := p.ref.Ask(ctx, PeerNeedWorkEvent{}).Await(ctx).Unpack()
+	if err != nil {
+		return StealResult{}, false, err
+	}
+
+	steal, ok := resp.(*PeerStealResp)
+	if !ok {
+		return StealResult{}, false, fmt.Errorf(
+			"unexpected peer steal response: %T", resp,
+		)
+	}
+
+	return steal.Result, steal.OK, nil
+}

--- a/querysync/actor_test.go
+++ b/querysync/actor_test.go
@@ -1,0 +1,346 @@
+package querysync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerActorDispatch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(NewSchedulerFSM(DefaultConfig()), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "peer",
+		Rank:  0,
+		State: PeerReady,
+	}))
+	require.NoError(t, manager.Enqueue(ctx, Task{ID: 1}))
+
+	assignment, ok, err := manager.AskDispatch(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "peer", assignment.PeerID)
+	require.EqualValues(t, 1, assignment.TaskID)
+}
+
+func TestManagerActorDispatchTask(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(NewSchedulerFSM(DefaultConfig()), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "avoided",
+		Rank:  0,
+		State: PeerReady,
+	}))
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "selected",
+		Rank:  10,
+		State: PeerReady,
+	}))
+
+	assignment, ok, err := manager.AskDispatchTask(ctx, Task{
+		ID:         7,
+		Timeout:    5 * time.Second,
+		AvoidPeers: []string{"avoided"},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "selected", assignment.PeerID)
+	require.EqualValues(t, 7, assignment.TaskID)
+	require.Equal(t, 5*time.Second, assignment.Timeout)
+}
+
+func TestManagerActorAssignLocalTask(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(NewSchedulerFSM(DefaultConfig()), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:        "loaded",
+		Rank:      0,
+		State:     PeerReady,
+		LocalWork: []TaskID{1, 2},
+	}))
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "empty",
+		Rank:  10,
+		State: PeerReady,
+	}))
+
+	assignment, ok, err := manager.AskAssignLocalTask(ctx, Task{ID: 3})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "empty", assignment.PeerID)
+
+	peer, ok, err := manager.SnapshotPeer(ctx, "empty")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []TaskID{3}, peer.LocalWork)
+}
+
+func TestManagerActorRecordsSchedulerEvents(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	events := &SchedulerEventRecorder{}
+	manager := NewManagerActor(NewSchedulerFSM(DefaultConfig()), 8)
+	manager.SetEventSink(events)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:        "donor",
+		Rank:      10,
+		State:     PeerReady,
+		LocalWork: []TaskID{1, 2},
+	}))
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "owner",
+		Rank:  0,
+		State: PeerReady,
+	}))
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "thief",
+		Rank:  20,
+		State: PeerReady,
+	}))
+
+	assignment, ok, err := manager.AskAssignLocalTask(ctx, Task{
+		ID:      3,
+		BatchID: 9,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "owner", assignment.PeerID)
+
+	result, ok, err := manager.AskSteal(ctx, "thief")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "donor", result.DonorID)
+
+	var ownedEvent, stealEvent *SchedulerEvent
+	for _, event := range events.Events() {
+		event := event
+		switch event.Type {
+		case SchedulerEventTaskOwned:
+			ownedEvent = &event
+
+		case SchedulerEventWorkStolen:
+			stealEvent = &event
+		}
+	}
+
+	require.NotNil(t, ownedEvent)
+	require.True(t, ownedEvent.OK)
+	require.Equal(t, "owner", ownedEvent.PeerID)
+	require.EqualValues(t, 3, ownedEvent.TaskID)
+	require.EqualValues(t, 9, ownedEvent.BatchID)
+	require.NotNil(t, ownedEvent.Assignment)
+	require.EqualValues(t, 1, ownedEvent.Metrics.Owned)
+
+	require.NotNil(t, stealEvent)
+	require.True(t, stealEvent.OK)
+	require.Equal(t, "thief", stealEvent.ThiefID)
+	require.Equal(t, "donor", stealEvent.DonorID)
+	require.EqualValues(t, 1, stealEvent.TaskID)
+	require.NotNil(t, stealEvent.Steal)
+	require.EqualValues(t, 1, stealEvent.Metrics.Stolen)
+}
+
+func TestManagerActorPeerLifecycleEvents(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(NewSchedulerFSM(DefaultConfig()), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "peer",
+		Rank:  0,
+		State: PeerReady,
+	}))
+	require.NoError(t, manager.UpdatePeerRTT(ctx, "peer",
+		125*time.Millisecond))
+
+	peer, ok, err := manager.SnapshotPeer(ctx, "peer")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 125*time.Millisecond, peer.RTT)
+
+	require.NoError(t, manager.Enqueue(ctx, Task{
+		ID:       1,
+		BatchID:  99,
+		Canceled: false,
+	}))
+	require.NoError(t, manager.CancelBatch(ctx, 99))
+
+	_, ok, err = manager.AskDispatch(ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	metrics, err := manager.Metrics(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, metrics.DroppedCanceled)
+
+	require.NoError(t, manager.Enqueue(ctx, Task{ID: 2}))
+	_, ok, err = manager.AskDispatch(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	peer, ok, err = manager.SnapshotPeer(ctx, "peer")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, PeerBusy, peer.State)
+
+	require.NoError(t, manager.CompletePeerWork(ctx, "peer"))
+	peer, ok, err = manager.SnapshotPeer(ctx, "peer")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, PeerReady, peer.State)
+
+	require.NoError(t, manager.RemovePeer(ctx, "peer"))
+	_, ok, err = manager.SnapshotPeer(ctx, "peer")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestPeerActorRequestsStolenWork(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(NewSchedulerFSM(DefaultConfig()), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:        "donor",
+		Rank:      0,
+		State:     PeerReady,
+		LocalWork: []TaskID{10, 11, 12},
+	}))
+
+	thief := NewPeerActor("thief", 10, manager, 8)
+	require.NoError(t, thief.Start(ctx))
+	defer thief.Stop()
+
+	result, ok, err := thief.RequestStolenWork(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "thief", result.ThiefID)
+	require.Equal(t, "donor", result.DonorID)
+	require.EqualValues(t, 10, result.TaskID)
+}
+
+func TestPeerActorBlockedNeedWorkReturnsNoSteal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(NewSchedulerFSM(DefaultConfig()), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:        "donor",
+		Rank:      0,
+		State:     PeerReady,
+		LocalWork: []TaskID{10, 11, 12},
+	}))
+
+	thief := NewPeerActor("thief", 10, manager, 8)
+	require.NoError(t, thief.Start(ctx))
+	defer thief.Stop()
+
+	require.NoError(t, thief.Send(ctx, PeerBlockedEvent{}))
+
+	_, ok, err := thief.RequestStolenWork(ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestPeerActorUpdatesManagerState(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	fsm := NewSchedulerFSM(DefaultConfig())
+	manager := NewManagerActor(fsm, 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	peer := NewPeerActor("peer", 0, manager, 8)
+	require.NoError(t, peer.Start(ctx))
+	defer peer.Stop()
+
+	require.NoError(t, peer.Send(ctx, PeerBlockedEvent{}))
+	require.NoError(t, manager.Enqueue(ctx, Task{ID: 1}))
+
+	_, ok, err := manager.AskDispatch(ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	require.NoError(t, peer.Send(ctx, PeerReadyEvent{}))
+	assignment, ok, err := manager.AskDispatch(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "peer", assignment.PeerID)
+}
+
+func TestPeerActorRankUpdatesManagerState(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(NewSchedulerFSM(DefaultConfig()), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	peer := NewPeerActor("peer", 10, manager, 8)
+	require.NoError(t, peer.Start(ctx))
+	defer peer.Stop()
+
+	require.NoError(t, peer.Send(ctx, PeerRankEvent{Rank: 3}))
+
+	snapshot, ok, err := manager.SnapshotPeer(ctx, "peer")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 3, snapshot.Rank)
+}
+
+func TestPeerActorQuarantineBlocksDispatchUntilReady(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(NewSchedulerFSM(DefaultConfig()), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	peer := NewPeerActor("peer", 0, manager, 8)
+	require.NoError(t, peer.Start(ctx))
+	defer peer.Stop()
+
+	require.NoError(t, peer.Send(ctx, PeerQuarantinedEvent{}))
+	require.NoError(t, manager.Enqueue(ctx, Task{ID: 1}))
+
+	_, ok, err := manager.AskDispatch(ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	require.NoError(t, peer.Send(ctx, PeerReadyEvent{}))
+	assignment, ok, err := manager.AskDispatch(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "peer", assignment.PeerID)
+}

--- a/querysync/bridge.go
+++ b/querysync/bridge.go
@@ -1,0 +1,168 @@
+package querysync
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// BridgeFixtures are JSON scenarios shared with the P model documentation. The
+// bridge does not replace P checking; it keeps a concrete set of model stories
+// executable against the Go FSM as implementation changes.
+type BridgeFixtures struct {
+	Dispatch []BridgeDispatchScenario `json:"dispatch"`
+	Steal    []BridgeStealScenario    `json:"steal"`
+}
+
+// BridgeDispatchScenario describes one DispatchNext model story.
+type BridgeDispatchScenario struct {
+	Name              string             `json:"name"`
+	BaseTimeoutMillis int                `json:"base_timeout_ms"`
+	Peers             []BridgePeer       `json:"peers"`
+	Tasks             []BridgeTask       `json:"tasks"`
+	Expect            BridgeDispatchWant `json:"expect"`
+}
+
+// BridgeStealScenario describes one StealOne model story.
+type BridgeStealScenario struct {
+	Name   string          `json:"name"`
+	Peers  []BridgePeer    `json:"peers"`
+	Thief  string          `json:"thief"`
+	Expect BridgeStealWant `json:"expect"`
+}
+
+// BridgePeer is the fixture form of PeerSnapshot.
+type BridgePeer struct {
+	ID        string   `json:"id"`
+	Rank      int      `json:"rank"`
+	RTTMillis int      `json:"rtt_ms"`
+	State     string   `json:"state"`
+	LocalWork []TaskID `json:"local_work"`
+}
+
+// BridgeTask is the fixture form of Task.
+type BridgeTask struct {
+	ID            TaskID   `json:"id"`
+	BatchID       uint64   `json:"batch_id"`
+	Canceled      bool     `json:"canceled"`
+	TimeoutMillis int      `json:"timeout_ms,omitempty"`
+	AvoidPeers    []string `json:"avoid_peers,omitempty"`
+}
+
+// BridgeDispatchWant is the fixture form of Assignment.
+type BridgeDispatchWant struct {
+	OK            bool   `json:"ok"`
+	PeerID        string `json:"peer_id"`
+	TaskID        TaskID `json:"task_id"`
+	TimeoutMillis int    `json:"timeout_ms"`
+}
+
+// BridgeStealWant is the fixture form of StealResult.
+type BridgeStealWant struct {
+	OK             bool     `json:"ok"`
+	ThiefID        string   `json:"thief_id"`
+	DonorID        string   `json:"donor_id"`
+	TaskID         TaskID   `json:"task_id"`
+	TaskIDs        []TaskID `json:"task_ids,omitempty"`
+	DonorRemaining int      `json:"donor_remaining"`
+	ThiefWorkLen   int      `json:"thief_work_len"`
+}
+
+// DecodeBridgeFixtures parses model bridge fixtures.
+func DecodeBridgeFixtures(data []byte) (BridgeFixtures, error) {
+	var fixtures BridgeFixtures
+	if err := json.Unmarshal(data, &fixtures); err != nil {
+		return BridgeFixtures{}, err
+	}
+
+	return fixtures, nil
+}
+
+// RunBridgeDispatch applies a dispatch scenario to the Go FSM.
+func RunBridgeDispatch(scenario BridgeDispatchScenario) (
+	BridgeDispatchWant, error) {
+
+	fsm, err := fsmFromBridgePeers(scenario.Peers, Config{
+		BaseTimeout: time.Duration(scenario.BaseTimeoutMillis) *
+			time.Millisecond,
+	})
+	if err != nil {
+		return BridgeDispatchWant{}, err
+	}
+
+	for _, task := range scenario.Tasks {
+		fsm.Enqueue(Task{
+			ID:         task.ID,
+			BatchID:    task.BatchID,
+			Canceled:   task.Canceled,
+			Timeout:    time.Duration(task.TimeoutMillis) * time.Millisecond,
+			AvoidPeers: task.AvoidPeers,
+		})
+	}
+
+	assignment, ok := fsm.DispatchNext()
+	if !ok {
+		return BridgeDispatchWant{OK: false}, nil
+	}
+
+	return BridgeDispatchWant{
+		OK:            true,
+		PeerID:        assignment.PeerID,
+		TaskID:        assignment.TaskID,
+		TimeoutMillis: int(assignment.Timeout / time.Millisecond),
+	}, nil
+}
+
+// RunBridgeSteal applies a work-stealing scenario to the Go FSM.
+func RunBridgeSteal(scenario BridgeStealScenario) (BridgeStealWant, error) {
+	fsm, err := fsmFromBridgePeers(scenario.Peers, DefaultConfig())
+	if err != nil {
+		return BridgeStealWant{}, err
+	}
+
+	result, ok := fsm.StealOne(scenario.Thief)
+	if !ok {
+		return BridgeStealWant{OK: false}, nil
+	}
+
+	thief, ok := fsm.SnapshotPeer(scenario.Thief)
+	if !ok {
+		return BridgeStealWant{}, fmt.Errorf("%w: %s",
+			ErrUnknownPeer, scenario.Thief)
+	}
+
+	return BridgeStealWant{
+		OK:             true,
+		ThiefID:        result.ThiefID,
+		DonorID:        result.DonorID,
+		TaskID:         result.TaskID,
+		TaskIDs:        append([]TaskID(nil), result.TaskIDs...),
+		DonorRemaining: result.DonorRemaining,
+		ThiefWorkLen:   len(thief.LocalWork),
+	}, nil
+}
+
+func fsmFromBridgePeers(peers []BridgePeer, cfg Config) (*SchedulerFSM,
+	error) {
+
+	fsm := NewSchedulerFSM(cfg)
+	for _, peer := range peers {
+		state, err := ParsePeerState(peer.State)
+		if err != nil {
+			return nil, err
+		}
+
+		err = fsm.AddPeer(PeerSnapshot{
+			ID:        peer.ID,
+			Rank:      peer.Rank,
+			RTT:       time.Duration(peer.RTTMillis) * time.Millisecond,
+			State:     state,
+			LocalWork: peer.LocalWork,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return fsm, nil
+}

--- a/querysync/events.go
+++ b/querysync/events.go
@@ -1,0 +1,368 @@
+package querysync
+
+import (
+	"sync"
+	"time"
+)
+
+// SchedulerEventType identifies one observable scheduler manager transition.
+type SchedulerEventType string
+
+const (
+	// SchedulerEventPeerAdded is emitted when the manager records a peer.
+	SchedulerEventPeerAdded SchedulerEventType = "peer_added"
+
+	// SchedulerEventPeerRemoved is emitted when the manager removes a peer.
+	SchedulerEventPeerRemoved SchedulerEventType = "peer_removed"
+
+	// SchedulerEventPeerStateUpdated is emitted when peer lifecycle state
+	// changes.
+	SchedulerEventPeerStateUpdated SchedulerEventType = "peer_state_updated"
+
+	// SchedulerEventPeerRTTUpdated is emitted when the manager receives a
+	// fresh peer RTT sample.
+	SchedulerEventPeerRTTUpdated SchedulerEventType = "peer_rtt_updated"
+
+	// SchedulerEventPeerLocalWorkSet is emitted when a peer's owned local
+	// work queue is replaced.
+	SchedulerEventPeerLocalWorkSet SchedulerEventType = "peer_local_work_set"
+
+	// SchedulerEventTaskEnqueued is emitted when global work is queued.
+	SchedulerEventTaskEnqueued SchedulerEventType = "task_enqueued"
+
+	// SchedulerEventBatchCanceled is emitted when queued work for a batch is
+	// marked canceled.
+	SchedulerEventBatchCanceled SchedulerEventType = "batch_canceled"
+
+	// SchedulerEventPeerCompleted is emitted when a peer completes its
+	// active work slot and returns to ready.
+	SchedulerEventPeerCompleted SchedulerEventType = "peer_completed"
+
+	// SchedulerEventTaskDispatched is emitted when the manager selects an
+	// active peer assignment.
+	SchedulerEventTaskDispatched SchedulerEventType = "task_dispatched"
+
+	// SchedulerEventTaskOwned is emitted when the manager assigns queued work
+	// to a peer-local owned queue.
+	SchedulerEventTaskOwned SchedulerEventType = "task_owned"
+
+	// SchedulerEventWorkStolen is emitted when unstarted local work moves
+	// from a donor peer to an idle thief peer.
+	SchedulerEventWorkStolen SchedulerEventType = "work_stolen"
+
+	// SchedulerEventTaskLocalQueued is emitted by the production work
+	// manager when a concrete job is placed into a peer-local queue.
+	SchedulerEventTaskLocalQueued SchedulerEventType = "task_local_queued"
+
+	// SchedulerEventTaskSent is emitted by the production work manager when
+	// a peer actor's local job is accepted by the worker.
+	SchedulerEventTaskSent SchedulerEventType = "task_sent"
+
+	// SchedulerEventTaskResult is emitted by the production work manager
+	// when a worker returns a result for an active job.
+	SchedulerEventTaskResult SchedulerEventType = "task_result"
+
+	// SchedulerEventWorkStealApplied is emitted after production has moved
+	// concrete jobs according to a model work-steal decision.
+	SchedulerEventWorkStealApplied SchedulerEventType = "work_steal_applied"
+
+	// SchedulerEventPeerCooldown is emitted when a failed peer is put into
+	// temporary retry-avoidance cooldown.
+	SchedulerEventPeerCooldown SchedulerEventType = "peer_cooldown"
+
+	// SchedulerEventPeerQuarantined is emitted when a peer crosses the
+	// repeated non-response threshold and is excluded from scheduling.
+	SchedulerEventPeerQuarantined SchedulerEventType = "peer_quarantined"
+)
+
+// SchedulerEvent is a structured, model-owned view of scheduler behavior. It is
+// separate from TraceEvent: traces are durable replay inputs, while scheduler
+// events are for production telemetry, validation summaries, and metrics.
+type SchedulerEvent struct {
+	Type SchedulerEventType
+	At   time.Time
+
+	PeerID  string
+	ThiefID string
+	DonorID string
+
+	State PeerState
+	Peer  *PeerSnapshot
+
+	TaskID     TaskID
+	TaskIDs    []TaskID
+	BatchID    uint64
+	Assignment *Assignment
+	Steal      *StealResult
+
+	RTT       time.Duration
+	LocalWork []TaskID
+	Timeout   time.Duration
+
+	Err string
+
+	TaskAge          time.Duration
+	ActiveDuration   time.Duration
+	LocalQueueAge    time.Duration
+	StealAge         time.Duration
+	DonorLocalAge    time.Duration
+	ThiefLocalAge    time.Duration
+	LocalWorkLen     int
+	DonorLocalLen    int
+	ThiefLocalLen    int
+	StolenTaskCount  int
+	StolenCount      uint16
+	Attempts         uint8
+	FailureCount     uint8
+	CooldownDuration time.Duration
+	Until            time.Time
+
+	QueueDepth int
+	Metrics    Metrics
+	OK         bool
+}
+
+// SchedulerEventSink receives structured scheduler events.
+type SchedulerEventSink interface {
+	RecordSchedulerEvent(SchedulerEvent)
+}
+
+// SchedulerEventCallback adapts a function into a SchedulerEventSink.
+type SchedulerEventCallback func(SchedulerEvent)
+
+// RecordSchedulerEvent records a scheduler event by calling the callback.
+func (c SchedulerEventCallback) RecordSchedulerEvent(event SchedulerEvent) {
+	if c != nil {
+		c(event)
+	}
+}
+
+// SchedulerEventRecorder stores scheduler events for tests and validation
+// harnesses.
+type SchedulerEventRecorder struct {
+	mu     sync.Mutex
+	events []SchedulerEvent
+}
+
+// RecordSchedulerEvent appends one scheduler event.
+func (r *SchedulerEventRecorder) RecordSchedulerEvent(event SchedulerEvent) {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.events = append(r.events, cloneSchedulerEvent(event))
+}
+
+// Events returns a stable copy of all recorded scheduler events.
+func (r *SchedulerEventRecorder) Events() []SchedulerEvent {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	events := make([]SchedulerEvent, len(r.events))
+	for i := range r.events {
+		events[i] = cloneSchedulerEvent(r.events[i])
+	}
+
+	return events
+}
+
+func cloneSchedulerEvent(event SchedulerEvent) SchedulerEvent {
+	if event.Peer != nil {
+		peer := event.Peer.clone()
+		event.Peer = &peer
+	}
+	if event.Assignment != nil {
+		assignment := *event.Assignment
+		event.Assignment = &assignment
+	}
+	if event.Steal != nil {
+		steal := *event.Steal
+		steal.TaskIDs = append([]TaskID(nil), steal.TaskIDs...)
+		event.Steal = &steal
+	}
+	event.TaskIDs = append([]TaskID(nil), event.TaskIDs...)
+	event.LocalWork = append([]TaskID(nil), event.LocalWork...)
+
+	return event
+}
+
+func schedulerEventForManagerMessage(fsm *SchedulerFSM, msg ManagerMsg,
+	resp ManagerResp) (SchedulerEvent, bool) {
+
+	base := SchedulerEvent{
+		At: time.Now(),
+	}
+	if fsm != nil {
+		base.QueueDepth = fsm.QueueLen()
+		base.Metrics = fsm.Metrics()
+	}
+
+	switch msg := msg.(type) {
+	case *AddPeerMsg:
+		peer := msg.Peer.clone()
+		base.Type = SchedulerEventPeerAdded
+		base.PeerID = msg.Peer.ID
+		base.State = msg.Peer.State
+		base.Peer = &peer
+		base.RTT = msg.Peer.RTT
+		base.LocalWork = append([]TaskID(nil), msg.Peer.LocalWork...)
+
+		return base, true
+
+	case *RemovePeerMsg:
+		base.Type = SchedulerEventPeerRemoved
+		base.PeerID = msg.ID
+
+		return base, true
+
+	case *UpdatePeerStateMsg:
+		base.Type = SchedulerEventPeerStateUpdated
+		base.PeerID = msg.ID
+		base.State = msg.State
+		if fsm != nil {
+			if peer, ok := fsm.SnapshotPeer(msg.ID); ok {
+				base.Peer = &peer
+				base.RTT = peer.RTT
+				base.LocalWork = append(
+					[]TaskID(nil), peer.LocalWork...,
+				)
+			}
+		}
+
+		return base, true
+
+	case *UpdatePeerRTTMsg:
+		base.Type = SchedulerEventPeerRTTUpdated
+		base.PeerID = msg.ID
+		base.RTT = msg.RTT
+		if fsm != nil {
+			if peer, ok := fsm.SnapshotPeer(msg.ID); ok {
+				base.Peer = &peer
+				base.State = peer.State
+				base.LocalWork = append(
+					[]TaskID(nil), peer.LocalWork...,
+				)
+			}
+		}
+
+		return base, true
+
+	case *SetPeerLocalWorkMsg:
+		base.Type = SchedulerEventPeerLocalWorkSet
+		base.PeerID = msg.ID
+		base.LocalWork = append([]TaskID(nil), msg.Work...)
+		if fsm != nil {
+			if peer, ok := fsm.SnapshotPeer(msg.ID); ok {
+				base.Peer = &peer
+				base.State = peer.State
+				base.RTT = peer.RTT
+			}
+		}
+
+		return base, true
+
+	case *CompletePeerWorkMsg:
+		base.Type = SchedulerEventPeerCompleted
+		base.PeerID = msg.ID
+		base.State = PeerReady
+		if fsm != nil {
+			if peer, ok := fsm.SnapshotPeer(msg.ID); ok {
+				base.Peer = &peer
+				base.RTT = peer.RTT
+				base.LocalWork = append(
+					[]TaskID(nil), peer.LocalWork...,
+				)
+			}
+		}
+
+		return base, true
+
+	case *CancelBatchMsg:
+		base.Type = SchedulerEventBatchCanceled
+		base.BatchID = msg.BatchID
+
+		return base, true
+
+	case *EnqueueMsg:
+		base.Type = SchedulerEventTaskEnqueued
+		base.TaskID = msg.Task.ID
+		base.BatchID = msg.Task.BatchID
+
+		return base, true
+
+	case *DispatchMsg:
+		return schedulerEventForDispatchResp(
+			base, SchedulerEventTaskDispatched, resp,
+		)
+
+	case *DispatchTaskMsg:
+		base.TaskID = msg.Task.ID
+		base.BatchID = msg.Task.BatchID
+
+		return schedulerEventForDispatchResp(
+			base, SchedulerEventTaskDispatched, resp,
+		)
+
+	case *AssignLocalTaskMsg:
+		base.TaskID = msg.Task.ID
+		base.BatchID = msg.Task.BatchID
+
+		return schedulerEventForDispatchResp(
+			base, SchedulerEventTaskOwned, resp,
+		)
+
+	case *StealMsg:
+		base.Type = SchedulerEventWorkStolen
+		base.ThiefID = msg.ThiefID
+		base.PeerID = msg.ThiefID
+
+		steal, ok := resp.(*StealResp)
+		if !ok {
+			return base, true
+		}
+
+		base.OK = steal.OK
+		base.Steal = &steal.Result
+		if steal.OK {
+			base.DonorID = steal.Result.DonorID
+			base.TaskID = steal.Result.TaskID
+			base.TaskIDs = append(
+				[]TaskID(nil), steal.Result.TaskIDs...,
+			)
+			base.StolenTaskCount = len(steal.Result.TaskIDs)
+			base.DonorLocalLen = steal.Result.DonorRemaining
+		}
+
+		return base, true
+
+	default:
+		return SchedulerEvent{}, false
+	}
+}
+
+func schedulerEventForDispatchResp(base SchedulerEvent,
+	eventType SchedulerEventType, resp ManagerResp) (SchedulerEvent, bool) {
+
+	base.Type = eventType
+
+	dispatch, ok := resp.(*DispatchResp)
+	if !ok {
+		return base, true
+	}
+
+	base.OK = dispatch.OK
+	base.Assignment = &dispatch.Assignment
+	if dispatch.OK {
+		base.PeerID = dispatch.Assignment.PeerID
+		base.TaskID = dispatch.Assignment.TaskID
+	}
+
+	return base, true
+}

--- a/querysync/fsm.go
+++ b/querysync/fsm.go
@@ -1,0 +1,507 @@
+package querysync
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// Metrics exposes counters that are useful both for production telemetry and
+// deterministic tests.
+type Metrics struct {
+	Dispatched       uint64
+	DroppedCanceled  uint64
+	Owned            uint64
+	Stolen           uint64
+	FailedDispatches uint64
+}
+
+// SchedulerFSM is the pure manager state machine. It does not perform I/O and
+// does not own goroutines; actor wrappers serialize access and bridge this pure
+// state to the rest of neutrino.
+type SchedulerFSM struct {
+	cfg     Config
+	peers   map[string]PeerSnapshot
+	queue   []Task
+	metrics Metrics
+}
+
+// NewSchedulerFSM creates a new scheduler FSM.
+func NewSchedulerFSM(cfg Config) *SchedulerFSM {
+	return &SchedulerFSM{
+		cfg:   cfg.normalize(),
+		peers: make(map[string]PeerSnapshot),
+	}
+}
+
+// AddPeer adds or replaces a peer snapshot.
+func (s *SchedulerFSM) AddPeer(peer PeerSnapshot) error {
+	if peer.ID == "" {
+		return fmt.Errorf("%w: empty peer id", ErrInvalidPeer)
+	}
+
+	if existing, ok := s.peers[peer.ID]; ok && peer.LocalWork == nil {
+		peer.LocalWork = existing.LocalWork
+	}
+
+	s.peers[peer.ID] = peer.clone()
+	return nil
+}
+
+// RemovePeer removes a peer from the scheduler.
+func (s *SchedulerFSM) RemovePeer(id string) {
+	delete(s.peers, id)
+}
+
+// SnapshotPeer returns a copy of the peer state.
+func (s *SchedulerFSM) SnapshotPeer(id string) (PeerSnapshot, bool) {
+	peer, ok := s.peers[id]
+	if !ok {
+		return PeerSnapshot{}, false
+	}
+
+	return peer.clone(), true
+}
+
+// Peers returns a stable snapshot of all peers.
+func (s *SchedulerFSM) Peers() []PeerSnapshot {
+	peers := make([]PeerSnapshot, 0, len(s.peers))
+	for _, peer := range s.peers {
+		peers = append(peers, peer.clone())
+	}
+
+	sort.Slice(peers, func(i, j int) bool {
+		return peers[i].ID < peers[j].ID
+	})
+
+	return peers
+}
+
+// Enqueue appends a task to the global work queue.
+func (s *SchedulerFSM) Enqueue(task Task) {
+	task.AvoidPeers = append([]string(nil), task.AvoidPeers...)
+	s.queue = append(s.queue, task)
+}
+
+// QueueLen returns the current global work queue length.
+func (s *SchedulerFSM) QueueLen() int {
+	return len(s.queue)
+}
+
+// Metrics returns the current scheduler counters.
+func (s *SchedulerFSM) Metrics() Metrics {
+	return s.metrics
+}
+
+// CancelBatch marks queued work in the batch as canceled. The next scheduling
+// pass will drop the canceled work rather than dispatching it to a peer.
+func (s *SchedulerFSM) CancelBatch(batchID uint64) {
+	for i := range s.queue {
+		if s.queue[i].BatchID == batchID {
+			s.queue[i].Canceled = true
+		}
+	}
+}
+
+// UpdatePeerState updates a peer's scheduling state.
+func (s *SchedulerFSM) UpdatePeerState(id string, state PeerState) error {
+	peer, ok := s.peers[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownPeer, id)
+	}
+
+	peer.State = state
+	s.peers[id] = peer
+	return nil
+}
+
+// UpdatePeerRTT updates the latest observed peer RTT.
+func (s *SchedulerFSM) UpdatePeerRTT(id string, rtt time.Duration) error {
+	peer, ok := s.peers[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownPeer, id)
+	}
+
+	peer.RTT = rtt
+	s.peers[id] = peer
+	return nil
+}
+
+// SetPeerLocalWork replaces a peer's local, unclaimed work queue.
+func (s *SchedulerFSM) SetPeerLocalWork(id string, work []TaskID) error {
+	peer, ok := s.peers[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownPeer, id)
+	}
+
+	peer.LocalWork = append([]TaskID(nil), work...)
+	s.peers[id] = peer
+	return nil
+}
+
+// CompletePeerWork marks a peer's active slot as ready again.
+func (s *SchedulerFSM) CompletePeerWork(id string) error {
+	return s.UpdatePeerState(id, PeerReady)
+}
+
+// DispatchNext applies one global scheduling transition. It first removes
+// canceled work at the head of the queue, then selects the best peer that can
+// accept work without blocking.
+func (s *SchedulerFSM) DispatchNext() (Assignment, bool) {
+	for len(s.queue) > 0 && s.queue[0].Canceled {
+		s.queue = s.queue[1:]
+		s.metrics.DroppedCanceled++
+	}
+
+	if len(s.queue) == 0 {
+		s.metrics.FailedDispatches++
+		return Assignment{}, false
+	}
+
+	task := s.queue[0]
+	assignment, ok := s.dispatchTask(task)
+	if !ok {
+		return Assignment{}, false
+	}
+
+	s.queue = s.queue[1:]
+	return assignment, true
+}
+
+// DispatchTask applies one scheduling transition for a task owned outside the
+// scheduler queue. This is the production migration bridge: the long-lived
+// manager actor owns peer state and dispatch rules while the existing query
+// work queue still owns concrete job ordering and cancellation.
+func (s *SchedulerFSM) DispatchTask(task Task) (Assignment, bool) {
+	if task.Canceled {
+		s.metrics.DroppedCanceled++
+		return Assignment{}, false
+	}
+
+	task.AvoidPeers = append([]string(nil), task.AvoidPeers...)
+	return s.dispatchTask(task)
+}
+
+// AssignLocalTask moves an externally queued task into a peer-local owned
+// queue without marking the peer busy. This is the production work-stealing
+// bridge: the concrete query job remains in the query package, while the model
+// decides which peer owns the next unstarted item and makes that ownership
+// visible to StealOne.
+func (s *SchedulerFSM) AssignLocalTask(task Task) (Assignment, bool) {
+	if task.Canceled {
+		s.metrics.DroppedCanceled++
+		return Assignment{}, false
+	}
+
+	task.AvoidPeers = append([]string(nil), task.AvoidPeers...)
+
+	peer, ok := s.selectLocalOwner(task.AvoidPeers)
+	if !ok {
+		s.metrics.FailedDispatches++
+		return Assignment{}, false
+	}
+
+	peer.LocalWork = append(peer.LocalWork, task.ID)
+	s.peers[peer.ID] = peer
+	s.metrics.Owned++
+
+	baseTimeout := s.cfg.BaseTimeout
+	if task.Timeout > 0 {
+		baseTimeout = task.Timeout
+	}
+
+	return Assignment{
+		PeerID: peer.ID,
+		TaskID: task.ID,
+		Timeout: QueryTimeoutForPeer(
+			baseTimeout, peer, s.cfg,
+		),
+	}, true
+}
+
+func (s *SchedulerFSM) dispatchTask(task Task) (Assignment, bool) {
+	peer, ok := s.selectPeer(task.AvoidPeers)
+	if !ok {
+		s.metrics.FailedDispatches++
+		return Assignment{}, false
+	}
+
+	peer.State = PeerBusy
+	s.peers[peer.ID] = peer
+	s.metrics.Dispatched++
+
+	baseTimeout := s.cfg.BaseTimeout
+	if task.Timeout > 0 {
+		baseTimeout = task.Timeout
+	}
+
+	return Assignment{
+		PeerID: peer.ID,
+		TaskID: task.ID,
+		Timeout: QueryTimeoutForPeer(
+			baseTimeout, peer, s.cfg,
+		),
+	}, true
+}
+
+func (s *SchedulerFSM) selectPeer(avoidPeers []string) (PeerSnapshot, bool) {
+	var (
+		best  PeerSnapshot
+		found bool
+	)
+
+	avoid := make(map[string]struct{}, len(avoidPeers))
+	for _, peer := range avoidPeers {
+		avoid[peer] = struct{}{}
+	}
+
+	for _, peer := range s.peers {
+		if peer.State != PeerReady {
+			continue
+		}
+		if _, ok := avoid[peer.ID]; ok {
+			continue
+		}
+
+		if !found || peerOrdersBefore(peer, best) {
+			best = peer
+			found = true
+		}
+	}
+
+	return best.clone(), found
+}
+
+func (s *SchedulerFSM) selectLocalOwner(avoidPeers []string) (
+	PeerSnapshot, bool) {
+
+	var (
+		best  PeerSnapshot
+		found bool
+	)
+
+	avoid := make(map[string]struct{}, len(avoidPeers))
+	for _, peer := range avoidPeers {
+		avoid[peer] = struct{}{}
+	}
+
+	for _, peer := range s.peers {
+		if s.localWorkSpare(peer) == 0 {
+			continue
+		}
+		if _, ok := avoid[peer.ID]; ok {
+			continue
+		}
+
+		if !found || s.localOwnerOrdersBefore(peer, best) {
+			best = peer
+			found = true
+		}
+	}
+
+	return best.clone(), found
+}
+
+func peerOrdersBefore(peer, candidate PeerSnapshot) bool {
+	if peer.Rank != candidate.Rank {
+		return peer.Rank < candidate.Rank
+	}
+
+	if peer.RTT != candidate.RTT {
+		return peer.RTT < candidate.RTT
+	}
+
+	return peer.ID < candidate.ID
+}
+
+func (s *SchedulerFSM) localOwnerOrdersBefore(peer,
+	candidate PeerSnapshot) bool {
+
+	peerSpare := s.localWorkSpare(peer)
+	candidateSpare := s.localWorkSpare(candidate)
+	if peerSpare != candidateSpare {
+		return peerSpare > candidateSpare
+	}
+
+	peerLoad := localOwnerLoad(peer)
+	candidateLoad := localOwnerLoad(candidate)
+	if peerLoad != candidateLoad {
+		return peerLoad < candidateLoad
+	}
+
+	return peerOrdersBefore(peer, candidate)
+}
+
+func localOwnerLoad(peer PeerSnapshot) int {
+	load := len(peer.LocalWork)
+	if peer.State == PeerBusy {
+		load++
+	}
+
+	return load
+}
+
+func (s *SchedulerFSM) localWorkSpare(peer PeerSnapshot) int {
+	if peer.State != PeerReady && peer.State != PeerBusy {
+		return 0
+	}
+
+	spare := s.cfg.MaxPeerOutstanding - localOwnerLoad(peer)
+	if spare < 0 {
+		return 0
+	}
+
+	return spare
+}
+
+// StealOne moves unclaimed work from the most loaded donor to an idle thief,
+// filling the thief's available local queue capacity. Ready and busy donors
+// retain one local task after the steal so useful peer-local queues do not
+// immediately collapse into reshuffling. A busy peer with only one queued local
+// task is not a useful donor yet: its active request should either finish or
+// fail before the queued task is considered stranded. Blocked and quarantined
+// donors can be drained because their local work is otherwise stranded.
+func (s *SchedulerFSM) StealOne(thiefID string) (StealResult, bool) {
+	thief, ok := s.peers[thiefID]
+	if !ok || thief.State != PeerReady || len(thief.LocalWork) != 0 {
+		return StealResult{}, false
+	}
+
+	thiefSpare := s.localWorkSpare(thief)
+	if thiefSpare == 0 {
+		return StealResult{}, false
+	}
+
+	donor, ok := s.selectStealDonor(thiefID)
+	if !ok {
+		return StealResult{}, false
+	}
+
+	stealCount := s.stealableWork(donor)
+	if stealCount > thiefSpare {
+		stealCount = thiefSpare
+	}
+	if stealCount == 0 {
+		return StealResult{}, false
+	}
+
+	stolenTasks := append([]TaskID(nil), donor.LocalWork[:stealCount]...)
+	donor.LocalWork = append([]TaskID(nil), donor.LocalWork[stealCount:]...)
+	thief.LocalWork = append(thief.LocalWork, stolenTasks...)
+
+	s.peers[donor.ID] = donor
+	s.peers[thief.ID] = thief
+	s.metrics.Stolen++
+
+	return StealResult{
+		ThiefID:        thief.ID,
+		DonorID:        donor.ID,
+		TaskID:         stolenTasks[0],
+		TaskIDs:        stolenTasks,
+		DonorRemaining: len(donor.LocalWork),
+	}, true
+}
+
+func (s *SchedulerFSM) selectStealDonor(thiefID string) (PeerSnapshot, bool) {
+	var (
+		best  PeerSnapshot
+		found bool
+	)
+
+	for _, peer := range s.peers {
+		if peer.ID == thiefID || s.stealableWork(peer) == 0 {
+			continue
+		}
+
+		if !found || betterStealDonor(peer, best) {
+			best = peer
+			found = true
+		}
+	}
+
+	return best.clone(), found
+}
+
+func (s *SchedulerFSM) stealableWork(peer PeerSnapshot) int {
+	switch peer.State {
+	case PeerReady:
+		if len(peer.LocalWork) <= 1 {
+			return 0
+		}
+
+		return len(peer.LocalWork) - 1
+
+	case PeerBusy:
+		if len(peer.LocalWork) <= 1 {
+			return 0
+		}
+
+		return len(peer.LocalWork) - 1
+
+	case PeerBlocked, PeerQuarantined:
+		return len(peer.LocalWork)
+
+	default:
+		return 0
+	}
+}
+
+func betterStealDonor(peer, candidate PeerSnapshot) bool {
+	peerPriority := stealDonorPriority(peer)
+	candidatePriority := stealDonorPriority(candidate)
+	if peerPriority != candidatePriority {
+		return peerPriority > candidatePriority
+	}
+
+	peerStealable := stealableWorkForOrder(peer)
+	candidateStealable := stealableWorkForOrder(candidate)
+	if peerStealable != candidateStealable {
+		return peerStealable > candidateStealable
+	}
+
+	if peer.Rank != candidate.Rank {
+		return peer.Rank > candidate.Rank
+	}
+
+	return peer.ID < candidate.ID
+}
+
+func stealDonorPriority(peer PeerSnapshot) int {
+	switch {
+	case peer.State == PeerBlocked || peer.State == PeerQuarantined:
+		return 3
+
+	case peer.State == PeerReady && len(peer.LocalWork) > 1:
+		return 2
+
+	case peer.State == PeerBusy && len(peer.LocalWork) > 1:
+		return 2
+
+	default:
+		return 0
+	}
+}
+
+func stealableWorkForOrder(peer PeerSnapshot) int {
+	switch peer.State {
+	case PeerReady:
+		if len(peer.LocalWork) <= 1 {
+			return 0
+		}
+
+		return len(peer.LocalWork) - 1
+
+	case PeerBusy:
+		if len(peer.LocalWork) <= 1 {
+			return 0
+		}
+
+		return len(peer.LocalWork) - 1
+
+	case PeerBlocked, PeerQuarantined:
+		return len(peer.LocalWork)
+
+	default:
+		return 0
+	}
+}

--- a/querysync/fsm_test.go
+++ b/querysync/fsm_test.go
@@ -1,0 +1,444 @@
+package querysync
+
+import (
+	"reflect"
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchedulerSkipsBlockedRankedPeer(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "best-but-blocked",
+		Rank:  0,
+		RTT:   20 * time.Millisecond,
+		State: PeerBlocked,
+	}))
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "capable",
+		Rank:  10,
+		RTT:   50 * time.Millisecond,
+		State: PeerReady,
+	}))
+
+	fsm.Enqueue(Task{ID: 100})
+
+	assignment, ok := fsm.DispatchNext()
+	require.True(t, ok)
+	require.Equal(t, "capable", assignment.PeerID)
+	require.EqualValues(t, 100, assignment.TaskID)
+}
+
+func TestSchedulerSkipsQuarantinedRankedPeer(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "best-but-quarantined",
+		Rank:  0,
+		RTT:   20 * time.Millisecond,
+		State: PeerQuarantined,
+	}))
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "capable",
+		Rank:  10,
+		RTT:   50 * time.Millisecond,
+		State: PeerReady,
+	}))
+
+	fsm.Enqueue(Task{ID: 100})
+
+	assignment, ok := fsm.DispatchNext()
+	require.True(t, ok)
+	require.Equal(t, "capable", assignment.PeerID)
+	require.EqualValues(t, 100, assignment.TaskID)
+}
+
+func TestSchedulerDropsCanceledQueuedWork(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "peer",
+		Rank:  0,
+		State: PeerReady,
+	}))
+
+	fsm.Enqueue(Task{ID: 100, BatchID: 1, Canceled: true})
+
+	_, ok := fsm.DispatchNext()
+	require.False(t, ok)
+	require.EqualValues(t, 1, fsm.Metrics().DroppedCanceled)
+	require.Zero(t, fsm.QueueLen())
+}
+
+func TestSchedulerRTTTimeoutFloor(t *testing.T) {
+	peer := PeerSnapshot{
+		ID:    "peer",
+		RTT:   750 * time.Millisecond,
+		State: PeerReady,
+	}
+
+	timeout := QueryTimeoutForPeer(
+		DefaultMinQueryTimeout, peer, DefaultConfig(),
+	)
+	require.Equal(t, 6*time.Second, timeout)
+
+	peer.RTT = 9 * time.Second
+	timeout = QueryTimeoutForPeer(
+		DefaultMinQueryTimeout, peer, DefaultConfig(),
+	)
+	require.Equal(t, DefaultMaxQueryTimeout, timeout)
+}
+
+func TestSchedulerDispatchTaskUsesTaskTimeoutAndAvoidsPeers(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "avoided",
+		Rank:  0,
+		RTT:   500 * time.Millisecond,
+		State: PeerReady,
+	}))
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "selected",
+		Rank:  10,
+		RTT:   500 * time.Millisecond,
+		State: PeerReady,
+	}))
+
+	assignment, ok := fsm.DispatchTask(Task{
+		ID:         10,
+		Timeout:    10 * time.Second,
+		AvoidPeers: []string{"avoided"},
+	})
+	require.True(t, ok)
+	require.Equal(t, "selected", assignment.PeerID)
+	require.EqualValues(t, 10, assignment.TaskID)
+	require.Equal(t, 10*time.Second, assignment.Timeout)
+}
+
+func TestSchedulerDispatchMarksPeerBusy(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "peer",
+		Rank:  0,
+		State: PeerReady,
+	}))
+
+	fsm.Enqueue(Task{ID: 1})
+	_, ok := fsm.DispatchNext()
+	require.True(t, ok)
+
+	peer, ok := fsm.SnapshotPeer("peer")
+	require.True(t, ok)
+	require.Equal(t, PeerBusy, peer.State)
+
+	require.NoError(t, fsm.CompletePeerWork("peer"))
+	peer, ok = fsm.SnapshotPeer("peer")
+	require.True(t, ok)
+	require.Equal(t, PeerReady, peer.State)
+}
+
+func TestSchedulerAssignLocalTaskBalancesOwnedWork(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:        "loaded",
+		Rank:      0,
+		State:     PeerReady,
+		LocalWork: []TaskID{1, 2},
+	}))
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "empty",
+		Rank:  10,
+		State: PeerReady,
+	}))
+
+	assignment, ok := fsm.AssignLocalTask(Task{ID: 3})
+	require.True(t, ok)
+	require.Equal(t, "empty", assignment.PeerID)
+
+	empty, ok := fsm.SnapshotPeer("empty")
+	require.True(t, ok)
+	require.Equal(t, []TaskID{3}, empty.LocalWork)
+	require.EqualValues(t, 1, fsm.Metrics().Owned)
+}
+
+func TestSchedulerAssignLocalTaskBuildsBoundedLocalQueue(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:        "peer",
+		State:     PeerReady,
+		LocalWork: []TaskID{1},
+	}))
+
+	assignment, ok := fsm.AssignLocalTask(Task{ID: 2})
+	require.True(t, ok)
+	require.Equal(t, "peer", assignment.PeerID)
+
+	peer, ok := fsm.SnapshotPeer("peer")
+	require.True(t, ok)
+	require.Equal(t, []TaskID{1, 2}, peer.LocalWork)
+}
+
+func TestSchedulerAssignLocalTaskDoesNotExceedPeerCapacity(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:        "peer",
+		State:     PeerReady,
+		LocalWork: []TaskID{1, 2, 3, 4},
+	}))
+
+	_, ok := fsm.AssignLocalTask(Task{ID: 5})
+	require.False(t, ok)
+
+	peer, ok := fsm.SnapshotPeer("peer")
+	require.True(t, ok)
+	require.Equal(t, []TaskID{1, 2, 3, 4}, peer.LocalWork)
+}
+
+func TestSchedulerBusyPeerActiveSlotCountsTowardCapacity(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:        "peer",
+		State:     PeerBusy,
+		LocalWork: []TaskID{1, 2, 3},
+	}))
+
+	_, ok := fsm.AssignLocalTask(Task{ID: 4})
+	require.False(t, ok)
+
+	peer, ok := fsm.SnapshotPeer("peer")
+	require.True(t, ok)
+	require.Equal(t, []TaskID{1, 2, 3}, peer.LocalWork)
+}
+
+func TestWorkStealingMovesUnclaimedWorkToIdlePeer(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:        "donor",
+		Rank:      0,
+		State:     PeerReady,
+		LocalWork: []TaskID{10, 11, 12},
+	}))
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "thief",
+		Rank:  10,
+		State: PeerReady,
+	}))
+
+	result, ok := fsm.StealOne("thief")
+	require.True(t, ok)
+	require.Equal(t, "thief", result.ThiefID)
+	require.Equal(t, "donor", result.DonorID)
+	require.EqualValues(t, 10, result.TaskID)
+	require.Equal(t, []TaskID{10, 11}, result.TaskIDs)
+	require.Equal(t, 1, result.DonorRemaining)
+
+	donor, ok := fsm.SnapshotPeer("donor")
+	require.True(t, ok)
+	require.Equal(t, []TaskID{12}, donor.LocalWork)
+
+	thief, ok := fsm.SnapshotPeer("thief")
+	require.True(t, ok)
+	require.Equal(t, []TaskID{10, 11}, thief.LocalWork)
+}
+
+func TestWorkStealingLeavesBusyDonorQueuedWork(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:        "donor",
+		Rank:      0,
+		State:     PeerBusy,
+		LocalWork: []TaskID{10, 11, 12},
+	}))
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "thief",
+		Rank:  10,
+		State: PeerReady,
+	}))
+
+	result, ok := fsm.StealOne("thief")
+	require.True(t, ok)
+	require.Equal(t, "thief", result.ThiefID)
+	require.Equal(t, "donor", result.DonorID)
+	require.Equal(t, []TaskID{10, 11}, result.TaskIDs)
+	require.Equal(t, 1, result.DonorRemaining)
+
+	donor, ok := fsm.SnapshotPeer("donor")
+	require.True(t, ok)
+	require.Equal(t, []TaskID{12}, donor.LocalWork)
+}
+
+func TestWorkStealingIgnoresBusySingletonDonor(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:        "busy-singleton",
+		Rank:      100,
+		State:     PeerBusy,
+		LocalWork: []TaskID{10},
+	}))
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:        "surplus-ready",
+		Rank:      0,
+		State:     PeerReady,
+		LocalWork: []TaskID{20, 21},
+	}))
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "thief",
+		State: PeerReady,
+	}))
+
+	result, ok := fsm.StealOne("thief")
+	require.True(t, ok)
+	require.Equal(t, "surplus-ready", result.DonorID)
+	require.Equal(t, []TaskID{20}, result.TaskIDs)
+
+	busy, ok := fsm.SnapshotPeer("busy-singleton")
+	require.True(t, ok)
+	require.Equal(t, []TaskID{10}, busy.LocalWork)
+}
+
+func TestWorkStealingDoesNotStealSingleton(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:        "donor",
+		State:     PeerReady,
+		LocalWork: []TaskID{10},
+	}))
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "thief",
+		State: PeerReady,
+	}))
+
+	_, ok := fsm.StealOne("thief")
+	require.False(t, ok)
+
+	donor, ok := fsm.SnapshotPeer("donor")
+	require.True(t, ok)
+	require.Equal(t, []TaskID{10}, donor.LocalWork)
+}
+
+func TestWorkStealingCanDrainBlockedDonor(t *testing.T) {
+	fsm := NewSchedulerFSM(DefaultConfig())
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:        "blocked",
+		State:     PeerBlocked,
+		LocalWork: []TaskID{10},
+	}))
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "thief",
+		State: PeerReady,
+	}))
+
+	result, ok := fsm.StealOne("thief")
+	require.True(t, ok)
+	require.Equal(t, "blocked", result.DonorID)
+	require.EqualValues(t, 10, result.TaskID)
+	require.Zero(t, result.DonorRemaining)
+}
+
+func TestPeerFSMRejectsAssignWhenBlocked(t *testing.T) {
+	peer := NewPeerFSM("peer")
+	require.NoError(t, peer.Apply(PeerBlockedEvent{}))
+	require.Error(t, peer.Apply(PeerAssignedEvent{TaskID: 1}))
+}
+
+func TestPeerFSMRejectsAssignWhenQuarantined(t *testing.T) {
+	peer := NewPeerFSM("peer")
+	require.NoError(t, peer.Apply(PeerQuarantinedEvent{}))
+	require.Error(t, peer.Apply(PeerAssignedEvent{TaskID: 1}))
+}
+
+func TestQuickQueryTimeoutMatchesRule(t *testing.T) {
+	property := func(baseMS uint16, rttMS uint16) bool {
+		cfg := DefaultConfig()
+		base := time.Duration(baseMS) * time.Millisecond
+		rtt := time.Duration(rttMS) * time.Millisecond
+
+		got := QueryTimeoutForPeer(base, PeerSnapshot{RTT: rtt}, cfg)
+
+		want := base
+		if want < cfg.MinTimeout {
+			want = cfg.MinTimeout
+		}
+		if rtt > 0 {
+			rttTimeout := rtt * time.Duration(cfg.RTTMultiplier)
+			if rttTimeout > want {
+				want = rttTimeout
+			}
+		}
+		if want > cfg.MaxTimeout {
+			want = cfg.MaxTimeout
+		}
+
+		return got == want &&
+			got >= cfg.MinTimeout &&
+			got <= cfg.MaxTimeout
+	}
+
+	require.NoError(t, quick.Check(property, &quick.Config{
+		MaxCount: 500,
+	}))
+}
+
+func TestQuickWorkStealingPreservesTaskMultiset(t *testing.T) {
+	property := func(rawDonor, rawThief uint8) bool {
+		donorCount := int(rawDonor % 8)
+		thiefCount := int(rawThief % 4)
+
+		donorWork := make([]TaskID, donorCount)
+		for i := range donorWork {
+			donorWork[i] = TaskID(i + 1)
+		}
+
+		thiefWork := make([]TaskID, thiefCount)
+		for i := range thiefWork {
+			thiefWork[i] = TaskID(100 + i)
+		}
+
+		fsm := NewSchedulerFSM(DefaultConfig())
+		if err := fsm.AddPeer(PeerSnapshot{
+			ID:        "donor",
+			State:     PeerReady,
+			LocalWork: donorWork,
+		}); err != nil {
+			return false
+		}
+		if err := fsm.AddPeer(PeerSnapshot{
+			ID:        "thief",
+			State:     PeerReady,
+			LocalWork: thiefWork,
+		}); err != nil {
+			return false
+		}
+
+		before := taskCounts(donorWork, thiefWork)
+		_, _ = fsm.StealOne("thief")
+
+		donor, ok := fsm.SnapshotPeer("donor")
+		if !ok {
+			return false
+		}
+		thief, ok := fsm.SnapshotPeer("thief")
+		if !ok {
+			return false
+		}
+
+		after := taskCounts(donor.LocalWork, thief.LocalWork)
+		return reflect.DeepEqual(before, after)
+	}
+
+	require.NoError(t, quick.Check(property, &quick.Config{
+		MaxCount: 500,
+	}))
+}
+
+func taskCounts(workSets ...[]TaskID) map[TaskID]int {
+	counts := make(map[TaskID]int)
+	for _, work := range workSets {
+		for _, task := range work {
+			counts[task]++
+		}
+	}
+
+	return counts
+}

--- a/querysync/model_bridge_test.go
+++ b/querysync/model_bridge_test.go
@@ -1,0 +1,34 @@
+package querysync
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPModelBridgeFixtures(t *testing.T) {
+	data, err := os.ReadFile(
+		"../p-models/neutrinoquery/bridge/scenarios.json",
+	)
+	require.NoError(t, err)
+
+	fixtures, err := DecodeBridgeFixtures(data)
+	require.NoError(t, err)
+
+	for _, scenario := range fixtures.Dispatch {
+		t.Run("dispatch/"+scenario.Name, func(t *testing.T) {
+			got, err := RunBridgeDispatch(scenario)
+			require.NoError(t, err)
+			require.Equal(t, scenario.Expect, got)
+		})
+	}
+
+	for _, scenario := range fixtures.Steal {
+		t.Run("steal/"+scenario.Name, func(t *testing.T) {
+			got, err := RunBridgeSteal(scenario)
+			require.NoError(t, err)
+			require.Equal(t, scenario.Expect, got)
+		})
+	}
+}

--- a/querysync/peer_fsm.go
+++ b/querysync/peer_fsm.go
@@ -1,0 +1,91 @@
+package querysync
+
+import (
+	"fmt"
+	"time"
+)
+
+// PeerFSM is the pure per-peer state machine. It deliberately models only the
+// state that the manager needs for scheduling decisions; network I/O belongs in
+// the actor or adapter layer that feeds events into this FSM.
+type PeerFSM struct {
+	id     string
+	state  PeerState
+	rtt    time.Duration
+	active *TaskID
+}
+
+// NewPeerFSM creates a new peer FSM.
+func NewPeerFSM(id string) *PeerFSM {
+	return &PeerFSM{
+		id:    id,
+		state: PeerReady,
+	}
+}
+
+func (PeerReadyEvent) apply(f *PeerFSM) error {
+	f.state = PeerReady
+	f.active = nil
+	return nil
+}
+
+func (PeerBlockedEvent) apply(f *PeerFSM) error {
+	f.state = PeerBlocked
+	return nil
+}
+
+func (PeerQuarantinedEvent) apply(f *PeerFSM) error {
+	f.state = PeerQuarantined
+	f.active = nil
+	return nil
+}
+
+func (PeerDownEvent) apply(f *PeerFSM) error {
+	f.state = PeerDown
+	f.active = nil
+	return nil
+}
+
+func (e PeerRTTEvent) apply(f *PeerFSM) error {
+	if e.RTT < 0 {
+		return fmt.Errorf("negative RTT: %v", e.RTT)
+	}
+
+	f.rtt = e.RTT
+	return nil
+}
+
+func (PeerRankEvent) apply(*PeerFSM) error {
+	return nil
+}
+
+func (e PeerAssignedEvent) apply(f *PeerFSM) error {
+	if f.state != PeerReady {
+		return fmt.Errorf("peer %s cannot accept work while %s",
+			f.id, f.state)
+	}
+
+	f.state = PeerBusy
+	f.active = &e.TaskID
+	return nil
+}
+
+func (PeerNeedWorkEvent) apply(*PeerFSM) error {
+	return nil
+}
+
+// Apply processes one peer event.
+func (f *PeerFSM) Apply(event PeerEvent) error {
+	return event.apply(f)
+}
+
+// Snapshot returns the manager-facing peer state.
+func (f *PeerFSM) Snapshot(rank int, localWork []TaskID) PeerSnapshot {
+	return PeerSnapshot{
+		ID:        f.id,
+		Rank:      rank,
+		RTT:       f.rtt,
+		State:     f.state,
+		LocalWork: append([]TaskID(nil), localWork...),
+	}
+}

--- a/querysync/trace.go
+++ b/querysync/trace.go
@@ -1,0 +1,495 @@
+package querysync
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+)
+
+const (
+	TraceOpAddPeer         = "add_peer"
+	TraceOpRemovePeer      = "remove_peer"
+	TraceOpUpdatePeerState = "update_peer_state"
+	TraceOpUpdatePeerRTT   = "update_peer_rtt"
+	TraceOpSetPeerWork     = "set_peer_work"
+	TraceOpCompletePeer    = "complete_peer"
+	TraceOpCancelBatch     = "cancel_batch"
+	TraceOpEnqueue         = "enqueue"
+	TraceOpDispatch        = "dispatch"
+	TraceOpDispatchTask    = "dispatch_task"
+	TraceOpAssignLocalTask = "assign_local_task"
+	TraceOpSteal           = "steal"
+)
+
+// TraceEvent is the durable, JSON-friendly form of a scheduler actor event.
+// It is intentionally phrased in model terms, not Go implementation terms, so
+// production traces can be replayed against both this actor-backed path and the
+// P bridge invariants.
+type TraceEvent struct {
+	Op string `json:"op"`
+
+	Peer  *BridgePeer `json:"peer,omitempty"`
+	State string      `json:"state,omitempty"`
+
+	PeerID string   `json:"peer_id,omitempty"`
+	RTTMS  int      `json:"rtt_ms,omitempty"`
+	Work   []TaskID `json:"work,omitempty"`
+
+	Task    *BridgeTask `json:"task,omitempty"`
+	BatchID uint64      `json:"batch_id,omitempty"`
+	ThiefID string      `json:"thief_id,omitempty"`
+
+	Dispatch *BridgeDispatchWant `json:"dispatch,omitempty"`
+	Steal    *BridgeStealWant    `json:"steal,omitempty"`
+	Error    string              `json:"error,omitempty"`
+}
+
+// TraceReplayResult is the sequence of externally visible scheduler decisions
+// produced by a trace replay.
+type TraceReplayResult struct {
+	Dispatches []BridgeDispatchWant `json:"dispatches"`
+	Steals     []BridgeStealWant    `json:"steals"`
+	Metrics    Metrics              `json:"metrics"`
+}
+
+// TraceRecorder stores scheduler trace events emitted by the manager actor.
+type TraceRecorder struct {
+	mu     sync.Mutex
+	events []TraceEvent
+}
+
+// Record appends one trace event.
+func (t *TraceRecorder) Record(event TraceEvent) {
+	if t == nil {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.events = append(t.events, cloneTraceEvent(event))
+}
+
+// Events returns a stable copy of the recorded trace.
+func (t *TraceRecorder) Events() []TraceEvent {
+	if t == nil {
+		return nil
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	events := make([]TraceEvent, len(t.events))
+	for i := range t.events {
+		events[i] = cloneTraceEvent(t.events[i])
+	}
+
+	return events
+}
+
+// ReplayTrace applies a recorded scheduler trace to a fresh manager actor. If
+// a dispatch or steal event includes an expected result, replay verifies that
+// the actor produces the same decision.
+func ReplayTrace(ctx context.Context, cfg Config,
+	events []TraceEvent) (TraceReplayResult, error) {
+
+	manager := NewManagerActor(NewSchedulerFSM(cfg), 128)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	var result TraceReplayResult
+	for index, event := range events {
+		if err := replayTraceEvent(ctx, manager, &result, event); err != nil {
+			return TraceReplayResult{}, fmt.Errorf(
+				"trace event %d (%s): %w", index, event.Op, err,
+			)
+		}
+	}
+
+	metrics, err := manager.Metrics(ctx)
+	if err != nil {
+		return TraceReplayResult{}, err
+	}
+	result.Metrics = metrics
+
+	return result, nil
+}
+
+func replayTraceEvent(ctx context.Context, manager *ManagerActor,
+	result *TraceReplayResult, event TraceEvent) error {
+
+	switch event.Op {
+	case TraceOpAddPeer:
+		if event.Peer == nil {
+			return fmt.Errorf("missing peer")
+		}
+
+		peer, err := peerFromBridge(*event.Peer)
+		if err != nil {
+			return err
+		}
+
+		return manager.AddPeer(ctx, peer)
+
+	case TraceOpRemovePeer:
+		return manager.RemovePeer(ctx, event.PeerID)
+
+	case TraceOpUpdatePeerState:
+		state, err := ParsePeerState(event.State)
+		if err != nil {
+			return err
+		}
+
+		return manager.UpdatePeerState(ctx, event.PeerID, state)
+
+	case TraceOpUpdatePeerRTT:
+		return manager.UpdatePeerRTT(
+			ctx, event.PeerID,
+			time.Duration(event.RTTMS)*time.Millisecond,
+		)
+
+	case TraceOpSetPeerWork:
+		return manager.SetPeerLocalWork(ctx, event.PeerID, event.Work)
+
+	case TraceOpCompletePeer:
+		return manager.CompletePeerWork(ctx, event.PeerID)
+
+	case TraceOpCancelBatch:
+		return manager.CancelBatch(ctx, event.BatchID)
+
+	case TraceOpEnqueue:
+		if event.Task == nil {
+			return fmt.Errorf("missing task")
+		}
+
+		return manager.Enqueue(ctx, taskFromBridge(*event.Task))
+
+	case TraceOpDispatch:
+		assignment, ok, err := manager.AskDispatch(ctx)
+		if err != nil {
+			return err
+		}
+
+		got := bridgeDispatchWant(assignment, ok)
+		result.Dispatches = append(result.Dispatches, got)
+		if event.Dispatch != nil && *event.Dispatch != got {
+			return fmt.Errorf("dispatch mismatch: got %+v, want %+v",
+				got, *event.Dispatch)
+		}
+
+		return nil
+
+	case TraceOpDispatchTask:
+		if event.Task == nil {
+			return fmt.Errorf("missing task")
+		}
+
+		assignment, ok, err := manager.AskDispatchTask(
+			ctx, taskFromBridge(*event.Task),
+		)
+		if err != nil {
+			return err
+		}
+
+		got := bridgeDispatchWant(assignment, ok)
+		result.Dispatches = append(result.Dispatches, got)
+		if event.Dispatch != nil && *event.Dispatch != got {
+			return fmt.Errorf("dispatch_task mismatch: got %+v, "+
+				"want %+v", got, *event.Dispatch)
+		}
+
+		return nil
+
+	case TraceOpAssignLocalTask:
+		if event.Task == nil {
+			return fmt.Errorf("missing task")
+		}
+
+		assignment, ok, err := manager.AskAssignLocalTask(
+			ctx, taskFromBridge(*event.Task),
+		)
+		if err != nil {
+			return err
+		}
+
+		got := bridgeDispatchWant(assignment, ok)
+		result.Dispatches = append(result.Dispatches, got)
+		if event.Dispatch != nil && *event.Dispatch != got {
+			return fmt.Errorf("assign_local_task mismatch: got "+
+				"%+v, want %+v", got, *event.Dispatch)
+		}
+
+		return nil
+
+	case TraceOpSteal:
+		got, err := replayTraceSteal(ctx, manager, event.ThiefID)
+		if err != nil {
+			return err
+		}
+
+		result.Steals = append(result.Steals, got)
+		if event.Steal != nil && !reflect.DeepEqual(*event.Steal, got) {
+			return fmt.Errorf("steal mismatch: got %+v, want %+v",
+				got, *event.Steal)
+		}
+
+		return nil
+
+	default:
+		return fmt.Errorf("unknown trace op")
+	}
+}
+
+func replayTraceSteal(ctx context.Context, manager *ManagerActor,
+	thiefID string) (BridgeStealWant, error) {
+
+	steal, ok, err := manager.AskSteal(ctx, thiefID)
+	if err != nil {
+		return BridgeStealWant{}, err
+	}
+	if !ok {
+		return BridgeStealWant{OK: false}, nil
+	}
+
+	thief, ok, err := manager.SnapshotPeer(ctx, thiefID)
+	if err != nil {
+		return BridgeStealWant{}, err
+	}
+	if !ok {
+		return BridgeStealWant{}, fmt.Errorf("%w: %s",
+			ErrUnknownPeer, thiefID)
+	}
+
+	return bridgeStealWant(steal, len(thief.LocalWork), true), nil
+}
+
+func traceEventForManagerMessage(fsm *SchedulerFSM, msg ManagerMsg,
+	resp ManagerResp) (TraceEvent, bool) {
+
+	switch msg := msg.(type) {
+	case *AddPeerMsg:
+		peer := bridgePeer(msg.Peer)
+
+		return TraceEvent{
+			Op:   TraceOpAddPeer,
+			Peer: &peer,
+		}, true
+
+	case *RemovePeerMsg:
+		return TraceEvent{
+			Op:     TraceOpRemovePeer,
+			PeerID: msg.ID,
+		}, true
+
+	case *UpdatePeerStateMsg:
+		return TraceEvent{
+			Op:     TraceOpUpdatePeerState,
+			PeerID: msg.ID,
+			State:  msg.State.String(),
+		}, true
+
+	case *UpdatePeerRTTMsg:
+		return TraceEvent{
+			Op:     TraceOpUpdatePeerRTT,
+			PeerID: msg.ID,
+			RTTMS:  int(msg.RTT / time.Millisecond),
+		}, true
+
+	case *SetPeerLocalWorkMsg:
+		return TraceEvent{
+			Op:     TraceOpSetPeerWork,
+			PeerID: msg.ID,
+			Work:   append([]TaskID(nil), msg.Work...),
+		}, true
+
+	case *CompletePeerWorkMsg:
+		return TraceEvent{
+			Op:     TraceOpCompletePeer,
+			PeerID: msg.ID,
+		}, true
+
+	case *CancelBatchMsg:
+		return TraceEvent{
+			Op:      TraceOpCancelBatch,
+			BatchID: msg.BatchID,
+		}, true
+
+	case *EnqueueMsg:
+		task := bridgeTask(msg.Task)
+
+		return TraceEvent{
+			Op:   TraceOpEnqueue,
+			Task: &task,
+		}, true
+
+	case *DispatchMsg:
+		event := TraceEvent{Op: TraceOpDispatch}
+		if dispatch, ok := resp.(*DispatchResp); ok {
+			want := bridgeDispatchWant(
+				dispatch.Assignment, dispatch.OK,
+			)
+			event.Dispatch = &want
+		}
+
+		return event, true
+
+	case *DispatchTaskMsg:
+		task := bridgeTask(msg.Task)
+		event := TraceEvent{
+			Op:   TraceOpDispatchTask,
+			Task: &task,
+		}
+		if dispatch, ok := resp.(*DispatchResp); ok {
+			want := bridgeDispatchWant(
+				dispatch.Assignment, dispatch.OK,
+			)
+			event.Dispatch = &want
+		}
+
+		return event, true
+
+	case *AssignLocalTaskMsg:
+		task := bridgeTask(msg.Task)
+		event := TraceEvent{
+			Op:   TraceOpAssignLocalTask,
+			Task: &task,
+		}
+		if dispatch, ok := resp.(*DispatchResp); ok {
+			want := bridgeDispatchWant(
+				dispatch.Assignment, dispatch.OK,
+			)
+			event.Dispatch = &want
+		}
+
+		return event, true
+
+	case *StealMsg:
+		event := TraceEvent{
+			Op:      TraceOpSteal,
+			ThiefID: msg.ThiefID,
+		}
+		if steal, ok := resp.(*StealResp); ok {
+			thiefWorkLen := 0
+			if steal.OK && fsm != nil {
+				thief, ok := fsm.SnapshotPeer(msg.ThiefID)
+				if ok {
+					thiefWorkLen = len(thief.LocalWork)
+				}
+			}
+
+			want := bridgeStealWant(
+				steal.Result, thiefWorkLen, steal.OK,
+			)
+			event.Steal = &want
+		}
+
+		return event, true
+
+	default:
+		return TraceEvent{}, false
+	}
+}
+
+func bridgeDispatchWant(assignment Assignment, ok bool) BridgeDispatchWant {
+	if !ok {
+		return BridgeDispatchWant{OK: false}
+	}
+
+	return BridgeDispatchWant{
+		OK:            true,
+		PeerID:        assignment.PeerID,
+		TaskID:        assignment.TaskID,
+		TimeoutMillis: int(assignment.Timeout / time.Millisecond),
+	}
+}
+
+func bridgeStealWant(result StealResult, thiefWorkLen int,
+	ok bool) BridgeStealWant {
+
+	if !ok {
+		return BridgeStealWant{OK: false}
+	}
+
+	return BridgeStealWant{
+		OK:             true,
+		ThiefID:        result.ThiefID,
+		DonorID:        result.DonorID,
+		TaskID:         result.TaskID,
+		TaskIDs:        append([]TaskID(nil), result.TaskIDs...),
+		DonorRemaining: result.DonorRemaining,
+		ThiefWorkLen:   thiefWorkLen,
+	}
+}
+
+func bridgePeer(peer PeerSnapshot) BridgePeer {
+	return BridgePeer{
+		ID:        peer.ID,
+		Rank:      peer.Rank,
+		RTTMillis: int(peer.RTT / time.Millisecond),
+		State:     peer.State.String(),
+		LocalWork: append([]TaskID(nil), peer.LocalWork...),
+	}
+}
+
+func peerFromBridge(peer BridgePeer) (PeerSnapshot, error) {
+	state, err := ParsePeerState(peer.State)
+	if err != nil {
+		return PeerSnapshot{}, err
+	}
+
+	return PeerSnapshot{
+		ID:        peer.ID,
+		Rank:      peer.Rank,
+		RTT:       time.Duration(peer.RTTMillis) * time.Millisecond,
+		State:     state,
+		LocalWork: append([]TaskID(nil), peer.LocalWork...),
+	}, nil
+}
+
+func bridgeTask(task Task) BridgeTask {
+	return BridgeTask{
+		ID:            task.ID,
+		BatchID:       task.BatchID,
+		Canceled:      task.Canceled,
+		TimeoutMillis: int(task.Timeout / time.Millisecond),
+		AvoidPeers:    append([]string(nil), task.AvoidPeers...),
+	}
+}
+
+func taskFromBridge(task BridgeTask) Task {
+	return Task{
+		ID:         task.ID,
+		BatchID:    task.BatchID,
+		Canceled:   task.Canceled,
+		Timeout:    time.Duration(task.TimeoutMillis) * time.Millisecond,
+		AvoidPeers: append([]string(nil), task.AvoidPeers...),
+	}
+}
+
+func cloneTraceEvent(event TraceEvent) TraceEvent {
+	if event.Peer != nil {
+		peer := *event.Peer
+		peer.LocalWork = append([]TaskID(nil), peer.LocalWork...)
+		event.Peer = &peer
+	}
+	if event.Task != nil {
+		task := *event.Task
+		task.AvoidPeers = append([]string(nil), task.AvoidPeers...)
+		event.Task = &task
+	}
+	event.Work = append([]TaskID(nil), event.Work...)
+
+	if event.Dispatch != nil {
+		dispatch := *event.Dispatch
+		event.Dispatch = &dispatch
+	}
+	if event.Steal != nil {
+		steal := *event.Steal
+		steal.TaskIDs = append([]TaskID(nil), steal.TaskIDs...)
+		event.Steal = &steal
+	}
+
+	return event
+}

--- a/querysync/trace_test.go
+++ b/querysync/trace_test.go
@@ -1,0 +1,115 @@
+package querysync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTraceRecorderReplaysActorDispatchTask(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	trace := &TraceRecorder{}
+	manager := NewManagerActor(NewSchedulerFSM(DefaultConfig()), 8)
+	manager.SetTraceRecorder(trace)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "avoided",
+		Rank:  0,
+		State: PeerReady,
+	}))
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "selected",
+		Rank:  10,
+		State: PeerReady,
+	}))
+
+	_, ok, err := manager.AskDispatchTask(ctx, Task{
+		ID:         7,
+		Timeout:    5 * time.Second,
+		AvoidPeers: []string{"avoided"},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	result, err := ReplayTrace(ctx, DefaultConfig(), trace.Events())
+	require.NoError(t, err)
+	require.Len(t, result.Dispatches, 1)
+	require.Equal(t, BridgeDispatchWant{
+		OK:            true,
+		PeerID:        "selected",
+		TaskID:        7,
+		TimeoutMillis: 5000,
+	}, result.Dispatches[0])
+}
+
+func TestTraceRecorderReplaysLocalAssignment(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	trace := &TraceRecorder{}
+	manager := NewManagerActor(NewSchedulerFSM(DefaultConfig()), 8)
+	manager.SetTraceRecorder(trace)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "peer",
+		State: PeerReady,
+	}))
+
+	assignment, ok, err := manager.AskAssignLocalTask(ctx, Task{ID: 99})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "peer", assignment.PeerID)
+
+	result, err := ReplayTrace(ctx, DefaultConfig(), trace.Events())
+	require.NoError(t, err)
+	require.Len(t, result.Dispatches, 1)
+	require.EqualValues(t, 99, result.Dispatches[0].TaskID)
+}
+
+func TestTraceRecorderReplaysPeerActorWorkSteal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	trace := &TraceRecorder{}
+	manager := NewManagerActor(NewSchedulerFSM(DefaultConfig()), 8)
+	manager.SetTraceRecorder(trace)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:        "donor",
+		Rank:      0,
+		State:     PeerReady,
+		LocalWork: []TaskID{10, 11, 12},
+	}))
+
+	thief := NewPeerActor("thief", 10, manager, 8)
+	require.NoError(t, thief.Start(ctx))
+	defer thief.Stop()
+
+	steal, ok, err := thief.RequestStolenWork(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.EqualValues(t, 10, steal.TaskID)
+
+	result, err := ReplayTrace(ctx, DefaultConfig(), trace.Events())
+	require.NoError(t, err)
+	require.Len(t, result.Steals, 1)
+	require.Equal(t, BridgeStealWant{
+		OK:             true,
+		ThiefID:        "thief",
+		DonorID:        "donor",
+		TaskID:         10,
+		TaskIDs:        []TaskID{10, 11},
+		DonorRemaining: 1,
+		ThiefWorkLen:   2,
+	}, result.Steals[0])
+}

--- a/querysync/types.go
+++ b/querysync/types.go
@@ -1,0 +1,219 @@
+package querysync
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	// DefaultMinQueryTimeout is the minimum timeout for a single peer query
+	// attempt. It matches the existing query manager floor.
+	DefaultMinQueryTimeout = 2 * time.Second
+
+	// DefaultMaxQueryTimeout is the maximum timeout for a single peer query
+	// attempt.
+	DefaultMaxQueryTimeout = 32 * time.Second
+
+	// DefaultRTTMultiplier is applied to the latest peer RTT sample to
+	// produce the per-peer timeout floor.
+	DefaultRTTMultiplier = 8
+
+	// DefaultMaxPeerOutstanding is the maximum amount of work a peer may
+	// own at once, counting both its active query slot and its unstarted
+	// local queue. This gives each peer a real bounded queue while keeping
+	// enough global visibility for work stealing to correct slow owners.
+	DefaultMaxPeerOutstanding = 4
+)
+
+var (
+	// ErrActorStopped is returned when a caller sends a message to an actor
+	// that is shutting down or already stopped.
+	ErrActorStopped = errors.New("actor stopped")
+
+	// ErrUnknownPeer is returned when an event references a peer that is not
+	// present in the FSM.
+	ErrUnknownPeer = errors.New("unknown peer")
+
+	// ErrInvalidPeer is returned when a malformed peer snapshot is added to
+	// the FSM.
+	ErrInvalidPeer = errors.New("invalid peer")
+)
+
+// PeerState is the scheduling state that matters to the sync manager. A peer
+// can be connected while still being unable to accept work, so blocked is a
+// first-class state rather than an error path.
+type PeerState uint8
+
+const (
+	PeerReady PeerState = iota
+	PeerBusy
+	PeerBlocked
+	PeerQuarantined
+	PeerDown
+)
+
+// String returns a stable lowercase form used by model bridge fixtures.
+func (p PeerState) String() string {
+	switch p {
+	case PeerReady:
+		return "ready"
+	case PeerBusy:
+		return "busy"
+	case PeerBlocked:
+		return "blocked"
+	case PeerQuarantined:
+		return "quarantined"
+	case PeerDown:
+		return "down"
+	default:
+		return fmt.Sprintf("unknown(%d)", p)
+	}
+}
+
+// ParsePeerState parses the stable fixture form of a peer state.
+func ParsePeerState(state string) (PeerState, error) {
+	switch state {
+	case "ready":
+		return PeerReady, nil
+	case "busy":
+		return PeerBusy, nil
+	case "blocked":
+		return PeerBlocked, nil
+	case "quarantined":
+		return PeerQuarantined, nil
+	case "down":
+		return PeerDown, nil
+	default:
+		return PeerDown, fmt.Errorf("unknown peer state %q", state)
+	}
+}
+
+// TaskID identifies a unit of query or sync work.
+type TaskID uint64
+
+// Task is the scheduler's global work item. The concrete Bitcoin request stays
+// outside this model; here we care about identity, batch ownership, and
+// cancellation.
+type Task struct {
+	ID       TaskID
+	BatchID  uint64
+	Canceled bool
+
+	// Timeout optionally overrides the scheduler's base timeout for this
+	// task. This lets the production query manager retain per-query
+	// backoff while dispatching through a long-lived scheduler actor.
+	Timeout time.Duration
+
+	// AvoidPeers is the set of peer IDs that should not receive this task
+	// unless the caller retries with a different task view. Production uses
+	// this for immediate retry avoidance and cooldown fallback.
+	AvoidPeers []string
+}
+
+// PeerSnapshot is the pure FSM view of a peer actor.
+type PeerSnapshot struct {
+	ID        string
+	Rank      int
+	RTT       time.Duration
+	State     PeerState
+	LocalWork []TaskID
+}
+
+func (p PeerSnapshot) clone() PeerSnapshot {
+	p.LocalWork = append([]TaskID(nil), p.LocalWork...)
+	return p
+}
+
+// Assignment is the command produced when the manager FSM dispatches work.
+type Assignment struct {
+	PeerID  string
+	TaskID  TaskID
+	Timeout time.Duration
+}
+
+// StealResult describes the bounded transfer performed by work stealing.
+type StealResult struct {
+	ThiefID        string
+	DonorID        string
+	TaskID         TaskID
+	TaskIDs        []TaskID
+	DonorRemaining int
+}
+
+// Config holds deterministic scheduler parameters. Keeping these values in a
+// struct makes it straightforward for the P bridge and property tests to run
+// the same transition rules with explicit bounds.
+type Config struct {
+	BaseTimeout   time.Duration
+	MinTimeout    time.Duration
+	MaxTimeout    time.Duration
+	RTTMultiplier int
+
+	// MaxPeerOutstanding caps the number of tasks a peer can own at once,
+	// counting an active task as one slot. A busy peer with a cap of four
+	// may therefore own at most three unstarted local tasks.
+	MaxPeerOutstanding int
+}
+
+// DefaultConfig returns the production-intent scheduler bounds.
+func DefaultConfig() Config {
+	return Config{
+		BaseTimeout:        DefaultMinQueryTimeout,
+		MinTimeout:         DefaultMinQueryTimeout,
+		MaxTimeout:         DefaultMaxQueryTimeout,
+		RTTMultiplier:      DefaultRTTMultiplier,
+		MaxPeerOutstanding: DefaultMaxPeerOutstanding,
+	}
+}
+
+func (c Config) normalize() Config {
+	defaults := DefaultConfig()
+	if c.BaseTimeout <= 0 {
+		c.BaseTimeout = defaults.BaseTimeout
+	}
+	if c.MinTimeout <= 0 {
+		c.MinTimeout = defaults.MinTimeout
+	}
+	if c.MaxTimeout <= 0 {
+		c.MaxTimeout = defaults.MaxTimeout
+	}
+	if c.RTTMultiplier <= 0 {
+		c.RTTMultiplier = defaults.RTTMultiplier
+	}
+	if c.MaxPeerOutstanding <= 0 {
+		c.MaxPeerOutstanding = defaults.MaxPeerOutstanding
+	}
+
+	return c
+}
+
+// QueryTimeoutForPeer is the Go implementation of the P model timeout rule:
+//
+//	timeout = clamp(max(base_timeout, latest_rtt * multiplier), min, max)
+//
+// A zero RTT means no sample is available, so the base timeout remains in
+// force after the minimum floor is applied.
+func QueryTimeoutForPeer(baseTimeout time.Duration, peer PeerSnapshot,
+	cfg Config) time.Duration {
+
+	cfg = cfg.normalize()
+
+	timeout := baseTimeout
+	if timeout < cfg.MinTimeout {
+		timeout = cfg.MinTimeout
+	}
+
+	if peer.RTT > 0 {
+		rttTimeout := peer.RTT * time.Duration(cfg.RTTMultiplier)
+		if rttTimeout > timeout {
+			timeout = rttTimeout
+		}
+	}
+
+	if timeout > cfg.MaxTimeout {
+		return cfg.MaxTimeout
+	}
+
+	return timeout
+}

--- a/querysync/workmanager/log.go
+++ b/querysync/workmanager/log.go
@@ -1,0 +1,23 @@
+package workmanager
+
+import "github.com/btcsuite/btclog"
+
+// log is a logger that is initialized with no output filters. This means the
+// package will not perform any logging by default until the caller requests it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	DisableLog()
+}
+
+// DisableLog disables all library log output. Logging output is disabled by
+// default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/querysync/workmanager/worker.go
+++ b/querysync/workmanager/worker.go
@@ -1,0 +1,289 @@
+package workmanager
+
+import (
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/neutrino/query"
+)
+
+// queryJob is the internal struct that wraps the Query to work on, in
+// addition to some information about the query.
+type queryJob struct {
+	tries              uint8
+	index              uint64
+	timeout            time.Duration
+	encoding           wire.MessageEncoding
+	cancelChan         <-chan struct{}
+	internalCancelChan <-chan struct{}
+	failedPeers        map[string]struct{}
+	createdAt          time.Time
+	ownedAt            time.Time
+	activeAt           time.Time
+	lastStolenAt       time.Time
+	stolenCount        uint16
+	*query.Request
+}
+
+// canceled returns true if the query was canceled by the caller or internally by
+// the work manager.
+func (q *queryJob) canceled() bool {
+	select {
+	case <-q.cancelChan:
+		return true
+	default:
+	}
+
+	select {
+	case <-q.internalCancelChan:
+		return true
+	default:
+		return false
+	}
+}
+
+// queryJob should satisfy the Task interface in order to be sorted by the
+// workQueue.
+var _ Task = (*queryJob)(nil)
+
+// Index returns the queryJob's index within the work queue.
+//
+// NOTE: Part of the Task interface.
+func (q *queryJob) Index() uint64 {
+	return q.index
+}
+
+// jobResult is the final result of the worker's handling of the queryJob.
+type jobResult struct {
+	job  *queryJob
+	peer query.Peer
+	err  error
+}
+
+// worker is responsible for polling work from its work queue, and handing it
+// to the associated peer. It validates incoming responses with the current
+// query's response handler, and polls more work for the peer when it has
+// successfully received a response to the request.
+type worker struct {
+	peer query.Peer
+
+	// nextJob is a channel of queries to be distributed, where the worker
+	// will poll new work from.
+	nextJob chan *queryJob
+}
+
+// A compile-time check to ensure worker satisfies the Worker interface.
+var _ Worker = (*worker)(nil)
+
+// NewWorker creates a new worker associated with the given peer.
+func NewWorker(peer query.Peer) Worker {
+	return &worker{
+		peer:    peer,
+		nextJob: make(chan *queryJob),
+	}
+}
+
+// Run starts the worker. The worker will supply its peer with queries, and
+// handle responses from it. Results for any query handled by this worker will
+// be delivered on the results channel. quit can be closed to immediately make
+// the worker exit.
+//
+// The method is blocking, and should be started in a goroutine. It will run
+// until the peer disconnects or the worker is told to quit.
+//
+// NOTE: Part of the Worker interface.
+func (w *worker) Run(results chan<- *jobResult, quit <-chan struct{}) {
+	peer := w.peer
+
+	// Subscribe to messages from the peer.
+	msgChan, cancel := peer.SubscribeRecvMsg()
+	defer cancel()
+
+	for {
+		log.Tracef("Worker %v waiting for more work", peer.Addr())
+
+		var job *queryJob
+		select {
+		// Poll a new job from the nextJob channel.
+		case job = <-w.nextJob:
+			log.Tracef("Worker %v picked up job with index %v",
+				peer.Addr(), job.Index())
+
+		// Ignore any message received while not working on anything.
+		case msg := <-msgChan:
+			log.Tracef("Worker %v ignoring received msg %T "+
+				"since no job active", peer.Addr(), msg)
+			continue
+
+		// If the peer disconnected, we can exit immediately, as we
+		// weren't working on a query.
+		case <-peer.OnDisconnect():
+			log.Debugf("Peer %v for worker disconnected",
+				peer.Addr())
+			return
+
+		case <-quit:
+			return
+		}
+
+		select {
+		// There is no point in queueing the request if the job already
+		// is canceled, so we check this quickly.
+		case <-job.cancelChan:
+			log.Tracef("Worker %v found job with index %v "+
+				"already canceled", peer.Addr(), job.Index())
+
+			// We break to the below loop, where we'll check the
+			// cancel channel again and the query.ErrJobCanceled
+			// result will be sent back.
+			break
+
+		case <-job.internalCancelChan:
+			log.Tracef("Worker %v found job with index %v "+
+				"already internally canceled (batch timed out)",
+				peer.Addr(), job.Index())
+
+			// We break to the below loop, where we'll check the
+			// internal cancel channel again and the query.ErrJobCanceled
+			// result will be sent back.
+			break
+
+		// We received a non-canceled query job, send it to the peer.
+		default:
+			log.Tracef("Worker %v queuing job %T with index %v",
+				peer.Addr(), job.Req, job.Index())
+
+			peer.QueueMessageWithEncoding(job.Req, nil, job.encoding)
+		}
+
+		// Wait for the correct response to be received from the peer,
+		// or an error happening.
+		var (
+			jobErr  error
+			timeout = time.NewTimer(job.timeout)
+		)
+
+	Loop:
+		for {
+			select {
+			// A message was received from the peer, use the
+			// response handler to check whether it was answering
+			// our request.
+			case resp := <-msgChan:
+				progress := job.HandleResp(
+					job.Req, resp, peer.Addr(),
+				)
+				if !progress.Finished &&
+					query.IsNotFoundResponse(job.Req, resp) {
+
+					jobErr = query.ErrPeerNotFound
+					log.Tracef("Worker %v received notfound "+
+						"for request %T with job index %v",
+						peer.Addr(), job.Req, job.Index())
+
+					break Loop
+				}
+
+				log.Tracef("Worker %v handled msg %T while "+
+					"waiting for response to %T (job=%v). "+
+					"Finished=%v, progressed=%v",
+					peer.Addr(), resp, job.Req, job.Index(),
+					progress.Finished, progress.Progressed)
+
+				// If the response did not answer our query, we
+				// check whether it did progress it.
+				if !progress.Finished {
+					// If it did make progress we reset the
+					// timeout. This ensures that the
+					// queries with multiple responses
+					// expected won't timeout before all
+					// responses have been handled.
+					// TODO(halseth): separate progress
+					// timeout value.
+					if progress.Progressed {
+						timeout.Stop()
+						timeout = time.NewTimer(
+							job.timeout,
+						)
+					}
+					continue Loop
+				}
+
+				// We did get a valid response, and can break
+				// the loop.
+				break Loop
+
+			// If the timeout is reached before a valid response
+			// has been received, we exit with an error.
+			case <-timeout.C:
+				// The query did experience a timeout and will
+				// be given to someone else.
+				jobErr = query.ErrQueryTimeout
+				log.Tracef("Worker %v timeout for request %T "+
+					"with job index %v", peer.Addr(),
+					job.Req, job.Index())
+
+				break Loop
+
+			// If the peer disconnects before giving us a valid
+			// answer, we'll also exit with an error.
+			case <-peer.OnDisconnect():
+				log.Debugf("Peer %v for worker disconnected, "+
+					"cancelling job %v", peer.Addr(),
+					job.Index())
+
+				jobErr = query.ErrPeerDisconnected
+				break Loop
+
+			// If the job was canceled, we report this back to the
+			// work manager.
+			case <-job.cancelChan:
+				log.Tracef("Worker %v job %v canceled",
+					peer.Addr(), job.Index())
+
+				jobErr = query.ErrJobCanceled
+				break Loop
+
+			case <-job.internalCancelChan:
+				log.Tracef("Worker %v job %v internally "+
+					"canceled", peer.Addr(), job.Index())
+
+				jobErr = query.ErrJobCanceled
+				break Loop
+
+			case <-quit:
+				return
+			}
+		}
+
+		// Stop to allow garbage collection.
+		timeout.Stop()
+
+		// We have a result ready for the query, hand it off before
+		// getting a new job.
+		select {
+		case results <- &jobResult{
+			job:  job,
+			peer: peer,
+			err:  jobErr,
+		}:
+		case <-quit:
+			return
+		}
+
+		// If the peer disconnected, we can exit immediately.
+		if jobErr == query.ErrPeerDisconnected {
+			return
+		}
+	}
+}
+
+// NewJob returns a channel where work that is to be handled by the worker can
+// be sent. If the worker reads a queryJob from this channel, it is guaranteed
+// that a response will eventually be deliverd on the results channel (except
+// when the quit channel has been closed).
+//
+// NOTE: Part of the Worker interface.
+func (w *worker) NewJob() chan<- *queryJob {
+	return w.nextJob
+}

--- a/querysync/workmanager/worker_test.go
+++ b/querysync/workmanager/worker_test.go
@@ -1,0 +1,117 @@
+package workmanager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/neutrino/query"
+	"github.com/stretchr/testify/require"
+)
+
+type livePeer struct {
+	requests      chan wire.Message
+	responses     chan<- wire.Message
+	subscriptions chan chan wire.Message
+	quit          chan struct{}
+}
+
+var _ query.Peer = (*livePeer)(nil)
+
+func (l *livePeer) QueueMessageWithEncoding(msg wire.Message,
+	_ chan<- struct{}, _ wire.MessageEncoding) {
+
+	l.requests <- msg
+}
+
+func (l *livePeer) SubscribeRecvMsg() (<-chan wire.Message, func()) {
+	msgChan := make(chan wire.Message)
+	l.subscriptions <- msgChan
+
+	return msgChan, func() {}
+}
+
+func (l *livePeer) Addr() string {
+	return "live-peer"
+}
+
+func (l *livePeer) LastPingMicros() int64 {
+	return 0
+}
+
+func (l *livePeer) OnDisconnect() <-chan struct{} {
+	return l.quit
+}
+
+func TestWorkerNotFoundFailsFast(t *testing.T) {
+	t.Parallel()
+
+	peer := &livePeer{
+		requests:      make(chan wire.Message),
+		subscriptions: make(chan chan wire.Message),
+		quit:          make(chan struct{}),
+	}
+	results := make(chan *jobResult)
+	quit := make(chan struct{})
+	defer close(quit)
+
+	wk := NewWorker(peer)
+	go wk.Run(results, quit)
+
+	select {
+	case peer.responses = <-peer.subscriptions:
+	case <-time.After(time.Second):
+		t.Fatalf("worker did not subscribe")
+	}
+
+	var blockHash chainhash.Hash
+	blockHash[0] = 1
+	inv := wire.NewInvVect(wire.InvTypeWitnessBlock, &blockHash)
+	getData := wire.NewMsgGetData()
+	require.NoError(t, getData.AddInvVect(inv))
+	notFound := wire.NewMsgNotFound()
+	require.NoError(t, notFound.AddInvVect(inv))
+
+	job := &queryJob{
+		index:    1,
+		timeout:  time.Hour,
+		encoding: wire.WitnessEncoding,
+		Request: &query.Request{
+			Req: getData,
+			HandleResp: func(_, _ wire.Message,
+				_ string) query.Progress {
+
+				return query.Progress{}
+			},
+		},
+	}
+
+	select {
+	case wk.NewJob() <- job:
+	case <-time.After(time.Second):
+		t.Fatalf("worker did not accept job")
+	}
+
+	select {
+	case <-peer.requests:
+	case <-time.After(time.Second):
+		t.Fatalf("request was not sent")
+	}
+
+	select {
+	case peer.responses <- notFound:
+	case <-time.After(time.Second):
+		t.Fatalf("worker did not receive notfound")
+	}
+
+	select {
+	case result := <-results:
+		require.Same(t, job, result.job)
+		require.Same(t, peer, result.peer)
+		require.ErrorIs(t, result.err, query.ErrPeerNotFound)
+
+	case <-time.After(time.Second):
+		t.Fatalf("worker did not report notfound")
+	}
+}

--- a/querysync/workmanager/workmanager.go
+++ b/querysync/workmanager/workmanager.go
@@ -1,0 +1,1597 @@
+package workmanager
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/lightninglabs/neutrino/query"
+	"github.com/lightninglabs/neutrino/querysync"
+)
+
+const (
+	// minQueryTimeout is the timeout a query will be initially given. If
+	// the peer given the query fails to respond within the timeout, it
+	// will be given to the next peer with an increased timeout.
+	minQueryTimeout = 2 * time.Second
+
+	// maxQueryTimeout is the maximum timeout given to a single query.
+	maxQueryTimeout = 32 * time.Second
+
+	// queryTimeoutRTTMultiplier is the multiplier applied to a peer's latest
+	// ping RTT sample when deriving a per-peer query timeout floor.
+	queryTimeoutRTTMultiplier = 8
+
+	// scheduleRetryInterval is the delay used when work is available but all
+	// nominally free workers decline a non-blocking job send.
+	scheduleRetryInterval = 10 * time.Millisecond
+
+	// failedPeerCooldown is the period after a failed query attempt during
+	// which the scheduler will prefer other ready peers for new work. If all
+	// peers are only soft-cooling down, the scheduler falls back to them
+	// rather than stalling progress. Non-responsive peers that still appear
+	// connected are hard-cooled for this same period so their unstarted local
+	// work can be reassigned instead of waiting behind a peer that just
+	// failed to answer.
+	failedPeerCooldown = 30 * time.Second
+
+	// nonResponsivePeerFailures is the number of consecutive query
+	// non-responses that escalates a peer from normal retry/cooldown into a
+	// local quarantine and optional external ban.
+	nonResponsivePeerFailures = 3
+
+	// nonResponsivePeerCooldown is the local quarantine duration used when
+	// the caller does not disconnect the peer through OnPeerUnresponsive.
+	nonResponsivePeerCooldown = 10 * time.Minute
+)
+
+type batch struct {
+	requests []*query.Request
+	options  query.Options
+	errChan  chan error
+}
+
+// Worker is the interface that must be satisfied by workers managed by this
+// package's query.WorkManager implementation.
+type Worker interface {
+	// Run starts the worker. The worker will supply its peer with queries,
+	// and handle responses from it. Results for any query handled by this
+	// worker will be delivered on the results channel. quit can be closed
+	// to immediately make the worker exit.
+	//
+	// The method is blocking, and should be started in a goroutine. It
+	// will run until the peer disconnects or the worker is told to quit.
+	Run(results chan<- *jobResult, quit <-chan struct{})
+
+	// NewJob returns a channel where work that is to be handled by the
+	// worker can be sent. If the worker reads a queryJob from this
+	// channel, it is guaranteed that a response will eventually be
+	// delivered on the results channel (except when the quit channel has
+	// been closed).
+	NewJob() chan<- *queryJob
+}
+
+// PeerRanking is an interface that must be satisfied by the underlying module
+// that is used to determine which peers to prioritize querios on.
+type PeerRanking interface {
+	// AddPeer adds a peer to the ranking.
+	AddPeer(peer string)
+
+	// Reward should be called when the peer has succeeded in a query,
+	// increasing the likelihood that it will be picked for subsequent
+	// queries.
+	Reward(peer string)
+
+	// Punish should be called when the peer has failed in a query,
+	// decreasing the likelihood that it will be picked for subsequent
+	// queries.
+	Punish(peer string)
+
+	// Order sorts the slice of peers according to their ranking.
+	Order(peers []string)
+
+	// ResetRanking sets the score of the passed peer to the defaultScore.
+	ResetRanking(peerAddr string)
+}
+
+type peerScorer interface {
+	// Score returns the current rank score for a peer. A lower score is
+	// better.
+	Score(peer string) uint64
+}
+
+// activeWorker wraps a Worker that is currently running, together with the job
+// we have given to it.
+// TODO(halseth): support more than one active job at a time.
+type activeWorker struct {
+	w            Worker
+	peer         query.Peer
+	actor        *querysync.PeerActor
+	activeJob    *queryJob
+	localWork    []*queryJob
+	cooldown     time.Time
+	hardCooldown time.Time
+	quarantine   time.Time
+	onExit       chan struct{}
+}
+
+// Config holds the configuration options for a new sync work manager.
+type Config struct {
+	// ConnectedPeers is a function that returns a channel where all
+	// connected peers will be sent. It is assumed that all current peers
+	// will be sent imemdiately, and new peers as they connect.
+	//
+	// The returned function closure is called to cancel the subscription.
+	ConnectedPeers func() (<-chan query.Peer, func(), error)
+
+	// NewWorker is function closure that should start a new worker. We
+	// make this configurable to easily mock the worker used during tests.
+	NewWorker func(query.Peer) Worker
+
+	// OnMaxTries gives the caller access to the peer once a maximum number
+	// of retries have been attempted. The caller can then access the peer's
+	// address and can choose to punish the peer accordingly.
+	OnMaxTries func(query.Peer)
+
+	// OnPeerUnresponsive gives the caller access to a peer that repeatedly
+	// failed to respond to assigned queries. Callers can use this to extend
+	// the normal peer ban system; the work manager also quarantines the peer
+	// locally so it is not selected while the callback disconnects it.
+	OnPeerUnresponsive func(query.Peer)
+
+	// Ranking is used to rank the connected peers when determining who to
+	// give work to.
+	Ranking PeerRanking
+
+	// SchedulerTrace, if non-nil, records the scheduler actor events used
+	// for dispatch decisions. The resulting trace can be replayed with
+	// querysync.ReplayTrace to compare production behavior with model
+	// invariants.
+	SchedulerTrace *querysync.TraceRecorder
+
+	// SchedulerEvents, if non-nil, records structured scheduler events for
+	// metrics, validation summaries, and live sync diagnostics.
+	SchedulerEvents querysync.SchedulerEventSink
+}
+
+// peerWorkManager is the main access point for outside callers, and satisfies
+// the QueryAccess API. It receives queries to pass to peers, and schedules them
+// among available workers, orchestrating where to send them. It implements the
+// query.WorkManager interface.
+type peerWorkManager struct {
+	cfg *Config
+
+	// newBatches is a channel where new batches of queries will be sent to
+	// the workDispatcher.
+	newBatches chan *batch
+
+	// jobResults is the common channel where results from queries from all
+	// workers will be sent.
+	jobResults chan *jobResult
+
+	quit chan struct{}
+	wg   sync.WaitGroup
+}
+
+// Compile time check to ensure peerWorkManager satisfies the query.WorkManager
+// interface.
+var _ query.WorkManager = (*peerWorkManager)(nil)
+
+// NewWorkManager returns a new query.WorkManager with the regular worker
+// implementation.
+func NewWorkManager(cfg *Config) query.WorkManager {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+	if cfg.NewWorker == nil {
+		cfg.NewWorker = NewWorker
+	}
+	if cfg.Ranking == nil {
+		cfg.Ranking = query.NewPeerRanking()
+	}
+
+	return &peerWorkManager{
+		cfg:        cfg,
+		newBatches: make(chan *batch),
+		jobResults: make(chan *jobResult),
+		quit:       make(chan struct{}),
+	}
+}
+
+// queryTimeoutForPeer returns the query timeout to use for the next attempt on
+// this peer. The job's current timeout is preserved as a lower bound so retry
+// backoff still works across peers.
+func queryTimeoutForPeer(baseTimeout time.Duration, peer query.Peer) time.Duration {
+	return querysync.QueryTimeoutForPeer(
+		baseTimeout, peerSnapshot(peer, 0, querysync.PeerReady),
+		querysync.Config{
+			BaseTimeout:   baseTimeout,
+			MinTimeout:    minQueryTimeout,
+			MaxTimeout:    maxQueryTimeout,
+			RTTMultiplier: queryTimeoutRTTMultiplier,
+		},
+	)
+}
+
+func peerSnapshot(peer query.Peer, rank int, state querysync.PeerState) querysync.PeerSnapshot {
+	return querysync.PeerSnapshot{
+		ID:    peer.Addr(),
+		Rank:  rank,
+		RTT:   time.Duration(peer.LastPingMicros()) * time.Microsecond,
+		State: state,
+	}
+}
+
+func workerRanks(workers map[string]*activeWorker,
+	ranking PeerRanking) map[string]int {
+
+	peers := make([]string, 0, len(workers))
+	for peer := range workers {
+		peers = append(peers, peer)
+	}
+	ranking.Order(peers)
+
+	ranks := make(map[string]int, len(peers))
+	if scorer, ok := ranking.(peerScorer); ok {
+		for _, peer := range peers {
+			ranks[peer] = int(scorer.Score(peer))
+		}
+
+		return ranks
+	}
+
+	for rank, peer := range peers {
+		ranks[peer] = rank
+	}
+
+	return ranks
+}
+
+func newQuerySchedulerManager(baseTimeout time.Duration) *querysync.ManagerActor {
+	return querysync.NewManagerActor(
+		querysync.NewSchedulerFSM(querysync.Config{
+			BaseTimeout:   baseTimeout,
+			MinTimeout:    minQueryTimeout,
+			MaxTimeout:    maxQueryTimeout,
+			RTTMultiplier: queryTimeoutRTTMultiplier,
+		}), 128,
+	)
+}
+
+func sortedPeerSet(peers map[string]struct{}) []string {
+	peerIDs := make([]string, 0, len(peers))
+	for peerID := range peers {
+		peerIDs = append(peerIDs, peerID)
+	}
+	sort.Strings(peerIDs)
+
+	return peerIDs
+}
+
+func isNonResponseErr(err error) bool {
+	return err == query.ErrQueryTimeout || err == query.ErrPeerDisconnected
+}
+
+func isHardCooldownErr(err error) bool {
+	return err == query.ErrQueryTimeout || err == query.ErrPeerNotFound
+}
+
+func recordSchedulerEvent(sink querysync.SchedulerEventSink,
+	event querysync.SchedulerEvent) {
+
+	if sink == nil {
+		return
+	}
+	if event.At.IsZero() {
+		event.At = time.Now()
+	}
+
+	sink.RecordSchedulerEvent(event)
+}
+
+func durationSince(now, then time.Time) time.Duration {
+	if then.IsZero() {
+		return 0
+	}
+
+	return now.Sub(then)
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	return err.Error()
+}
+
+func oldestLocalQueueAge(now time.Time, worker *activeWorker) time.Duration {
+	var oldest time.Duration
+	for _, job := range worker.localWork {
+		age := durationSince(now, job.ownedAt)
+		if age == 0 {
+			continue
+		}
+		if oldest == 0 || age > oldest {
+			oldest = age
+		}
+	}
+
+	return oldest
+}
+
+func peerStateEvent(state querysync.PeerState) querysync.PeerEvent {
+	switch state {
+	case querysync.PeerReady:
+		return querysync.PeerReadyEvent{}
+
+	case querysync.PeerBlocked:
+		return querysync.PeerBlockedEvent{}
+
+	case querysync.PeerQuarantined:
+		return querysync.PeerQuarantinedEvent{}
+
+	case querysync.PeerDown:
+		return querysync.PeerDownEvent{}
+
+	default:
+		return nil
+	}
+}
+
+func updateWorkerPeerState(ctx context.Context,
+	scheduler *querysync.ManagerActor, worker *activeWorker, rank int,
+	state querysync.PeerState) error {
+
+	snapshot := peerSnapshot(worker.peer, rank, state)
+	if worker.actor == nil {
+		return scheduler.AddPeer(ctx, snapshot)
+	}
+
+	if err := worker.actor.Send(ctx, querysync.PeerRankEvent{
+		Rank: rank,
+	}); err != nil {
+		return err
+	}
+
+	if err := worker.actor.Send(ctx, querysync.PeerRTTEvent{
+		RTT: snapshot.RTT,
+	}); err != nil {
+		return err
+	}
+
+	// Busy is entered only when a concrete assignment is accepted by the
+	// worker. Re-sending PeerAssignedEvent during ordinary scheduler
+	// refreshes would incorrectly look like a second concurrent assignment.
+	if state == querysync.PeerBusy {
+		return nil
+	}
+
+	event := peerStateEvent(state)
+	if event == nil {
+		return nil
+	}
+
+	return worker.actor.Send(ctx, event)
+}
+
+func setWorkerPeerState(ctx context.Context,
+	scheduler *querysync.ManagerActor, worker *activeWorker,
+	state querysync.PeerState) error {
+
+	if worker.actor != nil {
+		event := peerStateEvent(state)
+		if event == nil {
+			return nil
+		}
+
+		return worker.actor.Send(ctx, event)
+	}
+
+	return scheduler.UpdatePeerState(ctx, worker.peer.Addr(), state)
+}
+
+func assignWorkerJob(ctx context.Context,
+	scheduler *querysync.ManagerActor, worker *activeWorker,
+	job *queryJob) error {
+
+	if worker.actor != nil {
+		return worker.actor.Send(ctx, querysync.PeerAssignedEvent{
+			TaskID: querysync.TaskID(job.index),
+		})
+	}
+
+	return scheduler.UpdatePeerState(
+		ctx, worker.peer.Addr(), querysync.PeerBusy,
+	)
+}
+
+func workerLocalWorkIDs(worker *activeWorker) []querysync.TaskID {
+	ids := make([]querysync.TaskID, 0, len(worker.localWork))
+	for _, job := range worker.localWork {
+		ids = append(ids, querysync.TaskID(job.index))
+	}
+
+	return ids
+}
+
+func setWorkerLocalWork(ctx context.Context,
+	scheduler *querysync.ManagerActor, worker *activeWorker) error {
+
+	return scheduler.SetPeerLocalWork(
+		ctx, worker.peer.Addr(), workerLocalWorkIDs(worker),
+	)
+}
+
+func removeWorkerLocalWork(worker *activeWorker,
+	taskID querysync.TaskID) (*queryJob, bool) {
+
+	for i, job := range worker.localWork {
+		if querysync.TaskID(job.index) != taskID {
+			continue
+		}
+
+		worker.localWork = append(
+			worker.localWork[:i], worker.localWork[i+1:]...,
+		)
+
+		return job, true
+	}
+
+	return nil, false
+}
+
+func scheduleQueryJob(workers map[string]*activeWorker, ranking PeerRanking,
+	job *queryJob, batchNum uint64,
+	blocked map[string]struct{}, ignoreCooldown bool) (
+	querysync.Assignment, bool) {
+
+	ctx := context.Background()
+	scheduler := newQuerySchedulerManager(job.timeout)
+	scheduler.Start(ctx)
+	defer scheduler.Stop()
+
+	return scheduleQueryJobWithScheduler(
+		ctx, scheduler, workers, ranking, job, batchNum, blocked,
+		ignoreCooldown,
+	)
+}
+
+func scheduleQueryJobWithScheduler(ctx context.Context,
+	scheduler *querysync.ManagerActor, workers map[string]*activeWorker,
+	ranking PeerRanking, job *queryJob, batchNum uint64,
+	blocked map[string]struct{}, ignoreCooldown bool) (
+	querysync.Assignment, bool) {
+
+	ranks := workerRanks(workers, ranking)
+	now := time.Now()
+	avoidPeers := make(map[string]struct{})
+
+	for peerAddr, worker := range workers {
+		state := querysync.PeerReady
+		switch {
+		case worker.activeJob != nil:
+			state = querysync.PeerBusy
+		case now.Before(worker.quarantine):
+			state = querysync.PeerQuarantined
+			avoidPeers[peerAddr] = struct{}{}
+		case now.Before(worker.hardCooldown):
+			state = querysync.PeerBlocked
+			avoidPeers[peerAddr] = struct{}{}
+		case !ignoreCooldown && now.Before(worker.cooldown):
+			state = querysync.PeerBlocked
+			avoidPeers[peerAddr] = struct{}{}
+		case blocked != nil:
+			if _, ok := blocked[peerAddr]; ok {
+				state = querysync.PeerBlocked
+				avoidPeers[peerAddr] = struct{}{}
+			}
+		}
+
+		err := updateWorkerPeerState(
+			ctx, scheduler, worker, ranks[peerAddr], state,
+		)
+		if err != nil {
+			log.Warnf("Unable to update peer %v in query scheduler: %v",
+				peerAddr, err)
+		}
+	}
+
+	assignment, ok, err := scheduler.AskDispatchTask(ctx, querysync.Task{
+		ID:         querysync.TaskID(job.index),
+		BatchID:    batchNum,
+		Canceled:   job.canceled(),
+		Timeout:    job.timeout,
+		AvoidPeers: sortedPeerSet(avoidPeers),
+	})
+	if err != nil {
+		log.Warnf("Unable to dispatch query job %v: %v",
+			job.index, err)
+
+		return querysync.Assignment{}, false
+	}
+
+	return assignment, ok
+}
+
+func assignQueryJobToLocalWorkWithScheduler(ctx context.Context,
+	scheduler *querysync.ManagerActor, workers map[string]*activeWorker,
+	ranking PeerRanking, job *queryJob, batchNum uint64,
+	blocked map[string]struct{}, ignoreCooldown bool) (
+	querysync.Assignment, bool) {
+
+	ranks := workerRanks(workers, ranking)
+	now := time.Now()
+	avoidPeers := make(map[string]struct{})
+
+	for peerAddr, worker := range workers {
+		state := querysync.PeerReady
+		switch {
+		case worker.activeJob != nil:
+			state = querysync.PeerBusy
+		case now.Before(worker.quarantine):
+			state = querysync.PeerQuarantined
+			avoidPeers[peerAddr] = struct{}{}
+		case now.Before(worker.hardCooldown):
+			state = querysync.PeerBlocked
+			avoidPeers[peerAddr] = struct{}{}
+		case !ignoreCooldown && now.Before(worker.cooldown):
+			state = querysync.PeerBlocked
+			avoidPeers[peerAddr] = struct{}{}
+		case blocked != nil:
+			if _, ok := blocked[peerAddr]; ok {
+				state = querysync.PeerBlocked
+				avoidPeers[peerAddr] = struct{}{}
+			}
+		}
+
+		err := updateWorkerPeerState(
+			ctx, scheduler, worker, ranks[peerAddr], state,
+		)
+		if err != nil {
+			log.Warnf("Unable to update peer %v in query scheduler: %v",
+				peerAddr, err)
+		}
+
+		if err := setWorkerLocalWork(ctx, scheduler, worker); err != nil {
+			log.Warnf("Unable to update peer %v local work in "+
+				"query scheduler: %v", peerAddr, err)
+		}
+	}
+
+	assignment, ok, err := scheduler.AskAssignLocalTask(ctx, querysync.Task{
+		ID:         querysync.TaskID(job.index),
+		BatchID:    batchNum,
+		Canceled:   job.canceled(),
+		Timeout:    job.timeout,
+		AvoidPeers: sortedPeerSet(avoidPeers),
+	})
+	if err != nil {
+		log.Warnf("Unable to assign query job %v: %v", job.index, err)
+
+		return querysync.Assignment{}, false
+	}
+
+	return assignment, ok
+}
+
+// Start starts the peerWorkManager.
+//
+// NOTE: this is part of the query.WorkManager interface.
+func (w *peerWorkManager) Start() error {
+	w.wg.Add(1)
+	go w.workDispatcher()
+
+	return nil
+}
+
+// Stop stops the peerWorkManager and all underlying goroutines.
+//
+// NOTE: this is part of the query.WorkManager interface.
+func (w *peerWorkManager) Stop() error {
+	close(w.quit)
+	w.wg.Wait()
+
+	return nil
+}
+
+// workDispatcher receives batches of queries to be performed from external
+// callers, and dispatches these to active workers.  It makes sure to
+// prioritize the queries in the order they come in, such that early queries
+// will be attempted completed first.
+//
+// NOTE: MUST be run as a goroutine.
+func (w *peerWorkManager) workDispatcher() {
+	defer w.wg.Done()
+
+	// Get a peer subscription. We do it in this goroutine rather than
+	// Start to avoid a deadlock when starting the query.WorkManager fetches
+	// the peers from the server.
+	peersConnected, cancel, err := w.cfg.ConnectedPeers()
+	if err != nil {
+		log.Errorf("Unable to get connected peers: %v", err)
+		return
+	}
+	defer cancel()
+
+	// Init a work queue which will be used to sort the incoming queries in
+	// a first come first served fashion.
+	work := &workQueue[*queryJob]{}
+
+	type batchProgress struct {
+		noRetryMax bool
+		maxRetries uint8
+		timer      *time.Timer
+		rem        int
+		errChan    chan error
+		cancelChan chan struct{}
+	}
+
+	// We set up a batch index counter to keep track of batches that still
+	// have queries in flight. This lets us track when all queries for a
+	// batch have been finished, and return an (non-)error to the caller.
+	batchIndex := uint64(0)
+	currentBatches := make(map[uint64]*batchProgress)
+	batchTimeouts := make(chan uint64)
+
+	// When the work dispatcher exits, we'll loop through the remaining
+	// batches and send on their error channel.
+	defer func() {
+		for _, b := range currentBatches {
+			if b.timer != nil {
+				b.timer.Stop()
+			}
+			b.errChan <- query.ErrWorkManagerShuttingDown
+		}
+	}()
+
+	// We set up a counter that we'll increase with each incoming query,
+	// and will serve as the priority of each. In addition we map each
+	// query to the batch they are part of.
+	queryIndex := uint64(0)
+	currentQueries := make(map[uint64]uint64)
+
+	workers := make(map[string]*activeWorker)
+	nonResponseFailures := make(map[string]uint8)
+	quarantinedPeers := make(map[string]time.Time)
+	sendBlockedWorkers := make(map[string]struct{})
+	var scheduleRetry <-chan time.Time
+	defer func() {
+		for _, worker := range workers {
+			if worker.actor != nil {
+				worker.actor.Stop()
+			}
+		}
+	}()
+
+	schedulerCtx, stopScheduler := context.WithCancel(context.Background())
+	defer stopScheduler()
+
+	scheduler := newQuerySchedulerManager(minQueryTimeout)
+	scheduler.SetTraceRecorder(w.cfg.SchedulerTrace)
+	scheduler.SetEventSink(w.cfg.SchedulerEvents)
+	scheduler.Start(schedulerCtx)
+	defer scheduler.Stop()
+
+	armScheduleRetry := func() {
+		if scheduleRetry == nil {
+			scheduleRetry = time.After(scheduleRetryInterval)
+		}
+	}
+
+	finishBatch := func(batchNum uint64, batch *batchProgress,
+		err error, cancel bool) {
+
+		if batch.timer != nil {
+			batch.timer.Stop()
+		}
+
+		batch.errChan <- err
+		delete(currentBatches, batchNum)
+
+		if cancel && batch.cancelChan != nil {
+			close(batch.cancelChan)
+		}
+	}
+
+	dropCanceledJob := func(job *queryJob) {
+		batchNum, ok := currentQueries[job.index]
+		delete(currentQueries, job.index)
+		if !ok {
+			return
+		}
+
+		batch, ok := currentBatches[batchNum]
+		if ok {
+			finishBatch(batchNum, batch, query.ErrJobCanceled, true)
+			log.Debugf("Canceled batch %v", batchNum)
+		}
+	}
+
+	rankedWorkerIDs := func() []string {
+		ids := make([]string, 0, len(workers))
+		for id := range workers {
+			ids = append(ids, id)
+		}
+		w.cfg.Ranking.Order(ids)
+
+		return ids
+	}
+
+	removeWorker := func(peerID string, worker *activeWorker) {
+		for _, job := range worker.localWork {
+			work.Push(job)
+		}
+		worker.localWork = nil
+
+		delete(workers, peerID)
+		delete(sendBlockedWorkers, peerID)
+		if worker.actor != nil {
+			if err := worker.actor.Send(
+				schedulerCtx, querysync.PeerDownEvent{},
+			); err != nil {
+				log.Warnf("Unable to mark peer %v down in "+
+					"query scheduler: %v", peerID, err)
+			}
+			worker.actor.Stop()
+		}
+
+		if err := scheduler.RemovePeer(schedulerCtx, peerID); err != nil {
+			log.Warnf("Unable to remove peer %v from query "+
+				"scheduler: %v", peerID, err)
+		}
+	}
+
+	moveStolenWork := func(result querysync.StealResult) bool {
+		donor := workers[result.DonorID]
+		thief := workers[result.ThiefID]
+		if donor == nil || thief == nil {
+			return false
+		}
+
+		stolenTasks := result.TaskIDs
+		if len(stolenTasks) == 0 {
+			stolenTasks = []querysync.TaskID{result.TaskID}
+		}
+
+		now := time.Now()
+		moved := make([]*queryJob, 0, len(stolenTasks))
+		var stealAge time.Duration
+		var maxStolenCount uint16
+		for _, taskID := range stolenTasks {
+			job, ok := removeWorkerLocalWork(donor, taskID)
+			if !ok {
+				restored := append([]*queryJob(nil), moved...)
+				donor.localWork = append(restored, donor.localWork...)
+
+				log.Warnf("Peer %v stole job %v from peer %v, "+
+					"but donor no longer owns it",
+					result.ThiefID, taskID, result.DonorID)
+
+				return false
+			}
+
+			age := durationSince(now, job.ownedAt)
+			if age > stealAge {
+				stealAge = age
+			}
+
+			moved = append(moved, job)
+		}
+
+		for _, job := range moved {
+			job.ownedAt = now
+			job.lastStolenAt = now
+			job.stolenCount++
+			if job.stolenCount > maxStolenCount {
+				maxStolenCount = job.stolenCount
+			}
+		}
+
+		thief.localWork = append(thief.localWork, moved...)
+		donorAge := oldestLocalQueueAge(now, donor)
+		thiefAge := oldestLocalQueueAge(now, thief)
+
+		recordSchedulerEvent(w.cfg.SchedulerEvents, querysync.SchedulerEvent{
+			Type:             querysync.SchedulerEventWorkStealApplied,
+			At:               now,
+			PeerID:           result.ThiefID,
+			ThiefID:          result.ThiefID,
+			DonorID:          result.DonorID,
+			TaskID:           result.TaskID,
+			TaskIDs:          stolenTasks,
+			Steal:            &result,
+			OK:               true,
+			StealAge:         stealAge,
+			DonorLocalAge:    donorAge,
+			ThiefLocalAge:    thiefAge,
+			DonorLocalLen:    len(donor.localWork),
+			ThiefLocalLen:    len(thief.localWork),
+			StolenTaskCount:  len(moved),
+			StolenCount:      maxStolenCount,
+			LocalWorkLen:     len(thief.localWork),
+			LocalQueueAge:    thiefAge,
+			CooldownDuration: 0,
+		})
+
+		log.Debugf("Peer %v stole %v job(s) %v from peer %v "+
+			"(donor_remaining=%v, steal_age=%v, donor_queue=%v, "+
+			"thief_queue=%v)", result.ThiefID, len(moved),
+			stolenTasks, result.DonorID, result.DonorRemaining,
+			stealAge, len(donor.localWork), len(thief.localWork))
+
+		return true
+	}
+
+	dropCanceledLocalWork := func(peerID string, worker *activeWorker) {
+		for len(worker.localWork) > 0 &&
+			worker.localWork[0].canceled() {
+
+			job := worker.localWork[0]
+			worker.localWork = worker.localWork[1:]
+			if err := setWorkerLocalWork(
+				schedulerCtx, scheduler, worker,
+			); err != nil {
+				log.Warnf("Unable to drop canceled local work "+
+					"for peer %v in query scheduler: %v",
+					peerID, err)
+			}
+			dropCanceledJob(job)
+		}
+	}
+
+	dispatchOwnedWork := func() bool {
+		now := time.Now()
+		for _, peerID := range rankedWorkerIDs() {
+			worker := workers[peerID]
+			if worker == nil || worker.activeJob != nil {
+				continue
+			}
+			if now.Before(worker.quarantine) {
+
+				continue
+			}
+			if now.Before(worker.hardCooldown) {
+				for _, job := range worker.localWork {
+					work.Push(job)
+				}
+				worker.localWork = nil
+				if err := setWorkerLocalWork(
+					schedulerCtx, scheduler, worker,
+				); err != nil {
+					log.Warnf("Unable to clear hard-cooldown "+
+						"local work for peer %v in query "+
+						"scheduler: %v", peerID, err)
+				}
+
+				continue
+			}
+			if now.Before(worker.cooldown) &&
+				len(worker.localWork) == 0 {
+
+				continue
+			}
+
+			dropCanceledLocalWork(peerID, worker)
+			if len(worker.localWork) == 0 && worker.actor != nil {
+				steal, ok, err := worker.actor.RequestStolenWork(
+					schedulerCtx,
+				)
+				if err != nil {
+					log.Warnf("Peer %v failed to request "+
+						"stolen work: %v", peerID, err)
+				} else if ok {
+					moveStolenWork(steal)
+				}
+			}
+
+			dropCanceledLocalWork(peerID, worker)
+			if len(worker.localWork) == 0 {
+				continue
+			}
+
+			if err := setWorkerPeerState(
+				schedulerCtx, scheduler, worker,
+				querysync.PeerReady,
+			); err != nil {
+				log.Warnf("Unable to mark peer %v ready in "+
+					"query scheduler: %v", peerID, err)
+			}
+
+			job := worker.localWork[0]
+			originalTimeout := job.timeout
+			job.timeout = queryTimeoutForPeer(job.timeout, worker.peer)
+			sentAt := time.Now()
+			localQueueAge := durationSince(sentAt, job.ownedAt)
+			taskAge := durationSince(sentAt, job.createdAt)
+
+			select {
+			case worker.w.NewJob() <- job:
+				delete(sendBlockedWorkers, peerID)
+				worker.localWork = worker.localWork[1:]
+				if err := setWorkerLocalWork(
+					schedulerCtx, scheduler, worker,
+				); err != nil {
+					log.Warnf("Unable to update peer %v "+
+						"local work in query scheduler: %v",
+						peerID, err)
+				}
+
+				worker.activeJob = job
+				job.activeAt = sentAt
+				if err := assignWorkerJob(
+					schedulerCtx, scheduler, worker, job,
+				); err != nil {
+					log.Warnf("Unable to mark peer %v busy "+
+						"in query scheduler: %v", peerID,
+						err)
+				}
+
+				recordSchedulerEvent(
+					w.cfg.SchedulerEvents,
+					querysync.SchedulerEvent{
+						Type:          querysync.SchedulerEventTaskSent,
+						At:            sentAt,
+						PeerID:        peerID,
+						TaskID:        querysync.TaskID(job.index),
+						Timeout:       job.timeout,
+						TaskAge:       taskAge,
+						LocalQueueAge: localQueueAge,
+						LocalWorkLen:  len(worker.localWork),
+						StolenCount:   job.stolenCount,
+						Attempts:      job.tries,
+						OK:            true,
+					},
+				)
+
+				log.Tracef("Sent owned job %v to worker %v "+
+					"(queue_age=%v, task_age=%v, timeout=%v, "+
+					"local_remaining=%v)", job.Index(), peerID,
+					localQueueAge, taskAge, job.timeout,
+					len(worker.localWork))
+				scheduleRetry = nil
+
+				return true
+
+			case <-worker.onExit:
+				job.timeout = originalTimeout
+				removeWorker(peerID, worker)
+
+				return true
+
+			case <-w.quit:
+				return false
+
+			default:
+				job.timeout = originalTimeout
+				sendBlockedWorkers[peerID] = struct{}{}
+				if err := setWorkerPeerState(
+					schedulerCtx, scheduler, worker,
+					querysync.PeerBlocked,
+				); err != nil {
+					log.Warnf("Unable to mark peer %v "+
+						"blocked in query scheduler: %v",
+						peerID, err)
+				}
+				armScheduleRetry()
+			}
+		}
+
+		return false
+	}
+
+Loop:
+	for {
+		if dispatchOwnedWork() {
+			continue Loop
+		}
+
+		// If the work queue is non-empty, we'll take out the first
+		// element in order to distribute it to a worker.
+		if work.Len() > 0 {
+			next, _ := work.Peek()
+			if next.canceled() {
+				work.Pop()
+				batchNum, ok := currentQueries[next.index]
+				delete(currentQueries, next.index)
+
+				if ok {
+					batch, ok := currentBatches[batchNum]
+					if ok {
+						finishBatch(
+							batchNum, batch, query.ErrJobCanceled,
+							true,
+						)
+						log.Debugf(
+							"Canceled batch %v", batchNum,
+						)
+					}
+				}
+
+				continue Loop
+			}
+
+			batchNum, ok := currentQueries[next.index]
+			if !ok {
+				log.Warnf("Query(%d) found in work queue "+
+					"without batch tracking", next.index)
+				work.Pop()
+				continue Loop
+			}
+
+			blockedWorkers := make(map[string]struct{})
+			hardAvoidWorkers := make(map[string]struct{})
+			currentFailedPeers := 0
+			for peer := range next.failedPeers {
+				if _, ok := workers[peer]; ok {
+					currentFailedPeers++
+				}
+			}
+			if currentFailedPeers < len(workers) {
+				for peer := range next.failedPeers {
+					if _, ok := workers[peer]; ok {
+						hardAvoidWorkers[peer] = struct{}{}
+					}
+				}
+			}
+			for peer := range sendBlockedWorkers {
+				blockedWorkers[peer] = struct{}{}
+			}
+
+			now := time.Now()
+			softAvoidWorkers := make(map[string]struct{})
+			for peer, worker := range workers {
+				if now.Before(worker.quarantine) {
+					blockedWorkers[peer] = struct{}{}
+					continue
+				}
+				if now.Before(worker.hardCooldown) {
+					blockedWorkers[peer] = struct{}{}
+					continue
+				}
+				if now.Before(worker.cooldown) {
+					softAvoidWorkers[peer] = struct{}{}
+				}
+			}
+
+			for peer := range hardAvoidWorkers {
+				blockedWorkers[peer] = struct{}{}
+			}
+			for peer := range softAvoidWorkers {
+				blockedWorkers[peer] = struct{}{}
+			}
+
+			avoidingCooldown := len(softAvoidWorkers) > 0
+			ignoreCooldown := false
+			for {
+				assignment, ok := assignQueryJobToLocalWorkWithScheduler(
+					schedulerCtx, scheduler, workers,
+					w.cfg.Ranking, next, batchNum, blockedWorkers,
+					ignoreCooldown,
+				)
+				if !ok {
+					if avoidingCooldown {
+						for peer := range softAvoidWorkers {
+							delete(blockedWorkers, peer)
+						}
+						avoidingCooldown = false
+						ignoreCooldown = true
+						continue
+					}
+
+					break
+				}
+
+				p := assignment.PeerID
+				r, ok := workers[p]
+				if !ok {
+					blockedWorkers[p] = struct{}{}
+					continue
+				}
+
+				next.timeout = assignment.Timeout
+				ownedAt := time.Now()
+				if next.createdAt.IsZero() {
+					next.createdAt = ownedAt
+				}
+				next.ownedAt = ownedAt
+				r.localWork = append(r.localWork, next)
+				work.Pop()
+				recordSchedulerEvent(
+					w.cfg.SchedulerEvents,
+					querysync.SchedulerEvent{
+						Type:         querysync.SchedulerEventTaskLocalQueued,
+						At:           ownedAt,
+						PeerID:       p,
+						TaskID:       querysync.TaskID(next.index),
+						BatchID:      batchNum,
+						Timeout:      next.timeout,
+						TaskAge:      durationSince(ownedAt, next.createdAt),
+						LocalWorkLen: len(r.localWork),
+						Attempts:     next.tries,
+						OK:           true,
+					},
+				)
+				log.Tracef("Assigned job %v to peer %v local "+
+					"work queue (task_age=%v, local_len=%v)",
+					next.Index(), p,
+					durationSince(ownedAt, next.createdAt),
+					len(r.localWork))
+
+				continue Loop
+			}
+
+			if len(blockedWorkers) > 0 {
+				armScheduleRetry()
+			}
+		}
+
+		// Otherwise the work queue is empty, or there are no workers
+		// to distribute work to, so we'll just wait for a result of a
+		// previous query to come back, a new peer to connect, or for a
+		// new batch of queries to be scheduled.
+		select {
+		// Spin up a goroutine that runs a worker each time a peer
+		// connects.
+		case peer := <-peersConnected:
+			log.Debugf("Starting worker for peer %v",
+				peer.Addr())
+
+			r := w.cfg.NewWorker(peer)
+			peerActor := querysync.NewPeerActor(
+				peer.Addr(), 0, scheduler, 128,
+			)
+			if err := peerActor.Start(schedulerCtx); err != nil {
+				log.Warnf("Unable to start query peer actor for "+
+					"%v: %v", peer.Addr(), err)
+				peerActor = nil
+			}
+
+			// We'll create a channel that will close after the
+			// worker's Run method returns, to know when we can
+			// remove it from our set of active workers.
+			onExit := make(chan struct{})
+			workers[peer.Addr()] = &activeWorker{
+				w:          r,
+				peer:       peer,
+				actor:      peerActor,
+				activeJob:  nil,
+				quarantine: quarantinedPeers[peer.Addr()],
+				onExit:     onExit,
+			}
+
+			w.cfg.Ranking.AddPeer(peer.Addr())
+			if peerActor == nil {
+				err := scheduler.AddPeer(schedulerCtx,
+					querysync.PeerSnapshot{
+						ID:    peer.Addr(),
+						State: querysync.PeerReady,
+					},
+				)
+				if err != nil {
+					log.Warnf("Unable to add peer %v to "+
+						"query scheduler: %v",
+						peer.Addr(), err)
+				}
+			}
+
+			w.wg.Add(1)
+			go func() {
+				defer w.wg.Done()
+				defer close(onExit)
+
+				r.Run(w.jobResults, w.quit)
+			}()
+
+		// A new result came back.
+		case result := <-w.jobResults:
+			resultAt := time.Now()
+			activeDuration := durationSince(
+				resultAt, result.job.activeAt,
+			)
+			taskAge := durationSince(resultAt, result.job.createdAt)
+
+			log.Tracef("Result for job %v received from peer %v "+
+				"(err=%v)", result.job.index,
+				result.peer.Addr(), result.err)
+
+			// Delete the job from the worker's active job, such
+			// that the slot gets opened for more work.
+			r := workers[result.peer.Addr()]
+			if r != nil {
+				r.activeJob = nil
+				err := setWorkerPeerState(
+					schedulerCtx, scheduler, r,
+					querysync.PeerReady,
+				)
+				if err != nil {
+					log.Warnf("Unable to complete peer %v "+
+						"work in query scheduler: %v",
+						result.peer.Addr(), err)
+				}
+			}
+
+			// Get the index of this query's batch, and delete it
+			// from the map of current queries, since we don't have
+			// to track it anymore. We'll add it back if the result
+			// turns out to be an error.
+			batchNum, ok := currentQueries[result.job.index]
+			if !ok {
+				log.Warnf("Query(%d) result from peer %v "+
+					"discarded because query is no "+
+					"longer tracked: %v",
+					result.job.index,
+					result.peer.Addr(), result.err)
+
+				continue Loop
+			}
+
+			delete(currentQueries, result.job.index)
+
+			// In case the batch is already canceled we return
+			// early.
+			batch, ok := currentBatches[batchNum]
+			if !ok {
+				log.Warnf("Query(%d) result from peer %v "+
+					"discarded with retries %d, because "+
+					"batch already canceled: %v",
+					result.job.index,
+					result.peer.Addr(),
+					result.job.tries, result.err)
+
+				continue Loop
+			}
+
+			recordSchedulerEvent(
+				w.cfg.SchedulerEvents,
+				querysync.SchedulerEvent{
+					Type:           querysync.SchedulerEventTaskResult,
+					At:             resultAt,
+					PeerID:         result.peer.Addr(),
+					TaskID:         querysync.TaskID(result.job.index),
+					BatchID:        batchNum,
+					Err:            errString(result.err),
+					TaskAge:        taskAge,
+					ActiveDuration: activeDuration,
+					Timeout:        result.job.timeout,
+					StolenCount:    result.job.stolenCount,
+					Attempts:       result.job.tries,
+					OK:             result.err == nil,
+				},
+			)
+
+			switch {
+			// If the query ended because it was canceled, drop it.
+			case result.err == query.ErrJobCanceled:
+				log.Tracef("Query(%d) was canceled before "+
+					"result was available from peer %v",
+					result.job.index, result.peer.Addr())
+
+				// If this is the first job in this batch that
+				// was canceled, forward the error on the
+				// batch's error channel.  We do this since a
+				// cancellation applies to the whole batch.
+				finishBatch(
+					batchNum, batch, result.err, true,
+				)
+
+				log.Debugf("Canceled batch %v", batchNum)
+				continue Loop
+
+				// If the query ended with any other error, put it back
+				// into the work queue if it has not reached the
+			// maximum number of retries.
+			case result.err != nil:
+				quarantined := false
+				var failureCount uint8
+				if isNonResponseErr(result.err) {
+					failures := nonResponseFailures[result.peer.Addr()] + 1
+					nonResponseFailures[result.peer.Addr()] =
+						failures
+					failureCount = failures
+
+					if failures >= nonResponsivePeerFailures {
+						quarantineUntil := resultAt.Add(
+							nonResponsivePeerCooldown,
+						)
+						quarantinedPeers[result.peer.Addr()] =
+							quarantineUntil
+						delete(
+							nonResponseFailures,
+							result.peer.Addr(),
+						)
+
+						if r != nil {
+							r.quarantine = quarantineUntil
+							if err := setWorkerPeerState(
+								schedulerCtx,
+								scheduler, r,
+								querysync.PeerQuarantined,
+							); err != nil {
+								log.Warnf("Unable to "+
+									"quarantine "+
+									"peer %v in "+
+									"query "+
+									"scheduler: %v",
+									result.peer.Addr(),
+									err)
+							}
+						}
+						quarantined = true
+
+						log.Warnf("Peer %v failed to "+
+							"respond to %v queries; "+
+							"quarantining until %v "+
+							"(job=%v, active_for=%v, "+
+							"task_age=%v)",
+							result.peer.Addr(),
+							nonResponsivePeerFailures,
+							quarantineUntil,
+							result.job.index,
+							activeDuration, taskAge)
+
+						recordSchedulerEvent(
+							w.cfg.SchedulerEvents,
+							querysync.SchedulerEvent{
+								Type:           querysync.SchedulerEventPeerQuarantined,
+								At:             resultAt,
+								PeerID:         result.peer.Addr(),
+								State:          querysync.PeerQuarantined,
+								TaskID:         querysync.TaskID(result.job.index),
+								BatchID:        batchNum,
+								Err:            errString(result.err),
+								TaskAge:        taskAge,
+								ActiveDuration: activeDuration,
+								FailureCount:   failureCount,
+								Until:          quarantineUntil,
+								OK:             true,
+							},
+						)
+
+						if w.cfg.OnPeerUnresponsive != nil {
+							w.cfg.OnPeerUnresponsive(
+								result.peer,
+							)
+						}
+					}
+				}
+
+				if r != nil {
+					cooldownUntil := resultAt.Add(failedPeerCooldown)
+					r.cooldown = cooldownUntil
+					if isHardCooldownErr(result.err) {
+						r.hardCooldown = cooldownUntil
+					}
+					if !quarantined {
+						err := setWorkerPeerState(
+							schedulerCtx, scheduler, r,
+							querysync.PeerBlocked,
+						)
+						if err != nil {
+							log.Warnf("Unable to cool "+
+								"down peer %v in "+
+								"query scheduler: %v",
+								result.peer.Addr(),
+								err)
+						}
+					}
+
+					recordSchedulerEvent(
+						w.cfg.SchedulerEvents,
+						querysync.SchedulerEvent{
+							Type:             querysync.SchedulerEventPeerCooldown,
+							At:               resultAt,
+							PeerID:           result.peer.Addr(),
+							State:            querysync.PeerBlocked,
+							TaskID:           querysync.TaskID(result.job.index),
+							BatchID:          batchNum,
+							Err:              errString(result.err),
+							TaskAge:          taskAge,
+							ActiveDuration:   activeDuration,
+							FailureCount:     failureCount,
+							CooldownDuration: failedPeerCooldown,
+							Until:            cooldownUntil,
+							OK:               true,
+						},
+					)
+				}
+
+				// Refresh peer rank on disconnect.
+				if result.err == query.ErrPeerDisconnected {
+					w.cfg.Ranking.ResetRanking(
+						result.peer.Addr(),
+					)
+				} else {
+					// Punish the peer for the failed query.
+					w.cfg.Ranking.Punish(result.peer.Addr())
+				}
+
+				if !batch.noRetryMax {
+					result.job.tries++
+				}
+
+				// Check if this query has reached its maximum
+				// number of retries. If so, remove it from the
+				// batch and don't reschedule it.
+				if !batch.noRetryMax &&
+					result.job.tries >= batch.maxRetries {
+
+					log.Warnf("Query(%d) from peer %v "+
+						"failed and reached maximum "+
+						"number of retries, not "+
+						"rescheduling: %v "+
+						"(active_for=%v, task_age=%v, "+
+						"tries=%v)",
+						result.job.index,
+						result.peer.Addr(), result.err,
+						activeDuration, taskAge,
+						result.job.tries)
+
+					// Return the error and cancel the
+					// batch.
+					finishBatch(
+						batchNum, batch, result.err, true,
+					)
+
+					log.Debugf("Canceled batch %v",
+						batchNum)
+
+					// Since we've reached this query's
+					// maximum number of retries, now is the
+					// time to call the OnMaxTries callback
+					// function if it isn't nil.
+					if w.cfg.OnMaxTries != nil {
+						w.cfg.OnMaxTries(result.peer)
+					}
+
+					continue Loop
+				}
+
+				log.Warnf("Query(%d) from peer %v failed, "+
+					"rescheduling: %v (active_for=%v, "+
+					"task_age=%v, tries=%v, timeout=%v)",
+					result.job.index, result.peer.Addr(),
+					result.err, activeDuration, taskAge,
+					result.job.tries, result.job.timeout)
+
+				if result.job.failedPeers == nil {
+					result.job.failedPeers = make(map[string]struct{})
+				}
+				result.job.failedPeers[result.peer.Addr()] = struct{}{}
+
+				// If it was a timeout, we dynamically increase
+				// it for the next attempt.
+				if result.err == query.ErrQueryTimeout {
+					newTimeout := result.job.timeout * 2
+					if newTimeout > maxQueryTimeout {
+						newTimeout = maxQueryTimeout
+					}
+					result.job.timeout = newTimeout
+				}
+
+				work.Push(result.job)
+				currentQueries[result.job.index] = batchNum
+
+			// Otherwise, we got a successful result and update the
+			// status of the batch this query is a part of.
+			default:
+				delete(nonResponseFailures, result.peer.Addr())
+				delete(quarantinedPeers, result.peer.Addr())
+				if r != nil {
+					r.quarantine = time.Time{}
+					r.hardCooldown = time.Time{}
+				}
+
+				// Reward the peer for the successful query.
+				w.cfg.Ranking.Reward(result.peer.Addr())
+
+				// Decrement the number of queries remaining in
+				// the batch.
+				batch.rem--
+				log.Tracef("Remaining jobs for batch "+
+					"%v: %v ", batchNum, batch.rem)
+
+				// If this was the last query in flight
+				// for this batch, we can notify that
+				// it finished, and delete it.
+				if batch.rem == 0 {
+					finishBatch(
+						batchNum, batch, nil, false,
+					)
+
+					log.Tracef("Batch %v done",
+						batchNum)
+					continue Loop
+				}
+			}
+
+		// A new batch of queries where scheduled.
+		case batch := <-w.newBatches:
+			// Add all new queries in the batch to our work queue,
+			// with priority given by the order they were
+			// scheduled.
+			log.Debugf("Adding new batch(%d) of %d queries to "+
+				"work queue", batchIndex, len(batch.requests))
+
+			// Internal cancel channel of a batch request.
+			cancelChan := make(chan struct{})
+			thisBatchIndex := batchIndex
+			createdAt := time.Now()
+
+			for _, q := range batch.requests {
+				work.Push(&queryJob{
+					index:              queryIndex,
+					timeout:            minQueryTimeout,
+					encoding:           batch.options.Encoding,
+					cancelChan:         batch.options.CancelChan,
+					internalCancelChan: cancelChan,
+					createdAt:          createdAt,
+					Request:            q,
+				})
+				currentQueries[queryIndex] = batchIndex
+				queryIndex++
+			}
+
+			timer := time.AfterFunc(batch.options.Timeout, func() {
+				select {
+				case batchTimeouts <- thisBatchIndex:
+				case <-w.quit:
+				}
+			})
+
+			currentBatches[batchIndex] = &batchProgress{
+				noRetryMax: batch.options.NoRetryMax,
+				maxRetries: batch.options.NumRetries,
+				timer:      timer,
+				rem:        len(batch.requests),
+				errChan:    batch.errChan,
+				cancelChan: cancelChan,
+			}
+			batchIndex++
+
+		case batchNum := <-batchTimeouts:
+			batch, ok := currentBatches[batchNum]
+			if !ok {
+				continue Loop
+			}
+
+			finishBatch(
+				batchNum, batch, query.ErrQueryTimeout, true,
+			)
+
+			log.Warnf("Batch %v timed out", batchNum)
+
+		case <-scheduleRetry:
+			scheduleRetry = nil
+			sendBlockedWorkers = make(map[string]struct{})
+
+		case <-w.quit:
+			return
+		}
+	}
+}
+
+// Query distributes the slice of requests to the set of connected peers.
+//
+// NOTE: this is part of the query.WorkManager interface.
+func (w *peerWorkManager) Query(requests []*query.Request,
+	options ...query.QueryOption) chan error {
+
+	qo := query.ResolveOptions(options...)
+
+	errChan := make(chan error, 1)
+
+	// Add query messages to the queue of batches to handle.
+	select {
+	case w.newBatches <- &batch{
+		requests: requests,
+		options:  qo,
+		errChan:  errChan,
+	}:
+	case <-w.quit:
+		errChan <- query.ErrWorkManagerShuttingDown
+	}
+
+	return errChan
+}

--- a/querysync/workmanager/workmanager_test.go
+++ b/querysync/workmanager/workmanager_test.go
@@ -1,0 +1,445 @@
+package workmanager
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/neutrino/query"
+	"github.com/lightninglabs/neutrino/querysync"
+	"github.com/stretchr/testify/require"
+)
+
+type mockPeer struct {
+	addr           string
+	lastPingMicros int64
+	quit           chan struct{}
+}
+
+var _ query.Peer = (*mockPeer)(nil)
+
+func (m *mockPeer) QueueMessageWithEncoding(wire.Message,
+	chan<- struct{}, wire.MessageEncoding) {
+}
+
+func (m *mockPeer) SubscribeRecvMsg() (<-chan wire.Message, func()) {
+	return make(chan wire.Message), func() {}
+}
+
+func (m *mockPeer) Addr() string {
+	return m.addr
+}
+
+func (m *mockPeer) LastPingMicros() int64 {
+	return m.lastPingMicros
+}
+
+func (m *mockPeer) OnDisconnect() <-chan struct{} {
+	return m.quit
+}
+
+type mockWorker struct {
+	peer    query.Peer
+	nextJob chan *queryJob
+	results chan *jobResult
+}
+
+var _ Worker = (*mockWorker)(nil)
+
+func (m *mockWorker) NewJob() chan<- *queryJob {
+	return m.nextJob
+}
+
+func (m *mockWorker) Run(results chan<- *jobResult,
+	quit <-chan struct{}) {
+
+	for {
+		select {
+		case r := <-m.results:
+			r.peer = m.peer
+			results <- r
+
+		case <-quit:
+			return
+		}
+	}
+}
+
+type mockPeerRanking struct {
+	mu   sync.RWMutex
+	less func(i, j string) bool
+}
+
+var _ PeerRanking = (*mockPeerRanking)(nil)
+
+func (p *mockPeerRanking) AddPeer(string) {
+}
+
+func (p *mockPeerRanking) Order(peers []string) {
+	p.mu.RLock()
+	less := p.less
+	p.mu.RUnlock()
+
+	if less == nil {
+		sort.Strings(peers)
+		return
+	}
+
+	sort.Slice(peers, func(i, j int) bool {
+		return less(peers[i], peers[j])
+	})
+}
+
+func (p *mockPeerRanking) Punish(string) {
+}
+
+func (p *mockPeerRanking) Reward(string) {
+}
+
+func (p *mockPeerRanking) ResetRanking(string) {
+}
+
+func (p *mockPeerRanking) setLess(less func(i, j string) bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.less = less
+}
+
+func startWorkManager(t *testing.T, numWorkers int, trace *querysync.TraceRecorder,
+	events querysync.SchedulerEventSink) (query.WorkManager, []*mockWorker) {
+
+	t.Helper()
+
+	workerChan := make(chan *mockWorker)
+	peerChan := make(chan query.Peer)
+	ranking := &mockPeerRanking{}
+	ranking.setLess(func(i, j string) bool {
+		return i < j
+	})
+
+	wm := NewWorkManager(&Config{
+		ConnectedPeers: func() (<-chan query.Peer, func(), error) {
+			return peerChan, func() {}, nil
+		},
+		NewWorker: func(peer query.Peer) Worker {
+			m := &mockWorker{
+				peer:    peer,
+				nextJob: make(chan *queryJob, 1),
+				results: make(chan *jobResult),
+			}
+			workerChan <- m
+			return m
+		},
+		Ranking:         ranking,
+		SchedulerTrace:  trace,
+		SchedulerEvents: events,
+	})
+
+	require.NoError(t, wm.Start())
+
+	workers := make([]*mockWorker, numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		peer := &mockPeer{
+			addr: fmt.Sprintf("mock%v", i),
+			quit: make(chan struct{}),
+		}
+
+		select {
+		case peerChan <- peer:
+		case <-time.After(time.Second):
+			t.Fatal("work manager did not receive peer")
+		}
+
+		select {
+		case workers[i] = <-workerChan:
+		case <-time.After(time.Second):
+			t.Fatal("worker not started")
+		}
+	}
+
+	return wm, workers
+}
+
+func recvJob(t *testing.T, worker *mockWorker, errChan <-chan error) *queryJob {
+	t.Helper()
+
+	select {
+	case job := <-worker.nextJob:
+		return job
+
+	case err := <-errChan:
+		t.Fatalf("did not expect query result: %v", err)
+
+	case <-time.After(time.Second):
+		t.Fatal("job not scheduled")
+	}
+
+	return nil
+}
+
+func recvJobOnlyFrom(t *testing.T, worker, forbidden *mockWorker,
+	errChan <-chan error) *queryJob {
+
+	t.Helper()
+
+	select {
+	case job := <-worker.nextJob:
+		return job
+
+	case job := <-forbidden.nextJob:
+		t.Fatalf("unexpected job %v scheduled to peer %v", job.index,
+			forbidden.peer.Addr())
+
+	case err := <-errChan:
+		t.Fatalf("did not expect query result: %v", err)
+
+	case <-time.After(time.Second):
+		t.Fatalf("job not scheduled to peer %v", worker.peer.Addr())
+	}
+
+	return nil
+}
+
+func requireNoJob(t *testing.T, worker *mockWorker) {
+	t.Helper()
+
+	select {
+	case job := <-worker.nextJob:
+		t.Fatalf("unexpected job %v scheduled to peer %v", job.index,
+			worker.peer.Addr())
+
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func sendResult(t *testing.T, worker *mockWorker, job *queryJob, err error) {
+	t.Helper()
+
+	select {
+	case worker.results <- &jobResult{
+		job: job,
+		err: err,
+	}:
+	case <-time.After(time.Second):
+		t.Fatal("result not handled")
+	}
+}
+
+func requireQueryDone(t *testing.T, errChan <-chan error) {
+	t.Helper()
+
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+
+	case <-time.After(time.Second):
+		t.Fatal("query did not finish")
+	}
+}
+
+func TestWorkManagerRecordsReplayableSchedulerTraceAndEvents(t *testing.T) {
+	trace := &querysync.TraceRecorder{}
+	events := &querysync.SchedulerEventRecorder{}
+	wm, workers := startWorkManager(t, 2, trace, events)
+	defer func() {
+		require.NoError(t, wm.Stop())
+	}()
+
+	errChan := wm.Query([]*query.Request{{}})
+	job := recvJob(t, workers[0], errChan)
+	sendResult(t, workers[0], job, nil)
+	requireQueryDone(t, errChan)
+
+	replay, err := querysync.ReplayTrace(
+		context.Background(), querysync.DefaultConfig(), trace.Events(),
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, replay.Dispatches)
+	require.Equal(t, querysync.BridgeDispatchWant{
+		OK:            true,
+		PeerID:        "mock0",
+		TaskID:        0,
+		TimeoutMillis: int(minQueryTimeout / time.Millisecond),
+	}, replay.Dispatches[0])
+
+	var owned bool
+	var sent, resultEvent bool
+	for _, event := range events.Events() {
+		if event.Type == querysync.SchedulerEventTaskOwned &&
+			event.PeerID == "mock0" && event.OK {
+
+			owned = true
+		}
+		if event.Type == querysync.SchedulerEventTaskSent &&
+			event.PeerID == "mock0" && event.OK {
+
+			require.EqualValues(t, 0, event.TaskID)
+			require.Equal(t, minQueryTimeout, event.Timeout)
+			sent = true
+		}
+		if event.Type == querysync.SchedulerEventTaskResult &&
+			event.PeerID == "mock0" && event.OK {
+
+			require.EqualValues(t, 0, event.TaskID)
+			require.NotZero(t, event.ActiveDuration)
+			resultEvent = true
+		}
+	}
+	require.True(t, owned)
+	require.True(t, sent)
+	require.True(t, resultEvent)
+}
+
+func TestWorkManagerAvoidsAllFailedPeersForRetry(t *testing.T) {
+	wm, workers := startWorkManager(t, 3, nil, nil)
+	defer func() {
+		require.NoError(t, wm.Stop())
+	}()
+
+	errChan := wm.Query(
+		[]*query.Request{{}}, query.NumRetries(4),
+	)
+	job := recvJob(t, workers[0], errChan)
+
+	sendResult(t, workers[0], job, query.ErrPeerNotFound)
+	retry := recvJob(t, workers[1], errChan)
+	require.Same(t, job, retry)
+
+	sendResult(t, workers[1], retry, query.ErrQueryTimeout)
+	retry = recvJob(t, workers[2], errChan)
+	require.Same(t, job, retry)
+
+	sendResult(t, workers[2], retry, nil)
+	requireQueryDone(t, errChan)
+}
+
+func TestWorkManagerHardCoolsTimeoutPeerAndReassignsLocalWork(t *testing.T) {
+	wm, workers := startWorkManager(t, 2, nil, nil)
+	defer func() {
+		require.NoError(t, wm.Stop())
+	}()
+
+	errChan := wm.Query([]*query.Request{
+		{}, {}, {}, {}, {},
+	})
+
+	job0 := recvJob(t, workers[0], errChan)
+	job1 := recvJob(t, workers[1], errChan)
+
+	sendResult(t, workers[0], job0, query.ErrQueryTimeout)
+	requireNoJob(t, workers[0])
+
+	sendResult(t, workers[1], job1, nil)
+	for i := 0; i < 4; i++ {
+		job := recvJobOnlyFrom(t, workers[1], workers[0], errChan)
+		sendResult(t, workers[1], job, nil)
+	}
+
+	requireQueryDone(t, errChan)
+}
+
+func TestSchedulerDoesNotRelaxHardCooldown(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	scheduler := newQuerySchedulerManager(minQueryTimeout)
+	scheduler.Start(ctx)
+	defer scheduler.Stop()
+
+	now := time.Now()
+	workers := map[string]*activeWorker{
+		"hard": {
+			peer: &mockPeer{
+				addr: "hard",
+				quit: make(chan struct{}),
+			},
+			hardCooldown: now.Add(time.Minute),
+		},
+		"soft": {
+			peer: &mockPeer{
+				addr: "soft",
+				quit: make(chan struct{}),
+			},
+			cooldown: now.Add(time.Minute),
+		},
+	}
+
+	ranking := &mockPeerRanking{}
+	ranking.setLess(func(i, j string) bool {
+		return i < j
+	})
+
+	assignment, ok := assignQueryJobToLocalWorkWithScheduler(
+		ctx, scheduler, workers, ranking, &queryJob{
+			index:   1,
+			timeout: minQueryTimeout,
+			Request: &query.Request{},
+		}, 0, nil, true,
+	)
+	require.True(t, ok)
+	require.Equal(t, "soft", assignment.PeerID)
+}
+
+func TestWorkManagerStealsOwnedWorkFromBusyPeer(t *testing.T) {
+	events := &querysync.SchedulerEventRecorder{}
+	wm, workers := startWorkManager(t, 2, nil, events)
+	defer func() {
+		require.NoError(t, wm.Stop())
+	}()
+
+	errChan := wm.Query([]*query.Request{
+		{}, {}, {}, {}, {},
+	})
+
+	job0 := recvJob(t, workers[0], errChan)
+	job1 := recvJob(t, workers[1], errChan)
+
+	sendResult(t, workers[1], job1, nil)
+	local := recvJob(t, workers[1], errChan)
+	require.EqualValues(t, 3, local.index)
+
+	sendResult(t, workers[1], local, nil)
+	stolen := recvJob(t, workers[1], errChan)
+	require.EqualValues(t, 2, stolen.index)
+
+	sendResult(t, workers[0], job0, nil)
+	remaining := recvJob(t, workers[0], errChan)
+	require.EqualValues(t, 4, remaining.index)
+
+	sendResult(t, workers[1], stolen, nil)
+	sendResult(t, workers[0], remaining, nil)
+	requireQueryDone(t, errChan)
+
+	var steal *querysync.SchedulerEvent
+	var applied *querysync.SchedulerEvent
+	for _, event := range events.Events() {
+		event := event
+		if event.Type == querysync.SchedulerEventWorkStolen && event.OK {
+			steal = &event
+		}
+		if event.Type == querysync.SchedulerEventWorkStealApplied &&
+			event.OK {
+
+			applied = &event
+		}
+	}
+	require.NotNil(t, steal)
+	require.Equal(t, "mock1", steal.ThiefID)
+	require.Equal(t, "mock0", steal.DonorID)
+	require.EqualValues(t, 2, steal.TaskID)
+
+	require.NotNil(t, applied)
+	require.Equal(t, "mock1", applied.ThiefID)
+	require.Equal(t, "mock0", applied.DonorID)
+	require.EqualValues(t, 2, applied.TaskID)
+	require.Equal(t, []querysync.TaskID{2}, applied.TaskIDs)
+	require.Equal(t, 1, applied.StolenTaskCount)
+	require.Equal(t, 1, applied.ThiefLocalLen)
+	require.Equal(t, 1, applied.DonorLocalLen)
+	require.EqualValues(t, 1, applied.StolenCount)
+}

--- a/querysync/workmanager/workqueue.go
+++ b/querysync/workmanager/workqueue.go
@@ -1,0 +1,94 @@
+package workmanager
+
+// Task is an interface that has a method for returning their index in the
+// work queue.
+type Task interface {
+	// Index returns this Task's index in the work queue.
+	Index() uint64
+}
+
+// workQueue is a generic min-heap used to keep a list of remaining queryTasks
+// in order.
+type workQueue[T Task] struct {
+	tasks []T
+}
+
+// Len returns the number of nodes in the priority queue.
+func (w *workQueue[T]) Len() int { return len(w.tasks) }
+
+// Push adds the passed task to the work queue.
+func (w *workQueue[T]) Push(task T) {
+	w.tasks = append(w.tasks, task)
+	w.up(w.Len() - 1)
+}
+
+// Pop removes and returns the lowest-indexed task in the queue.
+func (w *workQueue[T]) Pop() (T, bool) {
+	var zero T
+	if w.Len() == 0 {
+		return zero, false
+	}
+
+	task := w.tasks[0]
+	last := w.Len() - 1
+	w.tasks[0] = w.tasks[last]
+	w.tasks[last] = zero
+	w.tasks = w.tasks[:last]
+
+	if w.Len() > 0 {
+		w.down(0)
+	}
+
+	return task, true
+}
+
+// Peek returns the first item in the queue.
+func (w *workQueue[T]) Peek() (T, bool) {
+	var zero T
+	if w.Len() == 0 {
+		return zero, false
+	}
+
+	return w.tasks[0], true
+}
+
+func (w *workQueue[T]) less(i, j int) bool {
+	return w.tasks[i].Index() < w.tasks[j].Index()
+}
+
+func (w *workQueue[T]) swap(i, j int) {
+	w.tasks[i], w.tasks[j] = w.tasks[j], w.tasks[i]
+}
+
+func (w *workQueue[T]) up(child int) {
+	for {
+		parent := (child - 1) / 2
+		if child == 0 || !w.less(child, parent) {
+			return
+		}
+
+		w.swap(parent, child)
+		child = parent
+	}
+}
+
+func (w *workQueue[T]) down(parent int) {
+	for {
+		left := 2*parent + 1
+		if left >= w.Len() {
+			return
+		}
+
+		child := left
+		if right := left + 1; right < w.Len() && w.less(right, left) {
+			child = right
+		}
+
+		if !w.less(child, parent) {
+			return
+		}
+
+		w.swap(parent, child)
+		parent = child
+	}
+}


### PR DESCRIPTION
In this PR, we add the `querysync` package as the actor/FSM scheduler layer for query dispatch. This is the package-level landing point for the work-stealing scheduler: peer actors own peer-local state, the manager actor owns global dispatch state, and the FSM tracks queued, active, completed, failed, stolen, stale, cooled-down, and quarantined work.

This PR does not flip production blockmanager/query callers over yet. The legacy `query` package only gets small exported seams so an external scheduler can implement the current work-manager API without reaching into private internals. The old worker behavior is left intact; the new fast `notfound` handling lives in the `querysync/workmanager` path.

## Stack

This stacks on #368, a.k.a `roasbeef/sync-01-models-protofsm`.

## Query adapter seams

We expose resolved query options, peer ranking scores, peer RTT samples, and a reusable `notfound` classifier. These are intentionally narrow: they let `querysync` plug into the existing API while keeping retry policy and actor state outside the legacy package.

## Actor/FSM scheduler

The new package adds the manager and peer state machines, actor wrappers, trace recording/replay, and a `query.WorkManager` adapter. The scheduler uses RTT-aware peer selection, cooldown and quarantine state, bounded peer-local queues, lease epochs, stale response rejection, and work stealing for stranded work.

The workmanager adapter is still package-local wiring at this point. A later PR will route production query dispatch through it once this package has had a focused review.

## Tests

```bash
go test ./query ./querysync ./querysync/workmanager -count=1
go test . -run 'TestNeutrinoSyncWithoutHeadersImport' -count=1
go test ./... -count=1
```

The first full run found that fast `notfound` handling in the legacy worker changed existing sync-test semantics. We moved that behavior back into the new `querysync/workmanager` worker and left the legacy worker alone; the full suite passed after that adjustment.
