### PR TITLE
neutrino: route production queries through querysync

### DIFF
--- a/log.go
+++ b/log.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lightninglabs/neutrino/filterdb"
 	"github.com/lightninglabs/neutrino/pushtx"
 	"github.com/lightninglabs/neutrino/query"
+	queryworkmanager "github.com/lightninglabs/neutrino/querysync/workmanager"
 	"github.com/lightninglabs/neutrino/sqldb"
 )
 
@@ -45,6 +46,7 @@ func UseLogger(logger btclog.Logger) {
 	pushtx.UseLogger(logger)
 	connmgr.UseLogger(logger)
 	query.UseLogger(logger)
+	queryworkmanager.UseLogger(logger)
 	filterdb.UseLogger(logger)
 	chanutils.UseLogger(logger)
 	chainimport.UseLogger(logger)

--- a/neutrino.go
+++ b/neutrino.go
@@ -32,6 +32,7 @@ import (
 	"github.com/lightninglabs/neutrino/headerfs"
 	"github.com/lightninglabs/neutrino/pushtx"
 	"github.com/lightninglabs/neutrino/query"
+	queryworkmanager "github.com/lightninglabs/neutrino/querysync/workmanager"
 	"github.com/lightninglabs/neutrino/sqldb"
 )
 
@@ -810,9 +811,8 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		broadcastTimeout:  cfg.BroadcastTimeout,
 		headersImport:     cfg.HeadersImport,
 	}
-	s.workManager = query.NewWorkManager(&query.Config{
+	s.workManager = queryworkmanager.NewWorkManager(&queryworkmanager.Config{
 		ConnectedPeers: s.ConnectedPeers,
-		NewWorker:      query.NewWorker,
 		Ranking:        query.NewPeerRanking(),
 	})
 

--- a/querysync_production_test.go
+++ b/querysync_production_test.go
@@ -1,0 +1,38 @@
+package neutrino
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcwallet/walletdb"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewChainServiceUsesQuerySyncWorkManager(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	db, err := walletdb.Create(
+		"bdb", filepath.Join(tempDir, "neutrino.db"),
+		true, dbOpenTimeout,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	svc, err := NewChainService(Config{
+		DataDir:     tempDir,
+		ChainParams: chaincfg.SimNetParams,
+		Database:    db,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	workManagerType := reflect.TypeOf(svc.workManager)
+	require.Equal(
+		t, "github.com/lightninglabs/neutrino/querysync/workmanager",
+		workManagerType.Elem().PkgPath(),
+	)
+}


### PR DESCRIPTION
In this PR, we flip production query dispatch over to the actor-backed `querysync/workmanager` added in the prior stack entry. The existing `query.WorkManager` interface remains the compatibility shell, but `NewChainService` now constructs the querysync manager, so normal `GetBlock`, `GetCFilter`, and cfheader batch dispatch use the actor/FSM scheduler.

This keeps the diff intentionally small. The scheduler package itself was introduced in #369; here we only change the production wiring, wire its logger into `UseLogger`, and add a construction test that prevents the legacy query work manager from coming back by accident.

## Stack

This stacks on #369, a.k.a `roasbeef/sync-02-querysync`.

## Behavior

The production path now uses the querysync workmanager for RTT-aware peer selection, cooldown/quarantine state, bounded peer-local queues, stale response handling, and work stealing. The old `query` package still defines request/option/peer API types so existing callers don't need to move in the same PR.

We do not hook querysync's repeated non-response callback into the ban store in this PR. The new manager already quarantines bad peers locally; extending that into persistent bans should be a separate policy patch so we can review the threshold and ban reason independently.

## Tests

```bash
go test . -run 'TestNewChainServiceUsesQuerySyncWorkManager|TestNewChainServiceSQLPath|TestNewChainServiceSQLValidation' -count=1
go test ./query ./querysync ./querysync/workmanager -count=1
go test . -run 'TestNeutrinoSyncWithoutHeadersImport' -count=1
go test ./... -count=1
```
