### PR TITLE
headersync: add actor scheduler package

### DIFF
--- a/headersync/actor.go
+++ b/headersync/actor.go
@@ -1,0 +1,2083 @@
+package headersync
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/lightninglabs/neutrino/protofsm"
+	"github.com/lightningnetwork/lnd/actor"
+	"github.com/lightningnetwork/lnd/fn/v2"
+)
+
+const (
+	managerActorID = "headersync-manager"
+	peerActorKey   = "headersync-peer"
+)
+
+// ManagerMsg is accepted by the header sync manager actor.
+type ManagerMsg interface {
+	actor.Message
+
+	managerMsg()
+}
+
+type managerMessage struct {
+	actor.BaseMessage
+}
+
+func (managerMessage) managerMsg() {}
+
+func (managerMessage) MessageType() string {
+	return "headersync.ManagerMsg"
+}
+
+// ManagerResp is returned by the header sync manager actor.
+type ManagerResp interface {
+	managerResp()
+}
+
+type managerResponse struct{}
+
+func (managerResponse) managerResp() {}
+
+// ManagerAck confirms a mutating manager message was applied.
+type ManagerAck struct {
+	managerResponse
+}
+
+// AddAnchorMsg adds or confirms an anchor.
+type AddAnchorMsg struct {
+	managerMessage
+
+	Height  uint32
+	Hash    Hash
+	Trusted bool
+}
+
+// AddAnchorResp reports the anchor after applying the observation.
+type AddAnchorResp struct {
+	managerResponse
+
+	Anchor Anchor
+	OK     bool
+}
+
+// AnchorsMsg asks the manager for the currently known anchor set.
+type AnchorsMsg struct {
+	managerMessage
+}
+
+// AnchorsResp reports the current anchor set sorted by height.
+type AnchorsResp struct {
+	managerResponse
+
+	Anchors []Anchor
+}
+
+// PlanRangeMsg asks the manager to create queued range work.
+type PlanRangeMsg struct {
+	managerMessage
+
+	ID          RangeID
+	StartHeight uint32
+	StopHeight  uint32
+}
+
+// PlanRangeResp reports the planned range, if anchors allowed it.
+type PlanRangeResp struct {
+	managerResponse
+
+	Range HeaderRange
+	OK    bool
+}
+
+// StageDiscoveredRangeMsg asks the manager to stage a range using headers
+// already returned by anchor discovery.
+type StageDiscoveredRangeMsg struct {
+	managerMessage
+
+	ID          RangeID
+	PeerID      string
+	StartHeight uint32
+	StopHeight  uint32
+	At          time.Time
+}
+
+// StageDiscoveredRangeResp reports the staged range, if one was created.
+type StageDiscoveredRangeResp struct {
+	managerResponse
+
+	Range HeaderRange
+	OK    bool
+}
+
+// PlanAnchorRangesMsg asks the manager to plan all bounded adjacent ranges
+// between confirmed anchors.
+type PlanAnchorRangesMsg struct {
+	managerMessage
+
+	NextID      RangeID
+	StartHeight uint32
+	StopHeight  uint32
+}
+
+// PlanAnchorRangesResp reports the created anchor-backed ranges.
+type PlanAnchorRangesResp struct {
+	managerResponse
+
+	Result PlanRangesResult
+}
+
+// AddPeerMsg asks the manager to add or replace a peer snapshot.
+type AddPeerMsg struct {
+	managerMessage
+
+	Peer PeerSnapshot
+}
+
+// RemovePeerMsg asks the manager to remove a peer.
+type RemovePeerMsg struct {
+	managerMessage
+
+	ID string
+}
+
+// UpdatePeerStateMsg asks the manager to update peer state.
+type UpdatePeerStateMsg struct {
+	managerMessage
+
+	ID    string
+	State PeerState
+}
+
+// UpdatePeerRTTMsg asks the manager to update peer RTT.
+type UpdatePeerRTTMsg struct {
+	managerMessage
+
+	ID  string
+	RTT time.Duration
+}
+
+// AssignRangeMsg asks the manager to move queued range work to a peer queue.
+type AssignRangeMsg struct {
+	managerMessage
+}
+
+// StartRangeMsg asks the manager to start the next range for a peer.
+type StartRangeMsg struct {
+	managerMessage
+
+	PeerID string
+}
+
+// RangeAssignmentResp reports a range assignment.
+type RangeAssignmentResp struct {
+	managerResponse
+
+	Assignment RangeAssignment
+	OK         bool
+}
+
+// StealRangeMsg asks the manager to steal a specific range, or to select one
+// if RangeID is NoRange.
+type StealRangeMsg struct {
+	managerMessage
+
+	ThiefID string
+	RangeID RangeID
+}
+
+// StealRangeResp reports a steal result.
+type StealRangeResp struct {
+	managerResponse
+
+	Result StealResult
+	OK     bool
+}
+
+// CompleteRangeMsg reports a peer range completion.
+type CompleteRangeMsg struct {
+	managerMessage
+
+	PeerID     string
+	RangeID    RangeID
+	LeaseEpoch uint64
+	Valid      bool
+	At         time.Time
+}
+
+// CompleteRangeResp reports how a completion was handled.
+type CompleteRangeResp struct {
+	managerResponse
+
+	Result CompleteResult
+}
+
+// CommitReadyMsg asks the manager to drain staged contiguous ranges.
+type CommitReadyMsg struct {
+	managerMessage
+}
+
+// CommitReadyResp reports committed ranges.
+type CommitReadyResp struct {
+	managerResponse
+
+	Result CommitResult
+}
+
+// ReadyRangesMsg asks which staged ranges can be persisted before committing
+// them in the FSM.
+type ReadyRangesMsg struct {
+	managerMessage
+}
+
+// ReadyRangesResp reports staged, contiguous range ids without mutating state.
+type ReadyRangesResp struct {
+	managerResponse
+
+	RangeIDs []RangeID
+}
+
+// SnapshotPeerMsg asks the manager for one peer snapshot.
+type SnapshotPeerMsg struct {
+	managerMessage
+
+	ID string
+}
+
+// SnapshotPeerResp is the response to SnapshotPeerMsg.
+type SnapshotPeerResp struct {
+	managerResponse
+
+	Peer PeerSnapshot
+	OK   bool
+}
+
+// SnapshotRangeMsg asks the manager for one range snapshot.
+type SnapshotRangeMsg struct {
+	managerMessage
+
+	ID RangeID
+}
+
+// SnapshotRangeResp is the response to SnapshotRangeMsg.
+type SnapshotRangeResp struct {
+	managerResponse
+
+	Range HeaderRange
+	OK    bool
+}
+
+// MetricsMsg asks for current counters.
+type MetricsMsg struct {
+	managerMessage
+}
+
+// MetricsResp is the response to MetricsMsg.
+type MetricsResp struct {
+	managerResponse
+
+	Metrics Metrics
+}
+
+// CommitStatsMsg asks for out-of-order staging pressure.
+type CommitStatsMsg struct {
+	managerMessage
+
+	Now time.Time
+}
+
+// CommitStatsResp is the response to CommitStatsMsg.
+type CommitStatsResp struct {
+	managerResponse
+
+	Stats CommitStats
+}
+
+type managerOutbox interface {
+	managerOutbox()
+}
+
+type managerOutboxResponse struct {
+	Response ManagerResp
+}
+
+func (managerOutboxResponse) managerOutbox() {}
+
+type managerEnv struct {
+	fsm      *HeaderSyncFSM
+	dispatch DispatchController
+}
+
+type managerState struct{}
+
+func (managerState) String() string {
+	return "headersync-manager"
+}
+
+func (managerState) IsTerminal() bool {
+	return false
+}
+
+func (managerState) ProcessEvent(ctx context.Context, msg ManagerMsg,
+	env *managerEnv) (*protofsm.StateTransition[
+	ManagerMsg, managerOutbox, *managerEnv], error) {
+
+	_ = ctx
+
+	respond := func(resp ManagerResp) (*protofsm.StateTransition[
+		ManagerMsg, managerOutbox, *managerEnv], error) {
+
+		return &protofsm.StateTransition[
+			ManagerMsg, managerOutbox, *managerEnv,
+		]{
+			NextState: managerState{},
+			NewEvents: fn.Some(protofsm.EmittedEvent[
+				ManagerMsg, managerOutbox,
+			]{
+				Outbox: []managerOutbox{
+					managerOutboxResponse{Response: resp},
+				},
+			}),
+		}, nil
+	}
+
+	switch m := msg.(type) {
+	case *AddAnchorMsg:
+		anchor, ok := env.fsm.AddOrConfirmAnchor(
+			m.Height, m.Hash, m.Trusted,
+		)
+
+		return respond(&AddAnchorResp{Anchor: anchor, OK: ok})
+
+	case *AnchorsMsg:
+		return respond(&AnchorsResp{Anchors: env.fsm.Anchors()})
+
+	case *PlanRangeMsg:
+		rng, ok, err := env.fsm.PlanRange(
+			m.ID, m.StartHeight, m.StopHeight,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return respond(&PlanRangeResp{Range: rng, OK: ok})
+
+	case *StageDiscoveredRangeMsg:
+		now := m.At
+		if now.IsZero() {
+			now = time.Now()
+		}
+		rng, ok, err := env.fsm.StageDiscoveredRange(
+			m.ID, m.PeerID, m.StartHeight, m.StopHeight, now,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return respond(&StageDiscoveredRangeResp{
+			Range: rng,
+			OK:    ok,
+		})
+
+	case *PlanAnchorRangesMsg:
+		result, err := env.fsm.PlanConfirmedAnchorRanges(
+			m.NextID, m.StartHeight, m.StopHeight,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return respond(&PlanAnchorRangesResp{Result: result})
+
+	case *AddPeerMsg:
+		if err := env.fsm.AddPeer(m.Peer); err != nil {
+			return nil, err
+		}
+		if env.dispatch != nil {
+			if err := env.dispatch.AddPeer(ctx, m.Peer); err != nil {
+				return nil, err
+			}
+		}
+
+		return respond(&ManagerAck{})
+
+	case *RemovePeerMsg:
+		env.fsm.RemovePeer(m.ID)
+		if env.dispatch != nil {
+			if err := env.dispatch.RemovePeer(ctx, m.ID); err != nil {
+				return nil, err
+			}
+		}
+
+		return respond(&ManagerAck{})
+
+	case *UpdatePeerStateMsg:
+		if err := env.fsm.UpdatePeerState(m.ID, m.State); err != nil {
+			return nil, err
+		}
+		if env.dispatch != nil {
+			if err := env.dispatch.UpdatePeerState(
+				ctx, m.ID, m.State,
+			); err != nil {
+				return nil, err
+			}
+		}
+
+		return respond(&ManagerAck{})
+
+	case *UpdatePeerRTTMsg:
+		if err := env.fsm.UpdatePeerRTT(m.ID, m.RTT); err != nil {
+			return nil, err
+		}
+		if env.dispatch != nil {
+			if err := env.dispatch.UpdatePeerRTT(
+				ctx, m.ID, m.RTT,
+			); err != nil {
+				return nil, err
+			}
+		}
+
+		return respond(&ManagerAck{})
+
+	case *AssignRangeMsg:
+		var (
+			assignment RangeAssignment
+			ok         bool
+			err        error
+		)
+		if env.dispatch == nil {
+			assignment, ok = env.fsm.AssignNextQueuedRange()
+		} else {
+			assignment, ok, err = assignRangeWithDispatch(ctx, env)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return respond(&RangeAssignmentResp{
+			Assignment: assignment,
+			OK:         ok,
+		})
+
+	case *StartRangeMsg:
+		assignment, ok, err := env.fsm.StartPeerRange(m.PeerID)
+		if err != nil {
+			return nil, err
+		}
+		if ok && env.dispatch != nil {
+			peer, peerOK := env.fsm.SnapshotPeer(m.PeerID)
+			if !peerOK {
+				return nil, fmt.Errorf("%w: %s", ErrUnknownPeer,
+					m.PeerID)
+			}
+			if err := env.dispatch.StartRange(ctx, peer); err != nil {
+				return nil, err
+			}
+		}
+
+		return respond(&RangeAssignmentResp{
+			Assignment: assignment,
+			OK:         ok,
+		})
+
+	case *StealRangeMsg:
+		var (
+			result StealResult
+			ok     bool
+			err    error
+		)
+		if m.RangeID == NoRange {
+			if env.dispatch == nil {
+				result, ok, err = env.fsm.StealNextRange(m.ThiefID)
+			} else {
+				result, ok, err = stealRangeWithDispatch(
+					ctx, env, m.ThiefID,
+				)
+			}
+		} else {
+			result, ok, err = env.fsm.StealRange(
+				m.ThiefID, m.RangeID,
+			)
+			if ok && env.dispatch != nil {
+				if err := syncStealPeers(ctx, env, result); err != nil {
+					return nil, err
+				}
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		return respond(&StealRangeResp{Result: result, OK: ok})
+
+	case *CompleteRangeMsg:
+		var (
+			result CompleteResult
+			err    error
+		)
+		if m.At.IsZero() {
+			result, err = env.fsm.CompleteRange(
+				m.PeerID, m.RangeID, m.LeaseEpoch, m.Valid,
+			)
+		} else {
+			result, err = env.fsm.CompleteRangeAt(
+				m.PeerID, m.RangeID, m.LeaseEpoch, m.Valid,
+				m.At,
+			)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if result.Accepted && !result.Stale && env.dispatch != nil {
+			if err := env.dispatch.CompleteRange(
+				ctx, m.PeerID,
+			); err != nil {
+				return nil, err
+			}
+			peer, peerOK := env.fsm.SnapshotPeer(m.PeerID)
+			if peerOK {
+				if err := env.dispatch.SyncPeer(
+					ctx, peer,
+				); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		return respond(&CompleteRangeResp{Result: result})
+
+	case *CommitReadyMsg:
+		return respond(&CommitReadyResp{
+			Result: env.fsm.CommitReadyRanges(),
+		})
+
+	case *ReadyRangesMsg:
+		return respond(&ReadyRangesResp{
+			RangeIDs: env.fsm.ReadyRanges(),
+		})
+
+	case *SnapshotPeerMsg:
+		peer, ok := env.fsm.SnapshotPeer(m.ID)
+
+		return respond(&SnapshotPeerResp{Peer: peer, OK: ok})
+
+	case *SnapshotRangeMsg:
+		rng, ok := env.fsm.RangeByID(m.ID)
+
+		return respond(&SnapshotRangeResp{Range: rng, OK: ok})
+
+	case *MetricsMsg:
+		return respond(&MetricsResp{Metrics: env.fsm.Metrics()})
+
+	case *CommitStatsMsg:
+		now := m.Now
+		if now.IsZero() {
+			now = time.Now()
+		}
+
+		return respond(&CommitStatsResp{
+			Stats: env.fsm.CommitStats(now),
+		})
+
+	default:
+		return nil, fmt.Errorf("unknown headersync manager message: %T",
+			msg)
+	}
+}
+
+func assignRangeWithDispatch(ctx context.Context, env *managerEnv) (
+	RangeAssignment, bool, error) {
+
+	rangeID, ok := env.fsm.nextQueuedRange()
+	if !ok {
+		env.fsm.metrics.FailedAssignments++
+		return RangeAssignment{}, false, nil
+	}
+
+	dispatchAssignment, ok, err := env.dispatch.AssignRange(ctx, rangeID)
+	if err != nil || !ok {
+		if !ok {
+			env.fsm.metrics.FailedAssignments++
+		}
+
+		return RangeAssignment{}, false, err
+	}
+
+	return env.fsm.AssignQueuedRangeToPeer(
+		dispatchAssignment.RangeID, dispatchAssignment.PeerID,
+	)
+}
+
+func stealRangeWithDispatch(ctx context.Context, env *managerEnv,
+	thiefID string) (StealResult, bool, error) {
+
+	dispatchSteal, ok, err := env.dispatch.StealRange(ctx, thiefID)
+	if err != nil {
+		return StealResult{}, false, err
+	}
+	if !ok {
+		result, ok, err := env.fsm.StealNextRange(thiefID)
+		if err != nil || !ok {
+			return StealResult{}, ok, err
+		}
+		if err := syncStealPeers(ctx, env, result); err != nil {
+			return StealResult{}, false, err
+		}
+
+		return result, true, nil
+	}
+
+	rangeIDs := dispatchSteal.RangeIDs
+	if len(rangeIDs) == 0 && dispatchSteal.RangeID != NoRange {
+		rangeIDs = []RangeID{dispatchSteal.RangeID}
+	}
+	if len(rangeIDs) == 0 {
+		env.fsm.metrics.FailedStealActions++
+		return StealResult{}, false, nil
+	}
+
+	var result StealResult
+	for _, rangeID := range rangeIDs {
+		steal, ok, err := env.fsm.stealRange(
+			thiefID, rangeID, StealReasonDispatch,
+		)
+		if err != nil || !ok {
+			return StealResult{}, false, err
+		}
+		if result.RangeID == NoRange {
+			result = steal
+		}
+	}
+
+	return result, true, nil
+}
+
+func syncStealPeers(ctx context.Context, env *managerEnv,
+	result StealResult) error {
+
+	thief, ok := env.fsm.SnapshotPeer(result.ThiefID)
+	if ok {
+		if err := env.dispatch.SyncPeer(ctx, thief); err != nil {
+			return err
+		}
+	}
+
+	donor, ok := env.fsm.SnapshotPeer(result.DonorID)
+	if ok {
+		if err := env.dispatch.SyncPeer(ctx, donor); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ManagerActor owns the header sync FSM and exposes it through lnd's actor
+// system.
+type ManagerActor struct {
+	fsm         *HeaderSyncFSM
+	mailboxSize int
+	dispatch    DispatchController
+
+	key     actor.ServiceKey[ManagerMsg, ManagerResp]
+	system  *actor.ActorSystem
+	machine *protofsm.StateMachine[ManagerMsg, managerOutbox, *managerEnv]
+	ref     actor.ActorRef[ManagerMsg, ManagerResp]
+	events  EventSink
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+var _ actor.ActorBehavior[ManagerMsg, ManagerResp] = (*ManagerActor)(nil)
+
+// NewManagerActor creates an actor wrapper around a HeaderSyncFSM.
+func NewManagerActor(fsm *HeaderSyncFSM, mailboxSize int) *ManagerActor {
+	if mailboxSize <= 0 {
+		mailboxSize = 1
+	}
+
+	return &ManagerActor{
+		fsm:         fsm,
+		mailboxSize: mailboxSize,
+		key: actor.NewServiceKey[ManagerMsg, ManagerResp](
+			managerActorID,
+		),
+	}
+}
+
+// SetEventSink enables structured header sync events.
+func (m *ManagerActor) SetEventSink(events EventSink) {
+	m.events = events
+}
+
+// SetDispatchController routes generic range ownership and unstarted-work
+// stealing through an external scheduler. It should be called before Start.
+func (m *ManagerActor) SetDispatchController(dispatch DispatchController) {
+	m.dispatch = dispatch
+}
+
+// Start starts the manager actor.
+func (m *ManagerActor) Start(ctx context.Context) {
+	m.startOnce.Do(func() {
+		m.system = actor.NewActorSystemWithConfig(actor.SystemConfig{
+			MailboxCapacity: m.mailboxSize,
+		})
+
+		machine, err := protofsm.NewStateMachine[
+			ManagerMsg, managerOutbox,
+		](protofsm.StateMachineCfg[
+			ManagerMsg, managerOutbox, *managerEnv,
+		]{
+			InitialState: managerState{},
+			Env: &managerEnv{
+				fsm:      m.fsm,
+				dispatch: m.dispatch,
+			},
+		})
+		if err != nil {
+			panic(fmt.Sprintf("unable to create header manager FSM: %v",
+				err))
+		}
+
+		m.machine = machine
+		m.machine.Start(ctx)
+		m.key.Spawn(m.system, managerActorID, m)
+
+		refs := actor.FindInReceptionist(
+			m.system.Receptionist(), m.key,
+		)
+		if len(refs) == 0 {
+			panic("unable to spawn header manager actor")
+		}
+		m.ref = refs[0]
+	})
+}
+
+// Stop stops the manager actor.
+func (m *ManagerActor) Stop() {
+	m.stopOnce.Do(func() {
+		if m.system != nil {
+			_ = m.system.Shutdown()
+		}
+		if m.machine != nil {
+			m.machine.Stop()
+		}
+	})
+}
+
+// Receive processes one manager actor message.
+func (m *ManagerActor) Receive(ctx context.Context,
+	msg ManagerMsg) fn.Result[ManagerResp] {
+
+	if m.machine == nil {
+		return fn.Err[ManagerResp](ErrActorStopped)
+	}
+
+	outbox, err := m.machine.ProcessEvent(ctx, msg)
+	if err != nil {
+		return fn.Err[ManagerResp](err)
+	}
+
+	var resp ManagerResp = &ManagerAck{}
+	for _, out := range outbox {
+		switch out := out.(type) {
+		case managerOutboxResponse:
+			resp = out.Response
+
+		default:
+			return fn.Err[ManagerResp](
+				fmt.Errorf("unknown manager outbox: %T", out),
+			)
+		}
+	}
+
+	if m.events != nil {
+		if event, ok := eventForManagerMessage(m.fsm, msg, resp); ok {
+			m.events.RecordHeaderSyncEvent(event)
+		}
+	}
+
+	return fn.Ok(resp)
+}
+
+func (m *ManagerActor) ask(ctx context.Context, msg ManagerMsg) (
+	ManagerResp, error) {
+
+	if m.ref == nil {
+		return nil, ErrActorStopped
+	}
+
+	return m.ref.Ask(ctx, msg).Await(ctx).Unpack()
+}
+
+// AddAnchor asks the manager to add or confirm an anchor.
+func (m *ManagerActor) AddAnchor(ctx context.Context, height uint32,
+	hash Hash, trusted bool) (Anchor, bool, error) {
+
+	resp, err := m.ask(ctx, &AddAnchorMsg{
+		Height:  height,
+		Hash:    hash,
+		Trusted: trusted,
+	})
+	if err != nil {
+		return Anchor{}, false, err
+	}
+
+	anchorResp, ok := resp.(*AddAnchorResp)
+	if !ok {
+		return Anchor{}, false, unexpectedManagerResp(resp)
+	}
+
+	return anchorResp.Anchor, anchorResp.OK, nil
+}
+
+// Anchors asks the manager actor for the current known anchors.
+func (m *ManagerActor) Anchors(ctx context.Context) ([]Anchor, error) {
+	resp, err := m.ask(ctx, &AnchorsMsg{})
+	if err != nil {
+		return nil, err
+	}
+
+	anchorsResp, ok := resp.(*AnchorsResp)
+	if !ok {
+		return nil, unexpectedManagerResp(resp)
+	}
+
+	return anchorsResp.Anchors, nil
+}
+
+// PlanRange asks the manager to create queued range work.
+func (m *ManagerActor) PlanRange(ctx context.Context, id RangeID,
+	startHeight, stopHeight uint32) (HeaderRange, bool, error) {
+
+	resp, err := m.ask(ctx, &PlanRangeMsg{
+		ID:          id,
+		StartHeight: startHeight,
+		StopHeight:  stopHeight,
+	})
+	if err != nil {
+		return HeaderRange{}, false, err
+	}
+
+	planResp, ok := resp.(*PlanRangeResp)
+	if !ok {
+		return HeaderRange{}, false, unexpectedManagerResp(resp)
+	}
+
+	return planResp.Range, planResp.OK, nil
+}
+
+// StageDiscoveredRange asks the manager to stage a range using a confirmed
+// anchor-discovery response.
+func (m *ManagerActor) StageDiscoveredRange(ctx context.Context,
+	id RangeID, peerID string, startHeight, stopHeight uint32,
+	at time.Time) (HeaderRange, bool, error) {
+
+	resp, err := m.ask(ctx, &StageDiscoveredRangeMsg{
+		ID:          id,
+		PeerID:      peerID,
+		StartHeight: startHeight,
+		StopHeight:  stopHeight,
+		At:          at,
+	})
+	if err != nil {
+		return HeaderRange{}, false, err
+	}
+
+	stageResp, ok := resp.(*StageDiscoveredRangeResp)
+	if !ok {
+		return HeaderRange{}, false, unexpectedManagerResp(resp)
+	}
+
+	return stageResp.Range, stageResp.OK, nil
+}
+
+// PlanConfirmedAnchorRanges asks the manager to plan all bounded adjacent
+// ranges between confirmed anchors in [startHeight, stopHeight].
+func (m *ManagerActor) PlanConfirmedAnchorRanges(ctx context.Context,
+	nextID RangeID, startHeight, stopHeight uint32) (
+	PlanRangesResult, error) {
+
+	resp, err := m.ask(ctx, &PlanAnchorRangesMsg{
+		NextID:      nextID,
+		StartHeight: startHeight,
+		StopHeight:  stopHeight,
+	})
+	if err != nil {
+		return PlanRangesResult{}, err
+	}
+
+	planResp, ok := resp.(*PlanAnchorRangesResp)
+	if !ok {
+		return PlanRangesResult{}, unexpectedManagerResp(resp)
+	}
+
+	return planResp.Result, nil
+}
+
+// AddPeer asks the manager actor to add a peer.
+func (m *ManagerActor) AddPeer(ctx context.Context,
+	peer PeerSnapshot) error {
+
+	_, err := m.ask(ctx, &AddPeerMsg{Peer: peer})
+
+	return err
+}
+
+// RemovePeer asks the manager actor to remove a peer.
+func (m *ManagerActor) RemovePeer(ctx context.Context, id string) error {
+	_, err := m.ask(ctx, &RemovePeerMsg{ID: id})
+
+	return err
+}
+
+// UpdatePeerState asks the manager actor to update peer state.
+func (m *ManagerActor) UpdatePeerState(ctx context.Context, id string,
+	state PeerState) error {
+
+	_, err := m.ask(ctx, &UpdatePeerStateMsg{
+		ID:    id,
+		State: state,
+	})
+
+	return err
+}
+
+// UpdatePeerRTT asks the manager actor to update peer RTT.
+func (m *ManagerActor) UpdatePeerRTT(ctx context.Context, id string,
+	rtt time.Duration) error {
+
+	_, err := m.ask(ctx, &UpdatePeerRTTMsg{ID: id, RTT: rtt})
+
+	return err
+}
+
+// AssignNextQueuedRange asks the manager to assign global queued work.
+func (m *ManagerActor) AssignNextQueuedRange(ctx context.Context) (
+	RangeAssignment, bool, error) {
+
+	resp, err := m.ask(ctx, &AssignRangeMsg{})
+	if err != nil {
+		return RangeAssignment{}, false, err
+	}
+
+	assignResp, ok := resp.(*RangeAssignmentResp)
+	if !ok {
+		return RangeAssignment{}, false, unexpectedManagerResp(resp)
+	}
+
+	return assignResp.Assignment, assignResp.OK, nil
+}
+
+// StartPeerRange asks the manager to start a peer-local range.
+func (m *ManagerActor) StartPeerRange(ctx context.Context,
+	peerID string) (RangeAssignment, bool, error) {
+
+	resp, err := m.ask(ctx, &StartRangeMsg{PeerID: peerID})
+	if err != nil {
+		return RangeAssignment{}, false, err
+	}
+
+	assignResp, ok := resp.(*RangeAssignmentResp)
+	if !ok {
+		return RangeAssignment{}, false, unexpectedManagerResp(resp)
+	}
+
+	return assignResp.Assignment, assignResp.OK, nil
+}
+
+// StealNextRange asks the manager to select stealable work for a peer.
+func (m *ManagerActor) StealNextRange(ctx context.Context,
+	thiefID string) (StealResult, bool, error) {
+
+	return m.StealRange(ctx, thiefID, NoRange)
+}
+
+// StealRange asks the manager to steal a specific range, or any stealable
+// range when rangeID is NoRange.
+func (m *ManagerActor) StealRange(ctx context.Context, thiefID string,
+	rangeID RangeID) (StealResult, bool, error) {
+
+	resp, err := m.ask(ctx, &StealRangeMsg{
+		ThiefID: thiefID,
+		RangeID: rangeID,
+	})
+	if err != nil {
+		return StealResult{}, false, err
+	}
+
+	stealResp, ok := resp.(*StealRangeResp)
+	if !ok {
+		return StealResult{}, false, unexpectedManagerResp(resp)
+	}
+
+	return stealResp.Result, stealResp.OK, nil
+}
+
+// CompleteRange asks the manager to record a range response.
+func (m *ManagerActor) CompleteRange(ctx context.Context, peerID string,
+	rangeID RangeID, leaseEpoch uint64, valid bool,
+	at time.Time) (CompleteResult, error) {
+
+	resp, err := m.ask(ctx, &CompleteRangeMsg{
+		PeerID:     peerID,
+		RangeID:    rangeID,
+		LeaseEpoch: leaseEpoch,
+		Valid:      valid,
+		At:         at,
+	})
+	if err != nil {
+		return CompleteResult{}, err
+	}
+
+	completeResp, ok := resp.(*CompleteRangeResp)
+	if !ok {
+		return CompleteResult{}, unexpectedManagerResp(resp)
+	}
+
+	return completeResp.Result, nil
+}
+
+// CommitReadyRanges asks the manager to drain staged contiguous ranges.
+func (m *ManagerActor) CommitReadyRanges(ctx context.Context) (
+	CommitResult, error) {
+
+	resp, err := m.ask(ctx, &CommitReadyMsg{})
+	if err != nil {
+		return CommitResult{}, err
+	}
+
+	commitResp, ok := resp.(*CommitReadyResp)
+	if !ok {
+		return CommitResult{}, unexpectedManagerResp(resp)
+	}
+
+	return commitResp.Result, nil
+}
+
+// ReadyRanges asks the manager which staged ranges are ready for side-effectful
+// persistence before the FSM-visible tip advances.
+func (m *ManagerActor) ReadyRanges(ctx context.Context) ([]RangeID, error) {
+	resp, err := m.ask(ctx, &ReadyRangesMsg{})
+	if err != nil {
+		return nil, err
+	}
+
+	readyResp, ok := resp.(*ReadyRangesResp)
+	if !ok {
+		return nil, unexpectedManagerResp(resp)
+	}
+
+	return append([]RangeID(nil), readyResp.RangeIDs...), nil
+}
+
+// SnapshotPeer asks the manager for one peer snapshot.
+func (m *ManagerActor) SnapshotPeer(ctx context.Context,
+	id string) (PeerSnapshot, bool, error) {
+
+	resp, err := m.ask(ctx, &SnapshotPeerMsg{ID: id})
+	if err != nil {
+		return PeerSnapshot{}, false, err
+	}
+
+	snapshotResp, ok := resp.(*SnapshotPeerResp)
+	if !ok {
+		return PeerSnapshot{}, false, unexpectedManagerResp(resp)
+	}
+
+	return snapshotResp.Peer, snapshotResp.OK, nil
+}
+
+// SnapshotRange asks the manager for one range snapshot.
+func (m *ManagerActor) SnapshotRange(ctx context.Context,
+	id RangeID) (HeaderRange, bool, error) {
+
+	resp, err := m.ask(ctx, &SnapshotRangeMsg{ID: id})
+	if err != nil {
+		return HeaderRange{}, false, err
+	}
+
+	snapshotResp, ok := resp.(*SnapshotRangeResp)
+	if !ok {
+		return HeaderRange{}, false, unexpectedManagerResp(resp)
+	}
+
+	return snapshotResp.Range, snapshotResp.OK, nil
+}
+
+// Metrics asks the manager for current counters.
+func (m *ManagerActor) Metrics(ctx context.Context) (Metrics, error) {
+	resp, err := m.ask(ctx, &MetricsMsg{})
+	if err != nil {
+		return Metrics{}, err
+	}
+
+	metricsResp, ok := resp.(*MetricsResp)
+	if !ok {
+		return Metrics{}, unexpectedManagerResp(resp)
+	}
+
+	return metricsResp.Metrics, nil
+}
+
+// CommitStats asks the manager for current staged-range pressure.
+func (m *ManagerActor) CommitStats(ctx context.Context,
+	now time.Time) (CommitStats, error) {
+
+	resp, err := m.ask(ctx, &CommitStatsMsg{Now: now})
+	if err != nil {
+		return CommitStats{}, err
+	}
+
+	statsResp, ok := resp.(*CommitStatsResp)
+	if !ok {
+		return CommitStats{}, unexpectedManagerResp(resp)
+	}
+
+	return statsResp.Stats, nil
+}
+
+func unexpectedManagerResp(resp ManagerResp) error {
+	return fmt.Errorf("unexpected manager response: %T", resp)
+}
+
+// PeerMsg is accepted by a header peer actor.
+type PeerMsg interface {
+	actor.Message
+
+	peerMsg()
+}
+
+type peerMessage struct {
+	actor.BaseMessage
+}
+
+func (peerMessage) peerMsg() {}
+
+func (peerMessage) MessageType() string {
+	return "headersync.PeerMsg"
+}
+
+// PeerResp is returned by peer actor messages.
+type PeerResp interface {
+	peerResp()
+}
+
+type peerResponse struct{}
+
+func (peerResponse) peerResp() {}
+
+// PeerAck confirms a peer message was applied.
+type PeerAck struct {
+	peerResponse
+}
+
+// PeerRangeResp reports started range work.
+type PeerRangeResp struct {
+	peerResponse
+
+	Assignment RangeAssignment
+	OK         bool
+}
+
+// PeerStealResp reports stolen work.
+type PeerStealResp struct {
+	peerResponse
+
+	Result StealResult
+	OK     bool
+}
+
+// PeerCompleteResp reports completion handling.
+type PeerCompleteResp struct {
+	peerResponse
+
+	Result CompleteResult
+}
+
+// PeerReadyEvent moves the peer into a schedulable state.
+type PeerReadyEvent struct {
+	peerMessage
+}
+
+// PeerBlockedEvent marks the peer temporarily unable to make progress.
+type PeerBlockedEvent struct {
+	peerMessage
+}
+
+// PeerQuarantinedEvent marks the peer as banned/quarantined.
+type PeerQuarantinedEvent struct {
+	peerMessage
+}
+
+// PeerDownEvent marks the peer disconnected.
+type PeerDownEvent struct {
+	peerMessage
+}
+
+// PeerRTTEvent updates the peer RTT sample.
+type PeerRTTEvent struct {
+	peerMessage
+
+	RTT time.Duration
+}
+
+// PeerRankEvent updates the peer rank.
+type PeerRankEvent struct {
+	peerMessage
+
+	Rank int
+}
+
+// PeerNeedRangeEvent asks the manager for the next locally owned range.
+type PeerNeedRangeEvent struct {
+	peerMessage
+}
+
+// PeerNeedStealEvent asks the manager for stealable range work.
+type PeerNeedStealEvent struct {
+	peerMessage
+}
+
+// PeerRangeAssignedEvent records range work accepted by this peer.
+type PeerRangeAssignedEvent struct {
+	peerMessage
+
+	Assignment RangeAssignment
+}
+
+// PeerRangeCompletedEvent reports the active range result.
+type PeerRangeCompletedEvent struct {
+	peerMessage
+
+	RangeID    RangeID
+	LeaseEpoch uint64
+	Valid      bool
+	At         time.Time
+}
+
+// PeerRangeStolenEvent clears this peer's active range after the manager has
+// transferred its lease to another peer.
+type PeerRangeStolenEvent struct {
+	peerMessage
+
+	RangeID       RangeID
+	OldLeaseEpoch uint64
+}
+
+type peerOutbox interface {
+	peerOutbox()
+}
+
+type peerSnapshotOutbox struct {
+	Peer PeerSnapshot
+}
+
+func (peerSnapshotOutbox) peerOutbox() {}
+
+type peerStartRangeOutbox struct {
+	PeerID string
+}
+
+func (peerStartRangeOutbox) peerOutbox() {}
+
+type peerStealRangeOutbox struct {
+	ThiefID string
+}
+
+func (peerStealRangeOutbox) peerOutbox() {}
+
+type peerCompleteRangeOutbox struct {
+	PeerID     string
+	RangeID    RangeID
+	LeaseEpoch uint64
+	Valid      bool
+	At         time.Time
+}
+
+func (peerCompleteRangeOutbox) peerOutbox() {}
+
+type peerEnv struct {
+	id   string
+	rank int
+}
+
+type peerReadyState struct {
+	rtt time.Duration
+}
+
+func (s peerReadyState) String() string {
+	return "headersync-peer-ready"
+}
+
+func (s peerReadyState) IsTerminal() bool {
+	return false
+}
+
+func (s peerReadyState) ProcessEvent(_ context.Context, msg PeerMsg,
+	env *peerEnv) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	switch m := msg.(type) {
+	case PeerReadyEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerReady,
+			RangeAssignment{}))
+
+	case PeerBlockedEvent:
+		next := peerBlockedState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt,
+			PeerBlocked, RangeAssignment{}))
+
+	case PeerQuarantinedEvent:
+		next := peerQuarantinedState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt,
+			PeerQuarantined, RangeAssignment{}))
+
+	case PeerDownEvent:
+		next := peerDownState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerDown,
+			RangeAssignment{}))
+
+	case PeerRTTEvent:
+		if m.RTT < 0 {
+			return nil, fmt.Errorf("negative RTT: %v", m.RTT)
+		}
+
+		next := peerReadyState{rtt: m.RTT}
+
+		return peerTransition(next, peerSnapshot(env, m.RTT,
+			PeerReady, RangeAssignment{}))
+
+	case PeerRankEvent:
+		env.rank = m.Rank
+
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerReady,
+			RangeAssignment{}))
+
+	case PeerNeedRangeEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerReady,
+			RangeAssignment{}), peerStartRangeOutbox{PeerID: env.id})
+
+	case PeerNeedStealEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerReady,
+			RangeAssignment{}), peerStealRangeOutbox{ThiefID: env.id})
+
+	case PeerRangeAssignedEvent:
+		if m.Assignment.RangeID == NoRange {
+			return nil, fmt.Errorf("empty range assignment")
+		}
+
+		next := peerBusyState{
+			rtt:    s.rtt,
+			active: m.Assignment,
+		}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerBusy,
+			m.Assignment))
+
+	default:
+		return nil, fmt.Errorf("ready peer cannot process %T", msg)
+	}
+}
+
+type peerBusyState struct {
+	rtt    time.Duration
+	active RangeAssignment
+}
+
+func (s peerBusyState) String() string {
+	return "headersync-peer-busy"
+}
+
+func (s peerBusyState) IsTerminal() bool {
+	return false
+}
+
+func (s peerBusyState) ProcessEvent(_ context.Context, msg PeerMsg,
+	env *peerEnv) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	switch m := msg.(type) {
+	case PeerReadyEvent:
+		next := peerReadyState{rtt: s.rtt}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerReady,
+			RangeAssignment{}))
+
+	case PeerBlockedEvent:
+		next := peerBlockedState{rtt: s.rtt, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt,
+			PeerBlocked, s.active))
+
+	case PeerQuarantinedEvent:
+		next := peerQuarantinedState{rtt: s.rtt, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt,
+			PeerQuarantined, s.active))
+
+	case PeerDownEvent:
+		next := peerDownState{rtt: s.rtt, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerDown,
+			s.active))
+
+	case PeerRTTEvent:
+		if m.RTT < 0 {
+			return nil, fmt.Errorf("negative RTT: %v", m.RTT)
+		}
+
+		next := peerBusyState{rtt: m.RTT, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, m.RTT, PeerBusy,
+			s.active))
+
+	case PeerRankEvent:
+		env.rank = m.Rank
+
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerBusy,
+			s.active))
+
+	case PeerRangeCompletedEvent:
+		return completePeerRangeTransition(env, s.rtt, PeerReady, s.active, m)
+
+	case PeerRangeStolenEvent:
+		return clearStolenPeerRangeTransition(
+			env, s.rtt, PeerReady, s.active, m,
+		)
+
+	case PeerNeedRangeEvent, PeerNeedStealEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerBusy,
+			s.active))
+
+	case PeerRangeAssignedEvent:
+		return nil, fmt.Errorf("peer %s already has active range",
+			env.id)
+
+	default:
+		return nil, fmt.Errorf("busy peer cannot process %T", msg)
+	}
+}
+
+type peerBlockedState struct {
+	rtt    time.Duration
+	active RangeAssignment
+}
+
+func (s peerBlockedState) String() string {
+	return "headersync-peer-blocked"
+}
+
+func (s peerBlockedState) IsTerminal() bool {
+	return false
+}
+
+func (s peerBlockedState) ProcessEvent(_ context.Context, msg PeerMsg,
+	env *peerEnv) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	switch m := msg.(type) {
+	case PeerReadyEvent:
+		return peerReadyOrBusyTransition(env, s.rtt, s.active)
+
+	case PeerBlockedEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt,
+			PeerBlocked, s.active))
+
+	case PeerQuarantinedEvent:
+		next := peerQuarantinedState{rtt: s.rtt, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt,
+			PeerQuarantined, s.active))
+
+	case PeerDownEvent:
+		next := peerDownState{rtt: s.rtt, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerDown,
+			s.active))
+
+	case PeerRTTEvent:
+		if m.RTT < 0 {
+			return nil, fmt.Errorf("negative RTT: %v", m.RTT)
+		}
+
+		next := peerBlockedState{rtt: m.RTT, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, m.RTT,
+			PeerBlocked, s.active))
+
+	case PeerRankEvent:
+		env.rank = m.Rank
+
+		return peerTransition(s, peerSnapshot(env, s.rtt,
+			PeerBlocked, s.active))
+
+	case PeerRangeCompletedEvent:
+		return completePeerRangeTransition(env, s.rtt, PeerBlocked, s.active, m)
+
+	case PeerRangeStolenEvent:
+		return clearStolenPeerRangeTransition(
+			env, s.rtt, PeerBlocked, s.active, m,
+		)
+
+	case PeerNeedRangeEvent, PeerNeedStealEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt,
+			PeerBlocked, s.active))
+
+	case PeerRangeAssignedEvent:
+		return nil, fmt.Errorf("blocked peer %s cannot accept range",
+			env.id)
+
+	default:
+		return nil, fmt.Errorf("blocked peer cannot process %T", msg)
+	}
+}
+
+type peerQuarantinedState struct {
+	rtt    time.Duration
+	active RangeAssignment
+}
+
+func (s peerQuarantinedState) String() string {
+	return "headersync-peer-quarantined"
+}
+
+func (s peerQuarantinedState) IsTerminal() bool {
+	return false
+}
+
+func (s peerQuarantinedState) ProcessEvent(_ context.Context, msg PeerMsg,
+	env *peerEnv) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	switch m := msg.(type) {
+	case PeerReadyEvent:
+		return peerReadyOrBusyTransition(env, s.rtt, s.active)
+
+	case PeerBlockedEvent:
+		next := peerBlockedState{rtt: s.rtt, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt,
+			PeerBlocked, s.active))
+
+	case PeerQuarantinedEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt,
+			PeerQuarantined, s.active))
+
+	case PeerDownEvent:
+		next := peerDownState{rtt: s.rtt, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt, PeerDown,
+			s.active))
+
+	case PeerRTTEvent:
+		if m.RTT < 0 {
+			return nil, fmt.Errorf("negative RTT: %v", m.RTT)
+		}
+
+		next := peerQuarantinedState{rtt: m.RTT, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, m.RTT,
+			PeerQuarantined, s.active))
+
+	case PeerRankEvent:
+		env.rank = m.Rank
+
+		return peerTransition(s, peerSnapshot(env, s.rtt,
+			PeerQuarantined, s.active))
+
+	case PeerRangeCompletedEvent:
+		return completePeerRangeTransition(env, s.rtt, PeerQuarantined, s.active, m)
+
+	case PeerRangeStolenEvent:
+		return clearStolenPeerRangeTransition(
+			env, s.rtt, PeerQuarantined, s.active, m,
+		)
+
+	case PeerNeedRangeEvent, PeerNeedStealEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt,
+			PeerQuarantined, s.active))
+
+	case PeerRangeAssignedEvent:
+		return nil, fmt.Errorf("quarantined peer %s cannot accept range",
+			env.id)
+
+	default:
+		return nil, fmt.Errorf("quarantined peer cannot process %T", msg)
+	}
+}
+
+type peerDownState struct {
+	rtt    time.Duration
+	active RangeAssignment
+}
+
+func (s peerDownState) String() string {
+	return "headersync-peer-down"
+}
+
+func (s peerDownState) IsTerminal() bool {
+	return false
+}
+
+func (s peerDownState) ProcessEvent(_ context.Context, msg PeerMsg,
+	env *peerEnv) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	switch m := msg.(type) {
+	case PeerReadyEvent:
+		return peerReadyOrBusyTransition(env, s.rtt, s.active)
+
+	case PeerBlockedEvent:
+		next := peerBlockedState{rtt: s.rtt, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt,
+			PeerBlocked, s.active))
+
+	case PeerQuarantinedEvent:
+		next := peerQuarantinedState{rtt: s.rtt, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, s.rtt,
+			PeerQuarantined, s.active))
+
+	case PeerDownEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerDown,
+			s.active))
+
+	case PeerRTTEvent:
+		if m.RTT < 0 {
+			return nil, fmt.Errorf("negative RTT: %v", m.RTT)
+		}
+
+		next := peerDownState{rtt: m.RTT, active: s.active}
+
+		return peerTransition(next, peerSnapshot(env, m.RTT, PeerDown,
+			s.active))
+
+	case PeerRankEvent:
+		env.rank = m.Rank
+
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerDown,
+			s.active))
+
+	case PeerRangeCompletedEvent:
+		return completePeerRangeTransition(env, s.rtt, PeerDown, s.active, m)
+
+	case PeerRangeStolenEvent:
+		return clearStolenPeerRangeTransition(
+			env, s.rtt, PeerDown, s.active, m,
+		)
+
+	case PeerNeedRangeEvent, PeerNeedStealEvent:
+		return peerTransition(s, peerSnapshot(env, s.rtt, PeerDown,
+			s.active))
+
+	case PeerRangeAssignedEvent:
+		return nil, fmt.Errorf("down peer %s cannot accept range",
+			env.id)
+
+	default:
+		return nil, fmt.Errorf("down peer cannot process %T", msg)
+	}
+}
+
+func peerReadyOrBusyTransition(env *peerEnv, rtt time.Duration,
+	active RangeAssignment) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	if active.RangeID == NoRange {
+		next := peerReadyState{rtt: rtt}
+
+		return peerTransition(next, peerSnapshot(env, rtt, PeerReady,
+			RangeAssignment{}))
+	}
+
+	next := peerBusyState{rtt: rtt, active: active}
+
+	return peerTransition(next, peerSnapshot(env, rtt, PeerBusy, active))
+}
+
+func completePeerRangeTransition(env *peerEnv, rtt time.Duration,
+	state PeerState, active RangeAssignment, event PeerRangeCompletedEvent) (
+	*protofsm.StateTransition[PeerMsg, peerOutbox, *peerEnv], error) {
+
+	if active.RangeID == NoRange {
+		return nil, fmt.Errorf("peer %s has no active range", env.id)
+	}
+	if active.RangeID != event.RangeID ||
+		active.LeaseEpoch != event.LeaseEpoch {
+
+		return nil, fmt.Errorf(
+			"peer %s completion range/epoch mismatch", env.id,
+		)
+	}
+
+	next := peerStateFromSnapshot(state, rtt, RangeAssignment{})
+
+	return peerTransition(next,
+		peerCompleteRangeOutbox{
+			PeerID:     env.id,
+			RangeID:    event.RangeID,
+			LeaseEpoch: event.LeaseEpoch,
+			Valid:      event.Valid,
+			At:         event.At,
+		},
+		peerSnapshot(env, rtt, state, RangeAssignment{}),
+	)
+}
+
+func clearStolenPeerRangeTransition(env *peerEnv, rtt time.Duration,
+	state PeerState, active RangeAssignment, event PeerRangeStolenEvent) (
+	*protofsm.StateTransition[PeerMsg, peerOutbox, *peerEnv], error) {
+
+	if active.RangeID != event.RangeID ||
+		active.LeaseEpoch != event.OldLeaseEpoch {
+
+		return peerTransition(peerStateFromSnapshot(state, rtt, active),
+			peerSnapshot(env, rtt, state, active))
+	}
+
+	return peerTransition(peerStateFromSnapshot(state, rtt, RangeAssignment{}),
+		peerSnapshot(env, rtt, state, RangeAssignment{}))
+}
+
+func peerStateFromSnapshot(state PeerState, rtt time.Duration,
+	active RangeAssignment) protofsm.State[PeerMsg, peerOutbox, *peerEnv] {
+
+	switch state {
+	case PeerReady:
+		if active.RangeID != NoRange {
+			return peerBusyState{rtt: rtt, active: active}
+		}
+
+		return peerReadyState{rtt: rtt}
+
+	case PeerBusy:
+		return peerBusyState{rtt: rtt, active: active}
+
+	case PeerBlocked:
+		return peerBlockedState{rtt: rtt, active: active}
+
+	case PeerQuarantined:
+		return peerQuarantinedState{rtt: rtt, active: active}
+
+	case PeerDown:
+		return peerDownState{rtt: rtt, active: active}
+
+	default:
+		return peerDownState{rtt: rtt, active: active}
+	}
+}
+
+func peerSnapshot(env *peerEnv, rtt time.Duration, state PeerState,
+	active RangeAssignment) peerSnapshotOutbox {
+
+	return peerSnapshotOutbox{
+		Peer: PeerSnapshot{
+			ID:          env.id,
+			Rank:        env.rank,
+			RTT:         rtt,
+			State:       state,
+			ActiveRange: active.RangeID,
+		},
+	}
+}
+
+func peerTransition(next protofsm.State[PeerMsg, peerOutbox, *peerEnv],
+	outbox ...peerOutbox) (*protofsm.StateTransition[
+	PeerMsg, peerOutbox, *peerEnv], error) {
+
+	return &protofsm.StateTransition[PeerMsg, peerOutbox, *peerEnv]{
+		NextState: next,
+		NewEvents: fn.Some(protofsm.EmittedEvent[PeerMsg, peerOutbox]{
+			Outbox: outbox,
+		}),
+	}, nil
+}
+
+// PeerActor owns peer-local header sync state and communicates with the manager
+// only through actor messages emitted from FSM outboxes.
+type PeerActor struct {
+	id          string
+	rank        int
+	manager     *ManagerActor
+	mailboxSize int
+
+	key     actor.ServiceKey[PeerMsg, PeerResp]
+	system  *actor.ActorSystem
+	machine *protofsm.StateMachine[PeerMsg, peerOutbox, *peerEnv]
+	ref     actor.ActorRef[PeerMsg, PeerResp]
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+var _ actor.ActorBehavior[PeerMsg, PeerResp] = (*PeerActor)(nil)
+
+// NewPeerActor creates a peer actor.
+func NewPeerActor(id string, rank int, manager *ManagerActor,
+	mailboxSize int) *PeerActor {
+
+	if mailboxSize <= 0 {
+		mailboxSize = 1
+	}
+
+	return &PeerActor{
+		id:          id,
+		rank:        rank,
+		manager:     manager,
+		mailboxSize: mailboxSize,
+		key: actor.NewServiceKey[PeerMsg, PeerResp](
+			peerActorKey + "-" + id,
+		),
+	}
+}
+
+// Start starts the peer actor and registers its initial snapshot.
+func (p *PeerActor) Start(ctx context.Context) error {
+	var startErr error
+	p.startOnce.Do(func() {
+		p.system = actor.NewActorSystemWithConfig(actor.SystemConfig{
+			MailboxCapacity: p.mailboxSize,
+		})
+
+		machine, err := protofsm.NewStateMachine[PeerMsg, peerOutbox](
+			protofsm.StateMachineCfg[
+				PeerMsg, peerOutbox, *peerEnv,
+			]{
+				InitialState: peerReadyState{},
+				Env: &peerEnv{
+					id:   p.id,
+					rank: p.rank,
+				},
+			},
+		)
+		if err != nil {
+			startErr = err
+			return
+		}
+
+		p.machine = machine
+		p.machine.Start(ctx)
+		p.key.Spawn(p.system, p.id, p)
+
+		refs := actor.FindInReceptionist(
+			p.system.Receptionist(), p.key,
+		)
+		if len(refs) == 0 {
+			startErr = fmt.Errorf("unable to spawn header peer %s",
+				p.id)
+			return
+		}
+		p.ref = refs[0]
+	})
+	if startErr != nil {
+		return startErr
+	}
+
+	return p.Send(ctx, PeerReadyEvent{})
+}
+
+// Stop stops the peer actor.
+func (p *PeerActor) Stop() {
+	p.stopOnce.Do(func() {
+		if p.system != nil {
+			_ = p.system.Shutdown()
+		}
+		if p.machine != nil {
+			p.machine.Stop()
+		}
+	})
+}
+
+// Receive processes one peer actor message.
+func (p *PeerActor) Receive(ctx context.Context,
+	msg PeerMsg) fn.Result[PeerResp] {
+
+	if p.machine == nil {
+		return fn.Err[PeerResp](ErrActorStopped)
+	}
+
+	outbox, err := p.machine.ProcessEvent(ctx, msg)
+	if err != nil {
+		return fn.Err[PeerResp](err)
+	}
+
+	resp, err := p.applyPeerOutbox(ctx, outbox)
+	if err != nil {
+		return fn.Err[PeerResp](err)
+	}
+
+	return fn.Ok(resp)
+}
+
+func (p *PeerActor) applyPeerOutbox(ctx context.Context,
+	outbox []peerOutbox) (PeerResp, error) {
+
+	resp := PeerResp(&PeerAck{})
+	for _, out := range outbox {
+		switch out := out.(type) {
+		case peerSnapshotOutbox:
+			if err := p.manager.AddPeer(ctx, out.Peer); err != nil {
+				return nil, err
+			}
+
+		case peerStartRangeOutbox:
+			assignment, ok, err := p.manager.StartPeerRange(
+				ctx, out.PeerID,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			resp = &PeerRangeResp{
+				Assignment: assignment,
+				OK:         ok,
+			}
+			if ok {
+				followUp, err := p.machine.ProcessEvent(
+					ctx, PeerRangeAssignedEvent{
+						Assignment: assignment,
+					},
+				)
+				if err != nil {
+					return nil, err
+				}
+				if _, err := p.applyPeerOutbox(ctx, followUp); err != nil {
+					return nil, err
+				}
+			}
+
+		case peerStealRangeOutbox:
+			result, ok, err := p.manager.StealNextRange(
+				ctx, out.ThiefID,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			resp = &PeerStealResp{Result: result, OK: ok}
+
+		case peerCompleteRangeOutbox:
+			result, err := p.manager.CompleteRange(
+				ctx, out.PeerID, out.RangeID, out.LeaseEpoch,
+				out.Valid, out.At,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			resp = &PeerCompleteResp{Result: result}
+
+		default:
+			return nil, fmt.Errorf("unknown peer outbox: %T", out)
+		}
+	}
+
+	return resp, nil
+}
+
+// Send applies an event to the peer actor.
+func (p *PeerActor) Send(ctx context.Context, event PeerMsg) error {
+	if p.ref == nil {
+		return ErrActorStopped
+	}
+
+	_, err := p.ref.Ask(ctx, event).Await(ctx).Unpack()
+
+	return err
+}
+
+// RequestRange asks the peer actor to request its next local range from the
+// manager.
+func (p *PeerActor) RequestRange(ctx context.Context) (
+	RangeAssignment, bool, error) {
+
+	if p.ref == nil {
+		return RangeAssignment{}, false, ErrActorStopped
+	}
+
+	resp, err := p.ref.Ask(
+		ctx, PeerNeedRangeEvent{},
+	).Await(ctx).Unpack()
+	if err != nil {
+		return RangeAssignment{}, false, err
+	}
+
+	rangeResp, ok := resp.(*PeerRangeResp)
+	if !ok {
+		if _, ok := resp.(*PeerAck); ok {
+			return RangeAssignment{}, false, nil
+		}
+
+		return RangeAssignment{}, false, fmt.Errorf(
+			"unexpected peer range response: %T", resp,
+		)
+	}
+
+	return rangeResp.Assignment, rangeResp.OK, nil
+}
+
+// RequestStolenRange asks the peer actor to ask the manager for stealable work.
+func (p *PeerActor) RequestStolenRange(ctx context.Context) (
+	StealResult, bool, error) {
+
+	if p.ref == nil {
+		return StealResult{}, false, ErrActorStopped
+	}
+
+	resp, err := p.ref.Ask(
+		ctx, PeerNeedStealEvent{},
+	).Await(ctx).Unpack()
+	if err != nil {
+		return StealResult{}, false, err
+	}
+
+	stealResp, ok := resp.(*PeerStealResp)
+	if !ok {
+		if _, ok := resp.(*PeerAck); ok {
+			return StealResult{}, false, nil
+		}
+
+		return StealResult{}, false, fmt.Errorf(
+			"unexpected peer steal response: %T", resp,
+		)
+	}
+
+	return stealResp.Result, stealResp.OK, nil
+}
+
+// CompleteRange reports this peer's active range completion.
+func (p *PeerActor) CompleteRange(ctx context.Context, rangeID RangeID,
+	leaseEpoch uint64, valid bool, at time.Time) (CompleteResult, error) {
+
+	if p.ref == nil {
+		return CompleteResult{}, ErrActorStopped
+	}
+
+	resp, err := p.ref.Ask(ctx, PeerRangeCompletedEvent{
+		RangeID:    rangeID,
+		LeaseEpoch: leaseEpoch,
+		Valid:      valid,
+		At:         at,
+	}).Await(ctx).Unpack()
+	if err != nil {
+		return CompleteResult{}, err
+	}
+
+	completeResp, ok := resp.(*PeerCompleteResp)
+	if !ok {
+		return CompleteResult{}, fmt.Errorf(
+			"unexpected peer complete response: %T", resp,
+		)
+	}
+
+	return completeResp.Result, nil
+}

--- a/headersync/actor_test.go
+++ b/headersync/actor_test.go
@@ -1,0 +1,342 @@
+package headersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerActorRangeLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	addManagerAnchor(t, ctx, manager, 0, 100)
+	addManagerAnchor(t, ctx, manager, 10, 110)
+	addManagerAnchor(t, ctx, manager, 20, 120)
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "peer1",
+		State: PeerReady,
+	}))
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "peer2",
+		State: PeerReady,
+	}))
+	mustManagerPlan(t, ctx, manager, 1, 0, 10)
+	mustManagerPlan(t, ctx, manager, 2, 10, 20)
+
+	_, ok, err := manager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, ok, err = manager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	first, ok, err := manager.StartPeerRange(ctx, "peer1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	second, ok, err := manager.StartPeerRange(ctx, "peer2")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	_, err = manager.CompleteRange(
+		ctx, "peer2", second.RangeID, second.LeaseEpoch, true,
+		time.Unix(100, 0),
+	)
+	require.NoError(t, err)
+	commit, err := manager.CommitReadyRanges(ctx)
+	require.NoError(t, err)
+	require.Empty(t, commit.Committed)
+
+	stats, err := manager.CommitStats(ctx, time.Unix(105, 0))
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.StagedCount)
+
+	_, err = manager.CompleteRange(
+		ctx, "peer1", first.RangeID, first.LeaseEpoch, true,
+		time.Unix(101, 0),
+	)
+	require.NoError(t, err)
+	commit, err = manager.CommitReadyRanges(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []RangeID{1, 2}, commit.Committed)
+	require.EqualValues(t, 20, commit.TipHeight)
+}
+
+func TestPeerActorRequestsAndCompletesRange(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	addManagerAnchor(t, ctx, manager, 0, 100)
+	addManagerAnchor(t, ctx, manager, 10, 110)
+
+	peer := NewPeerActor("peer", 0, manager, 8)
+	require.NoError(t, peer.Start(ctx))
+	defer peer.Stop()
+
+	mustManagerPlan(t, ctx, manager, 1, 0, 10)
+	_, ok, err := manager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	assignment, ok, err := peer.RequestRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.EqualValues(t, 1, assignment.RangeID)
+
+	snapshot, ok, err := manager.SnapshotPeer(ctx, "peer")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, PeerBusy, snapshot.State)
+	require.EqualValues(t, 1, snapshot.ActiveRange)
+
+	result, err := peer.CompleteRange(
+		ctx, assignment.RangeID, assignment.LeaseEpoch, true,
+		time.Unix(100, 0),
+	)
+	require.NoError(t, err)
+	require.True(t, result.Accepted)
+
+	snapshot, ok, err = manager.SnapshotPeer(ctx, "peer")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, PeerReady, snapshot.State)
+	require.Equal(t, NoRange, snapshot.ActiveRange)
+
+	commit, err := manager.CommitReadyRanges(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []RangeID{1}, commit.Committed)
+}
+
+func TestPeerActorRequestsStolenRange(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	addManagerAnchor(t, ctx, manager, 0, 100)
+	addManagerAnchor(t, ctx, manager, 10, 110)
+	addManagerAnchor(t, ctx, manager, 20, 120)
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "donor",
+		State: PeerReady,
+	}))
+	mustManagerPlan(t, ctx, manager, 1, 0, 10)
+	mustManagerPlan(t, ctx, manager, 2, 10, 20)
+	_, ok, err := manager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, ok, err = manager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	thief := NewPeerActor("thief", 10, manager, 8)
+	require.NoError(t, thief.Start(ctx))
+	defer thief.Stop()
+
+	result, ok, err := thief.RequestStolenRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "thief", result.ThiefID)
+	require.Equal(t, "donor", result.DonorID)
+	require.EqualValues(t, 1, result.RangeID)
+
+	snapshot, ok, err := manager.SnapshotPeer(ctx, "thief")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []RangeID{1}, snapshot.LocalRanges)
+}
+
+func TestPeerActorClearsStolenActiveRange(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	addManagerAnchor(t, ctx, manager, 0, 100)
+	addManagerAnchor(t, ctx, manager, 10, 110)
+
+	donor := NewPeerActor("donor", 0, manager, 8)
+	require.NoError(t, donor.Start(ctx))
+	defer donor.Stop()
+	thief := NewPeerActor("thief", 10, manager, 8)
+	require.NoError(t, thief.Start(ctx))
+	defer thief.Stop()
+
+	mustManagerPlan(t, ctx, manager, 1, 0, 10)
+	_, ok, err := manager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	assignment, ok, err := donor.RequestRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, donor.Send(ctx, PeerQuarantinedEvent{}))
+
+	steal, ok, err := manager.StealRange(ctx, "thief", assignment.RangeID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, donor.Send(ctx, PeerRangeStolenEvent{
+		RangeID:       steal.RangeID,
+		OldLeaseEpoch: steal.OldLeaseEpoch,
+	}))
+	require.NoError(t, donor.Send(ctx, PeerReadyEvent{}))
+
+	snapshot, ok, err := manager.SnapshotPeer(ctx, "donor")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, PeerReady, snapshot.State)
+	require.Equal(t, NoRange, snapshot.ActiveRange)
+}
+
+func TestPeerActorBlockedDoesNotRequestRange(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	peer := NewPeerActor("peer", 0, manager, 8)
+	require.NoError(t, peer.Start(ctx))
+	defer peer.Stop()
+	require.NoError(t, peer.Send(ctx, PeerBlockedEvent{}))
+
+	_, ok, err := peer.RequestRange(ctx)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestPeerActorCompletionPreservesQuarantine(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	addManagerAnchor(t, ctx, manager, 0, 100)
+	addManagerAnchor(t, ctx, manager, 10, 110)
+
+	peer := NewPeerActor("peer", 0, manager, 8)
+	require.NoError(t, peer.Start(ctx))
+	defer peer.Stop()
+
+	mustManagerPlan(t, ctx, manager, 1, 0, 10)
+	_, ok, err := manager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	assignment, ok, err := peer.RequestRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.NoError(t, peer.Send(ctx, PeerQuarantinedEvent{}))
+	result, err := peer.CompleteRange(
+		ctx, assignment.RangeID, assignment.LeaseEpoch, false,
+		time.Unix(100, 0),
+	)
+	require.NoError(t, err)
+	require.True(t, result.Accepted)
+
+	snapshot, ok, err := manager.SnapshotPeer(ctx, "peer")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, PeerQuarantined, snapshot.State)
+	require.Equal(t, NoRange, snapshot.ActiveRange)
+}
+
+func TestManagerActorRecordsStructuredEvents(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	events := &EventRecorder{}
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.SetEventSink(events)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	addManagerAnchor(t, ctx, manager, 0, 100)
+	addManagerAnchor(t, ctx, manager, 10, 110)
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "peer",
+		State: PeerReady,
+	}))
+	mustManagerPlan(t, ctx, manager, 1, 0, 10)
+	assignment, ok, err := manager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assignment, ok, err = manager.StartPeerRange(ctx, assignment.PeerID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, err = manager.CompleteRange(
+		ctx, assignment.PeerID, assignment.RangeID,
+		assignment.LeaseEpoch, true, time.Unix(100, 0),
+	)
+	require.NoError(t, err)
+	_, err = manager.CommitReadyRanges(ctx)
+	require.NoError(t, err)
+
+	var planned, assigned, started, completed, committed *Event
+	for _, event := range events.Events() {
+		event := event
+		switch event.Type {
+		case EventRangePlanned:
+			planned = &event
+		case EventRangeAssigned:
+			assigned = &event
+		case EventRangeStarted:
+			started = &event
+		case EventRangeCompleted:
+			completed = &event
+		case EventRangeCommitted:
+			committed = &event
+		}
+	}
+
+	require.NotNil(t, planned)
+	require.True(t, planned.OK)
+	require.EqualValues(t, 1, planned.RangeID)
+	require.NotNil(t, assigned)
+	require.Equal(t, "peer", assigned.PeerID)
+	require.NotNil(t, started)
+	require.EqualValues(t, 1, started.LeaseEpoch)
+	require.NotNil(t, completed)
+	require.True(t, completed.Valid)
+	require.NotNil(t, committed)
+	require.Equal(t, []RangeID{1}, committed.Committed)
+	require.EqualValues(t, 1, committed.Metrics.RangesCommitted)
+}
+
+func addManagerAnchor(t *testing.T, ctx context.Context,
+	manager *ManagerActor, height uint32, hashByte byte) {
+
+	t.Helper()
+	anchor, ok, err := manager.AddAnchor(ctx, height, testHash(hashByte),
+		true)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, manager.fsm.AnchorConfirmed(anchor))
+}
+
+func mustManagerPlan(t *testing.T, ctx context.Context,
+	manager *ManagerActor, id RangeID, startHeight, stopHeight uint32) {
+
+	t.Helper()
+	_, ok, err := manager.PlanRange(ctx, id, startHeight, stopHeight)
+	require.NoError(t, err)
+	require.True(t, ok)
+}

--- a/headersync/bridge.go
+++ b/headersync/bridge.go
@@ -1,0 +1,279 @@
+package headersync
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// BridgeFixtures contains concrete model stories shared with the P spec. The
+// bridge does not replace P checking; it keeps the same scenarios executable
+// against the Go FSM as the implementation evolves.
+type BridgeFixtures struct {
+	Scenarios []BridgeScenario `json:"scenarios"`
+}
+
+// BridgeScenario describes one deterministic FSM story.
+type BridgeScenario struct {
+	Name          string         `json:"name"`
+	CommittedTip  uint32         `json:"committed_tip"`
+	CommittedHash uint32         `json:"committed_hash"`
+	Anchors       []BridgeAnchor `json:"anchors"`
+	Peers         []BridgePeer   `json:"peers"`
+	Steps         []BridgeStep   `json:"steps"`
+	Expect        BridgeExpect   `json:"expect"`
+}
+
+// BridgeAnchor is the fixture form of Anchor.
+type BridgeAnchor struct {
+	Height  uint32 `json:"height"`
+	Hash    uint32 `json:"hash"`
+	Trusted bool   `json:"trusted"`
+}
+
+// BridgePeer is the fixture form of PeerSnapshot.
+type BridgePeer struct {
+	ID          string    `json:"id"`
+	Rank        int       `json:"rank"`
+	RTTMillis   int       `json:"rtt_ms"`
+	State       string    `json:"state"`
+	LocalRanges []RangeID `json:"local_ranges,omitempty"`
+	ActiveRange RangeID   `json:"active_range,omitempty"`
+}
+
+// BridgeStep is one applied transition.
+type BridgeStep struct {
+	Op          string  `json:"op"`
+	RangeID     RangeID `json:"range_id,omitempty"`
+	StartHeight uint32  `json:"start_height,omitempty"`
+	StopHeight  uint32  `json:"stop_height,omitempty"`
+	PeerID      string  `json:"peer_id,omitempty"`
+	ThiefID     string  `json:"thief_id,omitempty"`
+	LeaseEpoch  uint64  `json:"lease_epoch,omitempty"`
+	Valid       bool    `json:"valid,omitempty"`
+	AtUnix      int64   `json:"at_unix,omitempty"`
+	Height      uint32  `json:"height,omitempty"`
+	Hash        uint32  `json:"hash,omitempty"`
+	Trusted     bool    `json:"trusted,omitempty"`
+}
+
+// BridgeExpect is the comparable output of running a scenario.
+type BridgeExpect struct {
+	CommittedTip      uint32              `json:"committed_tip"`
+	CommittedHash     uint32              `json:"committed_hash"`
+	CommitLog         []RangeID           `json:"commit_log,omitempty"`
+	ReadyRanges       []RangeID           `json:"ready_ranges,omitempty"`
+	ActiveAnchorCount int                 `json:"active_anchor_count,omitempty"`
+	PrunedAnchors     int                 `json:"pruned_anchors,omitempty"`
+	Ranges            []BridgeRangeExpect `json:"ranges,omitempty"`
+	Peers             []BridgePeerExpect  `json:"peers,omitempty"`
+	Metrics           BridgeMetrics       `json:"metrics"`
+}
+
+// BridgeRangeExpect is the fixture form of HeaderRange state.
+type BridgeRangeExpect struct {
+	ID         RangeID `json:"id"`
+	State      string  `json:"state"`
+	OwnerPeer  string  `json:"owner_peer,omitempty"`
+	LeaseEpoch uint64  `json:"lease_epoch,omitempty"`
+	Valid      bool    `json:"valid,omitempty"`
+}
+
+// BridgePeerExpect is the fixture form of peer state after a scenario.
+type BridgePeerExpect struct {
+	ID          string    `json:"id"`
+	State       string    `json:"state"`
+	LocalRanges []RangeID `json:"local_ranges,omitempty"`
+	ActiveRange RangeID   `json:"active_range,omitempty"`
+}
+
+// BridgeMetrics is the fixture subset of Metrics.
+type BridgeMetrics struct {
+	RangesStolen     uint64 `json:"ranges_stolen,omitempty"`
+	RangesCommitted  uint64 `json:"ranges_committed,omitempty"`
+	StaleCompletions uint64 `json:"stale_completions,omitempty"`
+}
+
+// DecodeBridgeFixtures parses model bridge fixtures.
+func DecodeBridgeFixtures(data []byte) (BridgeFixtures, error) {
+	var fixtures BridgeFixtures
+	if err := json.Unmarshal(data, &fixtures); err != nil {
+		return BridgeFixtures{}, err
+	}
+
+	return fixtures, nil
+}
+
+// RunBridgeScenario applies a bridge scenario to the Go FSM.
+func RunBridgeScenario(scenario BridgeScenario) (BridgeExpect, error) {
+	fsm := NewHeaderSyncFSM(
+		scenario.CommittedTip, hashFromBridge(scenario.CommittedHash),
+		DefaultConfig(),
+	)
+	session := NewSession()
+	var prunedAnchors int
+
+	for _, anchor := range scenario.Anchors {
+		fsm.AddOrConfirmAnchor(
+			anchor.Height, hashFromBridge(anchor.Hash),
+			anchor.Trusted,
+		)
+	}
+
+	for _, peer := range scenario.Peers {
+		state, err := ParsePeerState(peer.State)
+		if err != nil {
+			return BridgeExpect{}, err
+		}
+
+		err = fsm.AddPeer(PeerSnapshot{
+			ID:          peer.ID,
+			Rank:        peer.Rank,
+			RTT:         time.Duration(peer.RTTMillis) * time.Millisecond,
+			State:       state,
+			LocalRanges: peer.LocalRanges,
+			ActiveRange: peer.ActiveRange,
+		})
+		if err != nil {
+			return BridgeExpect{}, err
+		}
+	}
+
+	for _, step := range scenario.Steps {
+		if err := runBridgeStep(fsm, session, &prunedAnchors,
+			step); err != nil {
+
+			return BridgeExpect{}, fmt.Errorf(
+				"%s: %w", scenario.Name, err,
+			)
+		}
+	}
+
+	return bridgeObserve(fsm, session, prunedAnchors), nil
+}
+
+func runBridgeStep(fsm *HeaderSyncFSM, session *Session,
+	prunedAnchors *int, step BridgeStep) error {
+
+	switch step.Op {
+	case "anchor":
+		fsm.AddOrConfirmAnchor(
+			step.Height, hashFromBridge(step.Hash), step.Trusted,
+		)
+
+	case "track_anchor":
+		session.TrackAnchor(step.PeerID, AnchorRequest{
+			StartHeight: step.StartHeight,
+			StopHeight:  step.StopHeight,
+		})
+
+	case "plan":
+		_, _, err := fsm.PlanRange(
+			step.RangeID, step.StartHeight, step.StopHeight,
+		)
+		return err
+
+	case "assign":
+		if _, ok := fsm.AssignNextQueuedRange(); !ok {
+			return fmt.Errorf("assign found no work or owner")
+		}
+
+	case "start":
+		if _, ok, err := fsm.StartPeerRange(step.PeerID); err != nil {
+			return err
+		} else if !ok {
+			return fmt.Errorf("peer %s could not start range",
+				step.PeerID)
+		}
+
+	case "steal":
+		if _, ok, err := fsm.StealRange(
+			step.ThiefID, step.RangeID,
+		); err != nil {
+			return err
+		} else if !ok {
+			return fmt.Errorf("peer %s could not steal range %d",
+				step.ThiefID, step.RangeID)
+		}
+
+	case "complete":
+		_, err := fsm.CompleteRangeAt(
+			step.PeerID, step.RangeID, step.LeaseEpoch,
+			step.Valid, time.Unix(step.AtUnix, 0),
+		)
+		return err
+
+	case "commit":
+		fsm.CommitReadyRanges()
+
+	case "commit_and_prune":
+		commit := fsm.CommitReadyRanges()
+		if len(commit.Committed) > 0 {
+			*prunedAnchors += session.PruneAnchorsAtOrBefore(
+				commit.TipHeight,
+			)
+		}
+
+	default:
+		return fmt.Errorf("unknown bridge op %q", step.Op)
+	}
+
+	return nil
+}
+
+func bridgeObserve(fsm *HeaderSyncFSM, session *Session,
+	prunedAnchors int) BridgeExpect {
+
+	ranges := fsm.Ranges()
+	var rangeExpect []BridgeRangeExpect
+	for _, rng := range ranges {
+		rangeExpect = append(rangeExpect, BridgeRangeExpect{
+			ID:         rng.ID,
+			State:      rng.State.String(),
+			OwnerPeer:  rng.OwnerPeer,
+			LeaseEpoch: rng.LeaseEpoch,
+			Valid:      rng.Valid,
+		})
+	}
+
+	peers := fsm.Peers()
+	var peerExpect []BridgePeerExpect
+	for _, peer := range peers {
+		peerExpect = append(peerExpect, BridgePeerExpect{
+			ID:          peer.ID,
+			State:       peer.State.String(),
+			LocalRanges: peer.LocalRanges,
+			ActiveRange: peer.ActiveRange,
+		})
+	}
+
+	metrics := fsm.Metrics()
+
+	return BridgeExpect{
+		CommittedTip:      fsm.CommittedTip(),
+		CommittedHash:     hashToBridge(fsm.CommittedHash()),
+		CommitLog:         fsm.CommitLog(),
+		ReadyRanges:       fsm.ReadyRanges(),
+		ActiveAnchorCount: session.ActiveAnchorCount(),
+		PrunedAnchors:     prunedAnchors,
+		Ranges:            rangeExpect,
+		Peers:             peerExpect,
+		Metrics: BridgeMetrics{
+			RangesStolen:     metrics.RangesStolen,
+			RangesCommitted:  metrics.RangesCommitted,
+			StaleCompletions: metrics.StaleCompletions,
+		},
+	}
+}
+
+func hashFromBridge(value uint32) Hash {
+	var hash Hash
+	binary.LittleEndian.PutUint32(hash[:4], value)
+
+	return hash
+}
+
+func hashToBridge(hash Hash) uint32 {
+	return binary.LittleEndian.Uint32(hash[:4])
+}

--- a/headersync/controller.go
+++ b/headersync/controller.go
@@ -1,0 +1,479 @@
+package headersync
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+// ChainPoint identifies a known header boundary.
+type ChainPoint struct {
+	Height uint32
+	Hash   Hash
+}
+
+// CheckpointRangePlan describes the result of one checkpoint-backed planning
+// pass. Ranges may be empty because the span is already planned, the peer set
+// is not high enough yet, or intermediate anchors are still needed.
+type CheckpointRangePlan struct {
+	Ranges            []HeaderRange
+	WaitingForAnchors bool
+	Span              uint32
+	MaxRangeHeaders   uint32
+}
+
+// PeerCandidate is the controller's peer-selection view. Production callers
+// keep concrete peer I/O outside headersync and pass this narrow snapshot in.
+type PeerCandidate struct {
+	ID     string
+	Height int32
+}
+
+// AnchorRequestPlan describes which peers should receive an anchor-discovery
+// getheaders request for a span.
+type AnchorRequestPlan struct {
+	Peers         []PeerCandidate
+	ActivePeers   int
+	EligiblePeers int
+	RequiredPeers int
+	Deferred      bool
+}
+
+// Active returns true when discovery is either already in flight or new peer
+// requests should be sent.
+func (a AnchorRequestPlan) Active() bool {
+	return a.Deferred || len(a.Peers) > 0
+}
+
+// ReplanResult records a replacement range planned after a failed response.
+type ReplanResult struct {
+	Range HeaderRange
+	ID    RangeID
+	OK    bool
+}
+
+// CommitReadyResult reports the FSM commit plus production session cleanup
+// performed after the visible header tip advances.
+type CommitReadyResult struct {
+	Commit        CommitResult
+	PrunedAnchors int
+}
+
+// AnchorHeadersResult reports how one anchor-discovery response was handled.
+type AnchorHeadersResult struct {
+	Request  AnchorRequest
+	Response AnchorResponse
+	Anchor   Anchor
+	Range    HeaderRange
+
+	Confirmed bool
+	Rejected  bool
+	Staged    bool
+	Reason    string
+}
+
+// Controller owns production header-sync orchestration policy that is
+// independent of blockmanager's storage and peer I/O. It composes the actor FSM
+// with request/session bookkeeping.
+type Controller struct {
+	manager *ManagerActor
+	session *Session
+	cfg     Config
+}
+
+// NewController creates a production controller around the manager actor and
+// session. The caller remains responsible for starting the manager actor.
+func NewController(manager *ManagerActor, session *Session,
+	cfg Config) *Controller {
+
+	if session == nil {
+		session = NewSession()
+	}
+
+	return &Controller{
+		manager: manager,
+		session: session,
+		cfg:     cfg.normalize(),
+	}
+}
+
+// Session returns the request bookkeeping state owned by the controller.
+func (c *Controller) Session() *Session {
+	return c.session
+}
+
+// PlanCheckpointRanges seeds the current tip and stop checkpoint as trusted
+// anchors, then plans all adjacent confirmed ranges between them. It does not
+// invent missing boundary hashes; callers should start anchor discovery when
+// WaitingForAnchors is true.
+func (c *Controller) PlanCheckpointRanges(ctx context.Context,
+	tip, stop ChainPoint, bestHeight uint32) (CheckpointRangePlan, error) {
+
+	if c == nil || c.manager == nil {
+		return CheckpointRangePlan{}, nil
+	}
+	if tip.Height >= stop.Height || bestHeight < stop.Height {
+		return CheckpointRangePlan{}, nil
+	}
+
+	if _, ok, err := c.manager.AddAnchor(ctx, tip.Height, tip.Hash,
+		true); err != nil {
+
+		return CheckpointRangePlan{}, err
+	} else if !ok {
+		return CheckpointRangePlan{}, nil
+	}
+
+	if _, ok, err := c.manager.AddAnchor(ctx, stop.Height, stop.Hash,
+		true); err != nil {
+
+		return CheckpointRangePlan{}, err
+	} else if !ok {
+		return CheckpointRangePlan{}, nil
+	}
+
+	result, err := c.manager.PlanConfirmedAnchorRanges(
+		ctx, c.session.NextRangeID(), tip.Height, stop.Height,
+	)
+	if err != nil {
+		return CheckpointRangePlan{}, err
+	}
+	c.session.SetNextRangeID(result.NextID)
+
+	span := stop.Height - tip.Height
+	return CheckpointRangePlan{
+		Ranges:            result.Ranges,
+		WaitingForAnchors: len(result.Ranges) == 0 && span > c.cfg.MaxRangeHeaders,
+		Span:              span,
+		MaxRangeHeaders:   c.cfg.MaxRangeHeaders,
+	}, nil
+}
+
+// AnchorDiscoverySpan returns the next span that needs anchor discovery before
+// it can be split into bounded parallel getheaders ranges. Discovery advances
+// from the furthest confirmed anchor ahead of the committed tip so range
+// downloads and future-anchor discovery can be pipelined.
+func (c *Controller) AnchorDiscoverySpan(ctx context.Context,
+	tip, stop ChainPoint, bestHeight uint32) (AnchorRequest, bool, error) {
+
+	if c == nil || c.manager == nil {
+		return AnchorRequest{}, false, nil
+	}
+
+	if tip.Height >= stop.Height || bestHeight < stop.Height {
+		return AnchorRequest{}, false, nil
+	}
+
+	start := tip
+	anchors, err := c.manager.Anchors(ctx)
+	if err != nil {
+		return AnchorRequest{}, false, err
+	}
+	for _, anchor := range anchors {
+		if anchor.Height < tip.Height || anchor.Height >= stop.Height {
+			continue
+		}
+		if !c.AnchorConfirmed(anchor) {
+			continue
+		}
+		if anchor.Height > start.Height {
+			start = ChainPoint{
+				Height: anchor.Height,
+				Hash:   anchor.Hash,
+			}
+		}
+	}
+
+	if stop.Height-start.Height <= c.cfg.MaxRangeHeaders {
+
+		return AnchorRequest{}, false, nil
+	}
+
+	return AnchorRequest{
+		StartHeight: start.Height,
+		StartHash:   start.Hash,
+		StopHeight:  stop.Height,
+		StopHash:    stop.Hash,
+	}, true, nil
+}
+
+// FrontierDiscoverySpan returns the next untrusted discovery span after the
+// final checkpoint. There is no known stop hash in this lane, so the request
+// uses a zero stop hash and bounds the expected response by height only. A
+// returned boundary still needs the normal independent confirmation policy
+// before it can become staged range work.
+func (c *Controller) FrontierDiscoverySpan(ctx context.Context,
+	tip ChainPoint, bestHeight uint32) (AnchorRequest, bool, error) {
+
+	if c == nil || c.manager == nil {
+		return AnchorRequest{}, false, nil
+	}
+	if tip.Height >= bestHeight {
+		return AnchorRequest{}, false, nil
+	}
+
+	start := tip
+	anchors, err := c.manager.Anchors(ctx)
+	if err != nil {
+		return AnchorRequest{}, false, err
+	}
+	for _, anchor := range anchors {
+		if anchor.Height < tip.Height || anchor.Height >= bestHeight {
+			continue
+		}
+		if !c.AnchorConfirmed(anchor) {
+			continue
+		}
+		if anchor.Height > start.Height {
+			start = ChainPoint{
+				Height: anchor.Height,
+				Hash:   anchor.Hash,
+			}
+		}
+	}
+
+	span, ok := c.FrontierLookaheadSpan(start, bestHeight)
+	return span, ok, nil
+}
+
+// FrontierLookaheadSpan returns the next zero-stop discovery request after a
+// confirmed frontier boundary. Production calls this as soon as an anchor
+// response has been structurally validated, before the just-downloaded range is
+// committed, so network discovery can overlap ordered local commit work.
+func (c *Controller) FrontierLookaheadSpan(start ChainPoint,
+	bestHeight uint32) (AnchorRequest, bool) {
+
+	if c == nil {
+		return AnchorRequest{}, false
+	}
+	if start.Height >= bestHeight {
+		return AnchorRequest{}, false
+	}
+
+	stopHeight := bestHeight
+	if stopHeight-start.Height > c.cfg.MaxRangeHeaders {
+		stopHeight = start.Height + c.cfg.MaxRangeHeaders
+	}
+	if stopHeight <= start.Height {
+		return AnchorRequest{}, false
+	}
+
+	return AnchorRequest{
+		StartHeight: start.Height,
+		StartHash:   start.Hash,
+		StopHeight:  stopHeight,
+	}, true
+}
+
+// PlanAnchorRequests selects peers for an anchor-discovery span while
+// respecting active range/anchor requests and excluded peers.
+func (c *Controller) PlanAnchorRequests(span AnchorRequest,
+	peers []PeerCandidate, excludedPeers ...string) AnchorRequestPlan {
+
+	requiredPeers := c.cfg.AnchorConfirmationsRequired
+	requestFanout := c.cfg.AnchorRequestFanout
+	excluded := make(map[string]struct{}, len(excludedPeers))
+	for _, peerID := range excludedPeers {
+		excluded[peerID] = struct{}{}
+	}
+
+	activePeers := c.session.MatchingActiveAnchors(
+		span.StartHeight, span.StartHash, span.StopHeight,
+	)
+	if activePeers >= requestFanout {
+		return AnchorRequestPlan{
+			ActivePeers:   activePeers,
+			RequiredPeers: requiredPeers,
+			Deferred:      true,
+		}
+	}
+
+	eligiblePeers := make([]PeerCandidate, 0, len(peers))
+	for _, peer := range peers {
+		if peer.Height < int32(span.StopHeight) {
+			continue
+		}
+		if _, ok := excluded[peer.ID]; ok {
+			continue
+		}
+		if c.session.RangeActive(peer.ID) ||
+			c.session.AnchorActive(peer.ID) {
+
+			continue
+		}
+
+		eligiblePeers = append(eligiblePeers, peer)
+	}
+
+	plan := AnchorRequestPlan{
+		ActivePeers:   activePeers,
+		EligiblePeers: len(eligiblePeers),
+		RequiredPeers: requiredPeers,
+	}
+	need := requestFanout - activePeers
+	if need > len(eligiblePeers) {
+		need = len(eligiblePeers)
+	}
+	if activePeers+len(eligiblePeers) < requestFanout {
+		plan.Deferred = activePeers > 0 || need > 0
+		plan.Peers = append(plan.Peers, eligiblePeers[:need]...)
+		return plan
+	}
+
+	plan.Peers = append(plan.Peers, eligiblePeers[:need]...)
+
+	return plan
+}
+
+// AnchorConfirmed returns true when an anchor can be used for range planning.
+func (c *Controller) AnchorConfirmed(anchor Anchor) bool {
+	return !anchor.Rejected && (anchor.Trusted ||
+		anchor.Confirmations >= c.cfg.AnchorConfirmationsRequired)
+}
+
+// FinishAnchorHeaders validates an in-flight anchor-discovery response and
+// records the discovered boundary in the manager FSM. The caller remains
+// responsible for peer I/O and any peer punishment/disconnect policy.
+func (c *Controller) FinishAnchorHeaders(ctx context.Context,
+	peerID string, headers []*wire.BlockHeader,
+	maxHeaders uint32) (AnchorHeadersResult, bool, error) {
+
+	if c == nil || c.manager == nil || c.session == nil {
+		return AnchorHeadersResult{}, false, nil
+	}
+
+	request, ok := c.session.FinishAnchor(peerID)
+	if !ok {
+		return AnchorHeadersResult{}, false, nil
+	}
+
+	result := AnchorHeadersResult{
+		Request: request,
+	}
+	response, err := ValidateAnchorResponse(
+		request, headers, maxHeaders,
+	)
+	if err != nil {
+		result.Rejected = true
+		result.Reason = err.Error()
+
+		return result, true, nil
+	}
+	result.Response = response
+
+	anchor, ok, err := c.manager.AddAnchor(
+		ctx, response.Height, response.Hash, response.Trusted,
+	)
+	if err != nil {
+		return result, true, err
+	}
+
+	result.Anchor = anchor
+	if !ok || anchor.Rejected {
+		result.Rejected = true
+		result.Reason = fmt.Sprintf(
+			"conflicting anchor height=%d hash=%s",
+			response.Height, response.Hash,
+		)
+
+		return result, true, nil
+	}
+
+	result.Confirmed = c.AnchorConfirmed(anchor)
+	if result.Confirmed {
+		rangeID := c.session.NextRangeID()
+		rng, staged, err := c.manager.StageDiscoveredRange(
+			ctx, rangeID, peerID, request.StartHeight,
+			response.Height, time.Now(),
+		)
+		if err != nil {
+			return result, true, err
+		}
+		if staged {
+			result.Range = rng
+			result.Staged = true
+			c.session.SetNextRangeID(rangeID + 1)
+		}
+	}
+
+	return result, true, nil
+}
+
+// AssignQueuedRanges mirrors queued ranges into the shared dispatch scheduler
+// until either the queues are filled or no queued range remains.
+func (c *Controller) AssignQueuedRanges(ctx context.Context,
+	peerCount int) ([]RangeAssignment, error) {
+
+	if c == nil || c.manager == nil || peerCount <= 0 {
+		return nil, nil
+	}
+
+	maxAssignments := peerCount * c.cfg.MaxPeerOutstandingRanges
+	assignments := make([]RangeAssignment, 0, maxAssignments)
+	for i := 0; i < maxAssignments; i++ {
+		assignment, ok, err := c.manager.AssignNextQueuedRange(ctx)
+		if err != nil {
+			return assignments, err
+		}
+		if !ok {
+			break
+		}
+
+		assignments = append(assignments, assignment)
+	}
+
+	return assignments, nil
+}
+
+// CommitReadyRanges advances the manager FSM through contiguous staged ranges
+// and drops obsolete in-flight anchor requests that can no longer produce new
+// work. This keeps late hedged discovery from blocking the next span until its
+// timeout after another peer has already committed the same stop height.
+func (c *Controller) CommitReadyRanges(ctx context.Context) (
+	CommitReadyResult, error) {
+
+	if c == nil || c.manager == nil {
+		return CommitReadyResult{}, nil
+	}
+
+	commit, err := c.manager.CommitReadyRanges(ctx)
+	if err != nil {
+		return CommitReadyResult{}, err
+	}
+
+	var pruned int
+	if c.session != nil && len(commit.Committed) > 0 {
+		pruned = c.session.PruneAnchorsAtOrBefore(commit.TipHeight)
+	}
+
+	return CommitReadyResult{
+		Commit:        commit,
+		PrunedAnchors: pruned,
+	}, nil
+}
+
+// ReplanRange allocates a new range ID and requeues a failed span.
+func (c *Controller) ReplanRange(ctx context.Context,
+	rng HeaderRange) (ReplanResult, error) {
+
+	if c == nil || c.manager == nil {
+		return ReplanResult{}, fmt.Errorf("%w: missing controller",
+			ErrInvalidRange)
+	}
+
+	retryID := c.session.AllocateRangeID()
+	retry, ok, err := c.manager.PlanRange(
+		ctx, retryID, rng.StartHeight, rng.StopHeight,
+	)
+	if err != nil {
+		return ReplanResult{ID: retryID}, err
+	}
+
+	return ReplanResult{
+		Range: retry,
+		ID:    retryID,
+		OK:    ok,
+	}, nil
+}

--- a/headersync/controller_test.go
+++ b/headersync/controller_test.go
@@ -1,0 +1,497 @@
+package headersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestControllerPlansCheckpointRanges(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	session := NewSession()
+	controller := NewController(manager, session, DefaultConfig())
+
+	plan, err := controller.PlanCheckpointRanges(
+		ctx,
+		ChainPoint{Height: 0, Hash: testHash(100)},
+		ChainPoint{Height: 10, Hash: testHash(110)},
+		10,
+	)
+	require.NoError(t, err)
+	require.False(t, plan.WaitingForAnchors)
+	require.Len(t, plan.Ranges, 1)
+	require.EqualValues(t, 1, plan.Ranges[0].ID)
+	require.EqualValues(t, 2, session.NextRangeID())
+
+	plan, err = controller.PlanCheckpointRanges(
+		ctx,
+		ChainPoint{Height: 0, Hash: testHash(100)},
+		ChainPoint{Height: 10, Hash: testHash(110)},
+		10,
+	)
+	require.NoError(t, err)
+	require.Empty(t, plan.Ranges)
+	require.False(t, plan.WaitingForAnchors)
+	require.EqualValues(t, 2, session.NextRangeID())
+}
+
+func TestControllerReportsAnchorDiscoveryNeeded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	cfg := DefaultConfig()
+	cfg.MaxRangeHeaders = 5
+
+	manager := NewManagerActor(
+		NewHeaderSyncFSM(0, testHash(100), cfg), 8,
+	)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	controller := NewController(manager, NewSession(), cfg)
+	plan, err := controller.PlanCheckpointRanges(
+		ctx,
+		ChainPoint{Height: 0, Hash: testHash(100)},
+		ChainPoint{Height: 10, Hash: testHash(110)},
+		10,
+	)
+	require.NoError(t, err)
+	require.Empty(t, plan.Ranges)
+	require.True(t, plan.WaitingForAnchors)
+	require.EqualValues(t, 10, plan.Span)
+	require.EqualValues(t, 5, plan.MaxRangeHeaders)
+
+	span, ok, err := controller.AnchorDiscoverySpan(
+		ctx,
+		ChainPoint{Height: 0, Hash: testHash(100)},
+		ChainPoint{Height: 10, Hash: testHash(110)},
+		10,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.EqualValues(t, 0, span.StartHeight)
+	require.EqualValues(t, 10, span.StopHeight)
+}
+
+func TestControllerAnchorDiscoveryStartsAtFurthestConfirmedAnchor(
+	t *testing.T) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	cfg := DefaultConfig()
+	cfg.MaxRangeHeaders = 5
+
+	manager := NewManagerActor(
+		NewHeaderSyncFSM(0, testHash(100), cfg), 8,
+	)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	session := NewSession()
+	session.TrackRange("busy", RangeRequest{
+		Assignment: RangeAssignment{RangeID: 1},
+	})
+	controller := NewController(manager, session, cfg)
+
+	_, ok, err := manager.AddAnchor(ctx, 5, testHash(105), false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, ok, err = manager.AddAnchor(ctx, 5, testHash(105), false)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	span, ok, err := controller.AnchorDiscoverySpan(
+		ctx,
+		ChainPoint{Height: 0, Hash: testHash(100)},
+		ChainPoint{Height: 20, Hash: testHash(120)},
+		20,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.EqualValues(t, 5, span.StartHeight)
+	require.Equal(t, testHash(105), span.StartHash)
+	require.EqualValues(t, 20, span.StopHeight)
+}
+
+func TestControllerFrontierDiscoverySpan(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	cfg := DefaultConfig()
+	cfg.MaxRangeHeaders = 5
+
+	manager := NewManagerActor(
+		NewHeaderSyncFSM(0, testHash(100), cfg), 8,
+	)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	controller := NewController(manager, NewSession(), cfg)
+	_, ok, err := manager.AddAnchor(ctx, 5, testHash(105), false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, ok, err = manager.AddAnchor(ctx, 5, testHash(105), false)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	span, ok, err := controller.FrontierDiscoverySpan(
+		ctx, ChainPoint{Height: 0, Hash: testHash(100)}, 20,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.EqualValues(t, 5, span.StartHeight)
+	require.Equal(t, testHash(105), span.StartHash)
+	require.EqualValues(t, 10, span.StopHeight)
+	require.Equal(t, Hash{}, span.StopHash)
+}
+
+func TestControllerFrontierLookaheadSpan(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxRangeHeaders = 5
+
+	controller := NewController(nil, NewSession(), cfg)
+	span, ok := controller.FrontierLookaheadSpan(
+		ChainPoint{
+			Height: 10,
+			Hash:   testHash(110),
+		},
+		20,
+	)
+	require.True(t, ok)
+	require.EqualValues(t, 10, span.StartHeight)
+	require.Equal(t, testHash(110), span.StartHash)
+	require.EqualValues(t, 15, span.StopHeight)
+	require.Equal(t, Hash{}, span.StopHash)
+
+	span, ok = controller.FrontierLookaheadSpan(
+		ChainPoint{
+			Height: 15,
+			Hash:   testHash(115),
+		},
+		18,
+	)
+	require.True(t, ok)
+	require.EqualValues(t, 15, span.StartHeight)
+	require.EqualValues(t, 18, span.StopHeight)
+
+	_, ok = controller.FrontierLookaheadSpan(
+		ChainPoint{
+			Height: 18,
+			Hash:   testHash(118),
+		},
+		18,
+	)
+	require.False(t, ok)
+}
+
+func TestControllerPlanAnchorRequestsFiltersPeers(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.AnchorConfirmationsRequired = 2
+
+	session := NewSession()
+	session.TrackAnchor("active", AnchorRequest{
+		StartHeight: 0,
+		StartHash:   testHash(100),
+		StopHeight:  10,
+		StopHash:    testHash(110),
+	})
+	session.TrackRange("busy", RangeRequest{
+		Assignment: RangeAssignment{RangeID: 1},
+	})
+
+	controller := NewController(nil, session, cfg)
+	plan := controller.PlanAnchorRequests(
+		AnchorRequest{
+			StartHeight: 0,
+			StartHash:   testHash(100),
+			StopHeight:  10,
+			StopHash:    testHash(110),
+		},
+		[]PeerCandidate{
+			{ID: "short", Height: 9},
+			{ID: "excluded", Height: 10},
+			{ID: "busy", Height: 10},
+			{ID: "next", Height: 10},
+			{ID: "extra", Height: 10},
+		},
+		"excluded",
+	)
+
+	require.Equal(t, 1, plan.ActivePeers)
+	require.Equal(t, 2, plan.EligiblePeers)
+	require.Equal(t, 2, plan.RequiredPeers)
+	require.Len(t, plan.Peers, 1)
+	require.Equal(t, "next", plan.Peers[0].ID)
+	require.True(t, plan.Active())
+}
+
+func TestControllerPlanAnchorRequestsStartsPartialDiscovery(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.AnchorConfirmationsRequired = 2
+
+	controller := NewController(nil, NewSession(), cfg)
+	plan := controller.PlanAnchorRequests(
+		AnchorRequest{
+			StartHeight: 0,
+			StartHash:   testHash(100),
+			StopHeight:  10,
+			StopHash:    testHash(110),
+		},
+		[]PeerCandidate{
+			{ID: "only-peer", Height: 10},
+		},
+	)
+
+	require.Equal(t, 1, plan.EligiblePeers)
+	require.Equal(t, 2, plan.RequiredPeers)
+	require.True(t, plan.Deferred)
+	require.Len(t, plan.Peers, 1)
+	require.Equal(t, "only-peer", plan.Peers[0].ID)
+	require.True(t, plan.Active())
+}
+
+func TestControllerPlanAnchorRequestsHedgesBeyondConfirmationCount(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.AnchorConfirmationsRequired = 1
+	cfg.AnchorRequestFanout = 3
+
+	controller := NewController(nil, NewSession(), cfg)
+	plan := controller.PlanAnchorRequests(
+		AnchorRequest{
+			StartHeight: 0,
+			StartHash:   testHash(100),
+			StopHeight:  10,
+			StopHash:    testHash(110),
+		},
+		[]PeerCandidate{
+			{ID: "peer-1", Height: 10},
+			{ID: "peer-2", Height: 10},
+			{ID: "peer-3", Height: 10},
+			{ID: "peer-4", Height: 10},
+		},
+	)
+
+	require.Equal(t, 4, plan.EligiblePeers)
+	require.Equal(t, 1, plan.RequiredPeers)
+	require.Len(t, plan.Peers, 3)
+	require.Equal(t, "peer-1", plan.Peers[0].ID)
+	require.Equal(t, "peer-2", plan.Peers[1].ID)
+	require.Equal(t, "peer-3", plan.Peers[2].ID)
+}
+
+func TestControllerFinishAnchorHeadersConfirmsDiscovery(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	cfg := DefaultConfig()
+	cfg.AnchorConfirmationsRequired = 2
+
+	start := testHash(100)
+	headers := makeTestHeaders(start, 2)
+	request := AnchorRequest{
+		StartHeight: 0,
+		StartHash:   start,
+		StopHeight:  10,
+		StopHash:    testHash(110),
+	}
+
+	manager := NewManagerActor(NewHeaderSyncFSM(0, start, cfg), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+	_, ok, err := manager.AddAnchor(ctx, 0, start, true)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	session := NewSession()
+	session.TrackAnchor("peer-a", request)
+	controller := NewController(manager, session, cfg)
+
+	result, ok, err := controller.FinishAnchorHeaders(
+		ctx, "peer-a", headers, DefaultMaxRangeHeaders,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, result.Rejected)
+	require.False(t, result.Response.Trusted)
+	require.False(t, result.Confirmed)
+	require.EqualValues(t, 2, result.Response.Height)
+	require.Equal(t, headers[1].BlockHash(), result.Response.Hash)
+	require.False(t, session.AnchorActive("peer-a"))
+
+	session.TrackAnchor("peer-b", request)
+	result, ok, err = controller.FinishAnchorHeaders(
+		ctx, "peer-b", headers, DefaultMaxRangeHeaders,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, result.Rejected)
+	require.True(t, result.Confirmed)
+	require.Equal(t, 2, result.Anchor.Confirmations)
+	require.True(t, result.Staged)
+	require.EqualValues(t, 1, result.Range.ID)
+	require.EqualValues(t, 0, result.Range.StartHeight)
+	require.EqualValues(t, 2, result.Range.StopHeight)
+	require.Equal(t, RangeStaged, result.Range.State)
+}
+
+func TestControllerFinishAnchorHeadersRejectsInvalidResponse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	start := testHash(100)
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	session := NewSession()
+	session.TrackAnchor("peer-a", AnchorRequest{
+		StartHeight: 0,
+		StartHash:   start,
+		StopHeight:  10,
+		StopHash:    testHash(110),
+	})
+	controller := NewController(manager, session, DefaultConfig())
+
+	result, ok, err := controller.FinishAnchorHeaders(
+		ctx, "peer-a", makeTestHeaders(testHash(101), 1),
+		DefaultMaxRangeHeaders,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, result.Rejected)
+	require.Contains(t, result.Reason, ErrRangeStartMismatch.Error())
+	require.False(t, session.AnchorActive("peer-a"))
+}
+
+func TestControllerAssignQueuedRangesHonorsControllerLimit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	addManagerAnchor(t, ctx, manager, 0, 100)
+	addManagerAnchor(t, ctx, manager, 10, 110)
+	addManagerAnchor(t, ctx, manager, 20, 120)
+	addManagerAnchor(t, ctx, manager, 30, 130)
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "peer",
+		State: PeerReady,
+	}))
+	mustManagerPlan(t, ctx, manager, 1, 0, 10)
+	mustManagerPlan(t, ctx, manager, 2, 10, 20)
+	mustManagerPlan(t, ctx, manager, 3, 20, 30)
+
+	cfg := DefaultConfig()
+	cfg.MaxPeerOutstandingRanges = 2
+	controller := NewController(manager, NewSession(), cfg)
+
+	assignments, err := controller.AssignQueuedRanges(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, assignments, 2)
+	require.EqualValues(t, 1, assignments[0].RangeID)
+	require.EqualValues(t, 2, assignments[1].RangeID)
+}
+
+func TestControllerCommitReadyPrunesObsoleteAnchors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	addManagerAnchor(t, ctx, manager, 0, 100)
+	addManagerAnchor(t, ctx, manager, 10, 110)
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "peer",
+		State: PeerReady,
+	}))
+	mustManagerPlan(t, ctx, manager, 1, 0, 10)
+	_, ok, err := manager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assignment, ok, err := manager.StartPeerRange(ctx, "peer")
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, err = manager.CompleteRange(
+		ctx, "peer", assignment.RangeID, assignment.LeaseEpoch, true,
+		time.Now(),
+	)
+	require.NoError(t, err)
+
+	session := NewSession()
+	session.TrackAnchor("obsolete", AnchorRequest{
+		StartHeight: 0,
+		StartHash:   testHash(100),
+		StopHeight:  10,
+		StopHash:    testHash(110),
+	})
+	session.TrackAnchor("future", AnchorRequest{
+		StartHeight: 10,
+		StartHash:   testHash(110),
+		StopHeight:  20,
+		StopHash:    testHash(120),
+	})
+
+	controller := NewController(manager, session, DefaultConfig())
+	result, err := controller.CommitReadyRanges(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []RangeID{1}, result.Commit.Committed)
+	require.EqualValues(t, 10, result.Commit.TipHeight)
+	require.Equal(t, 1, result.PrunedAnchors)
+	require.False(t, session.AnchorActive("obsolete"))
+	require.True(t, session.AnchorActive("future"))
+}
+
+func TestControllerReplanRangeAllocatesSessionID(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	addManagerAnchor(t, ctx, manager, 0, 100)
+	addManagerAnchor(t, ctx, manager, 10, 110)
+	require.NoError(t, manager.AddPeer(ctx, PeerSnapshot{
+		ID:    "peer",
+		State: PeerReady,
+	}))
+	mustManagerPlan(t, ctx, manager, 1, 0, 10)
+	_, ok, err := manager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assignment, ok, err := manager.StartPeerRange(ctx, "peer")
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, err = manager.CompleteRange(
+		ctx, "peer", assignment.RangeID, assignment.LeaseEpoch, false,
+		time.Now(),
+	)
+	require.NoError(t, err)
+
+	failedRange, ok, err := manager.SnapshotRange(ctx, 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, RangeFailed, failedRange.State)
+
+	session := NewSession()
+	session.SetNextRangeID(2)
+	controller := NewController(manager, session, DefaultConfig())
+	result, err := controller.ReplanRange(ctx, failedRange)
+	require.NoError(t, err)
+	require.True(t, result.OK)
+	require.EqualValues(t, 2, result.ID)
+	require.EqualValues(t, 3, session.NextRangeID())
+}

--- a/headersync/dispatch.go
+++ b/headersync/dispatch.go
@@ -1,0 +1,39 @@
+package headersync
+
+import (
+	"context"
+	"time"
+)
+
+// DispatchAssignment is the generic work ownership result returned by a shared
+// dispatch scheduler.
+type DispatchAssignment struct {
+	PeerID  string
+	RangeID RangeID
+}
+
+// DispatchStealResult is the generic unstarted-work steal result returned by a
+// shared dispatch scheduler.
+type DispatchStealResult struct {
+	ThiefID  string
+	DonorID  string
+	RangeID  RangeID
+	RangeIDs []RangeID
+}
+
+// DispatchController owns generic peer/work scheduling policy for headersync.
+// Implementations should not know about getheaders, anchors, validation, or
+// ordered commit. Those remain headersync responsibilities.
+type DispatchController interface {
+	AddPeer(context.Context, PeerSnapshot) error
+	RemovePeer(context.Context, string) error
+	UpdatePeerState(context.Context, string, PeerState) error
+	UpdatePeerRTT(context.Context, string, time.Duration) error
+
+	AssignRange(context.Context, RangeID) (DispatchAssignment, bool, error)
+	StartRange(context.Context, PeerSnapshot) error
+	CompleteRange(context.Context, string) error
+	SyncPeer(context.Context, PeerSnapshot) error
+
+	StealRange(context.Context, string) (DispatchStealResult, bool, error)
+}

--- a/headersync/events.go
+++ b/headersync/events.go
@@ -1,0 +1,190 @@
+package headersync
+
+import "sync"
+
+// EventType identifies a structured header sync event.
+type EventType string
+
+const (
+	EventAnchorUpdated  EventType = "anchor_updated"
+	EventRangePlanned   EventType = "range_planned"
+	EventRangeAssigned  EventType = "range_assigned"
+	EventRangeStarted   EventType = "range_started"
+	EventRangeStolen    EventType = "range_stolen"
+	EventRangeCompleted EventType = "range_completed"
+	EventRangeCommitted EventType = "range_committed"
+)
+
+// Event is the structured observability record emitted by the manager actor.
+type Event struct {
+	Type EventType
+	OK   bool
+
+	PeerID  string
+	ThiefID string
+	DonorID string
+
+	AnchorHeight uint32
+	RangeID      RangeID
+	StartHeight  uint32
+	StopHeight   uint32
+	LeaseEpoch   uint64
+	RangeState   RangeState
+
+	Valid     bool
+	Stale     bool
+	Committed []RangeID
+
+	Metrics Metrics
+}
+
+// EventSink receives structured header sync events.
+type EventSink interface {
+	RecordHeaderSyncEvent(Event)
+}
+
+// EventRecorder is an in-memory EventSink for tests and trace replay.
+type EventRecorder struct {
+	mu     sync.Mutex
+	events []Event
+}
+
+// RecordHeaderSyncEvent records an event.
+func (r *EventRecorder) RecordHeaderSyncEvent(event Event) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	event.Committed = append([]RangeID(nil), event.Committed...)
+	r.events = append(r.events, event)
+}
+
+// Events returns a snapshot of recorded events.
+func (r *EventRecorder) Events() []Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	events := make([]Event, len(r.events))
+	copy(events, r.events)
+	for i := range events {
+		events[i].Committed = append([]RangeID(nil), events[i].Committed...)
+	}
+
+	return events
+}
+
+func eventForManagerMessage(fsm *HeaderSyncFSM, msg ManagerMsg,
+	resp ManagerResp) (Event, bool) {
+
+	base := Event{Metrics: fsm.Metrics()}
+
+	switch m := msg.(type) {
+	case *AddAnchorMsg:
+		r, ok := resp.(*AddAnchorResp)
+		if !ok {
+			return Event{}, false
+		}
+
+		base.Type = EventAnchorUpdated
+		base.OK = r.OK
+		base.AnchorHeight = m.Height
+
+		return base, true
+
+	case *PlanRangeMsg:
+		r, ok := resp.(*PlanRangeResp)
+		if !ok {
+			return Event{}, false
+		}
+
+		base.Type = EventRangePlanned
+		base.OK = r.OK
+		base.RangeID = m.ID
+		base.StartHeight = m.StartHeight
+		base.StopHeight = m.StopHeight
+		base.RangeState = r.Range.State
+
+		return base, true
+
+	case *AssignRangeMsg:
+		r, ok := resp.(*RangeAssignmentResp)
+		if !ok {
+			return Event{}, false
+		}
+
+		base.Type = EventRangeAssigned
+		base.OK = r.OK
+		base.PeerID = r.Assignment.PeerID
+		base.RangeID = r.Assignment.RangeID
+		base.StartHeight = r.Assignment.StartHeight
+		base.StopHeight = r.Assignment.StopHeight
+		base.LeaseEpoch = r.Assignment.LeaseEpoch
+
+		return base, true
+
+	case *StartRangeMsg:
+		r, ok := resp.(*RangeAssignmentResp)
+		if !ok {
+			return Event{}, false
+		}
+
+		base.Type = EventRangeStarted
+		base.OK = r.OK
+		base.PeerID = m.PeerID
+		base.RangeID = r.Assignment.RangeID
+		base.StartHeight = r.Assignment.StartHeight
+		base.StopHeight = r.Assignment.StopHeight
+		base.LeaseEpoch = r.Assignment.LeaseEpoch
+
+		return base, true
+
+	case *StealRangeMsg:
+		r, ok := resp.(*StealRangeResp)
+		if !ok {
+			return Event{}, false
+		}
+
+		base.Type = EventRangeStolen
+		base.OK = r.OK
+		base.ThiefID = m.ThiefID
+		base.DonorID = r.Result.DonorID
+		base.RangeID = r.Result.RangeID
+		base.LeaseEpoch = r.Result.LeaseEpoch
+
+		return base, true
+
+	case *CompleteRangeMsg:
+		r, ok := resp.(*CompleteRangeResp)
+		if !ok {
+			return Event{}, false
+		}
+
+		base.Type = EventRangeCompleted
+		base.OK = r.Result.Accepted
+		base.PeerID = m.PeerID
+		base.RangeID = m.RangeID
+		base.LeaseEpoch = m.LeaseEpoch
+		base.Valid = r.Result.Valid
+		base.Stale = r.Result.Stale
+		base.RangeState = r.Result.RangeState
+
+		return base, true
+
+	case *CommitReadyMsg:
+		r, ok := resp.(*CommitReadyResp)
+		if !ok {
+			return Event{}, false
+		}
+
+		base.Type = EventRangeCommitted
+		base.OK = len(r.Result.Committed) > 0
+		base.Committed = append([]RangeID(nil), r.Result.Committed...)
+		if len(r.Result.Committed) > 0 {
+			base.RangeID = r.Result.Committed[len(r.Result.Committed)-1]
+		}
+
+		return base, true
+
+	default:
+		return Event{}, false
+	}
+}

--- a/headersync/fsm.go
+++ b/headersync/fsm.go
@@ -1,0 +1,1051 @@
+package headersync
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// HeaderSyncFSM is the pure manager state machine. It owns no goroutines and
+// performs no network I/O; actors and the block manager drive it with explicit
+// events.
+type HeaderSyncFSM struct {
+	cfg Config
+
+	committedTip  uint32
+	committedHash Hash
+
+	anchors   map[uint32]Anchor
+	ranges    map[RangeID]HeaderRange
+	rangeKeys []RangeID
+	peers     map[string]PeerSnapshot
+
+	commitLog []RangeID
+	metrics   Metrics
+}
+
+// NewHeaderSyncFSM creates a header sync FSM from the current committed tip.
+func NewHeaderSyncFSM(committedTip uint32, committedHash Hash,
+	cfg Config) *HeaderSyncFSM {
+
+	return &HeaderSyncFSM{
+		cfg:           cfg.normalize(),
+		committedTip:  committedTip,
+		committedHash: committedHash,
+		anchors:       make(map[uint32]Anchor),
+		ranges:        make(map[RangeID]HeaderRange),
+		peers:         make(map[string]PeerSnapshot),
+	}
+}
+
+// CommittedTip returns the visible chain tip height.
+func (h *HeaderSyncFSM) CommittedTip() uint32 {
+	return h.committedTip
+}
+
+// CommittedHash returns the visible chain tip hash.
+func (h *HeaderSyncFSM) CommittedHash() Hash {
+	return h.committedHash
+}
+
+// Metrics returns the current counters.
+func (h *HeaderSyncFSM) Metrics() Metrics {
+	return h.metrics
+}
+
+// CommitLog returns the ranges committed in order.
+func (h *HeaderSyncFSM) CommitLog() []RangeID {
+	return append([]RangeID(nil), h.commitLog...)
+}
+
+// AddOrConfirmAnchor adds a trusted checkpoint or records a matching peer
+// observation for a discovered anchor.
+func (h *HeaderSyncFSM) AddOrConfirmAnchor(height uint32, hash Hash,
+	trusted bool) (Anchor, bool) {
+
+	if existing, ok := h.anchors[height]; ok {
+		if existing.Hash != hash {
+			if trusted {
+				anchor := h.newAnchor(height, hash, true)
+				h.anchors[height] = anchor
+				h.metrics.AnchorsConfirmed++
+
+				return anchor, true
+			}
+
+			if !existing.Trusted {
+				existing.Rejected = true
+				h.anchors[height] = existing
+			}
+			h.metrics.AnchorsRejected++
+
+			return existing, false
+		}
+
+		wasConfirmed := h.anchorConfirmed(existing)
+		if trusted {
+			existing.Trusted = true
+			existing.Confirmations =
+				h.cfg.AnchorConfirmationsRequired
+		} else if existing.Confirmations <
+			h.cfg.AnchorConfirmationsRequired {
+
+			existing.Confirmations++
+		}
+
+		h.anchors[height] = existing
+		if !wasConfirmed && h.anchorConfirmed(existing) {
+			h.metrics.AnchorsConfirmed++
+		}
+
+		return existing, true
+	}
+
+	anchor := h.newAnchor(height, hash, trusted)
+	h.anchors[height] = anchor
+	h.metrics.AnchorsAdded++
+	if h.anchorConfirmed(anchor) {
+		h.metrics.AnchorsConfirmed++
+	}
+
+	return anchor, true
+}
+
+func (h *HeaderSyncFSM) newAnchor(height uint32, hash Hash,
+	trusted bool) Anchor {
+
+	confirmations := 1
+	if trusted {
+		confirmations = h.cfg.AnchorConfirmationsRequired
+	}
+
+	return Anchor{
+		Height:        height,
+		Hash:          hash,
+		Trusted:       trusted,
+		Confirmations: confirmations,
+	}
+}
+
+// AnchorByHeight returns an anchor by height.
+func (h *HeaderSyncFSM) AnchorByHeight(height uint32) (Anchor, bool) {
+	anchor, ok := h.anchors[height]
+	return anchor, ok
+}
+
+// Anchors returns all anchors sorted by height.
+func (h *HeaderSyncFSM) Anchors() []Anchor {
+	heights := make([]int, 0, len(h.anchors))
+	for height := range h.anchors {
+		heights = append(heights, int(height))
+	}
+	sort.Ints(heights)
+
+	anchors := make([]Anchor, 0, len(heights))
+	for _, height := range heights {
+		anchors = append(anchors, h.anchors[uint32(height)])
+	}
+
+	return anchors
+}
+
+// AnchorConfirmed returns true if the anchor can be used as a range boundary.
+func (h *HeaderSyncFSM) AnchorConfirmed(anchor Anchor) bool {
+	return h.anchorConfirmed(anchor)
+}
+
+func (h *HeaderSyncFSM) anchorConfirmed(anchor Anchor) bool {
+	return !anchor.Rejected && (anchor.Trusted ||
+		anchor.Confirmations >= h.cfg.AnchorConfirmationsRequired)
+}
+
+// AddPeer adds or replaces a peer snapshot.
+func (h *HeaderSyncFSM) AddPeer(peer PeerSnapshot) error {
+	if peer.ID == "" {
+		return fmt.Errorf("%w: empty peer id", ErrInvalidPeer)
+	}
+
+	if existing, ok := h.peers[peer.ID]; ok && peer.LocalRanges == nil {
+		peer.LocalRanges = existing.LocalRanges
+	}
+
+	h.peers[peer.ID] = peer.clone()
+	return nil
+}
+
+// RemovePeer removes a peer from the scheduler.
+func (h *HeaderSyncFSM) RemovePeer(id string) {
+	peer, ok := h.peers[id]
+	if ok {
+		for _, rangeID := range peer.LocalRanges {
+			h.requeuePeerRange(id, rangeID)
+		}
+		if peer.ActiveRange != NoRange {
+			h.requeuePeerRange(id, peer.ActiveRange)
+		}
+	}
+
+	for _, rng := range h.ranges {
+		if rng.OwnerPeer != id {
+			continue
+		}
+
+		h.requeuePeerRange(id, rng.ID)
+	}
+
+	delete(h.peers, id)
+}
+
+func (h *HeaderSyncFSM) requeuePeerRange(peerID string, rangeID RangeID) {
+	rng, ok := h.ranges[rangeID]
+	if !ok || rng.OwnerPeer != peerID {
+		return
+	}
+
+	switch rng.State {
+	case RangeOwned, RangeActive:
+	default:
+		return
+	}
+
+	rng.OwnerPeer = NoPeer
+	rng.LeaseEpoch++
+	rng.State = RangeQueued
+	rng.Valid = false
+	rng.StagedAt = time.Time{}
+
+	h.ranges[rangeID] = rng
+}
+
+// SnapshotPeer returns a copy of one peer.
+func (h *HeaderSyncFSM) SnapshotPeer(id string) (PeerSnapshot, bool) {
+	peer, ok := h.peers[id]
+	if !ok {
+		return PeerSnapshot{}, false
+	}
+
+	return peer.clone(), true
+}
+
+// Peers returns all peers sorted by ID.
+func (h *HeaderSyncFSM) Peers() []PeerSnapshot {
+	peers := make([]PeerSnapshot, 0, len(h.peers))
+	for _, peer := range h.peers {
+		peers = append(peers, peer.clone())
+	}
+
+	sort.Slice(peers, func(i, j int) bool {
+		return peers[i].ID < peers[j].ID
+	})
+
+	return peers
+}
+
+// UpdatePeerState updates a peer scheduling state.
+func (h *HeaderSyncFSM) UpdatePeerState(id string,
+	state PeerState) error {
+
+	peer, ok := h.peers[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownPeer, id)
+	}
+
+	peer.State = state
+	h.peers[id] = peer
+
+	return nil
+}
+
+// UpdatePeerRTT updates a peer RTT sample.
+func (h *HeaderSyncFSM) UpdatePeerRTT(id string,
+	rtt time.Duration) error {
+
+	peer, ok := h.peers[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownPeer, id)
+	}
+
+	peer.RTT = rtt
+	h.peers[id] = peer
+
+	return nil
+}
+
+// RangeByID returns a copy of one range.
+func (h *HeaderSyncFSM) RangeByID(id RangeID) (HeaderRange, bool) {
+	rng, ok := h.ranges[id]
+	return rng, ok
+}
+
+// Ranges returns all ranges sorted by start height, then ID.
+func (h *HeaderSyncFSM) Ranges() []HeaderRange {
+	ranges := make([]HeaderRange, 0, len(h.ranges))
+	for _, rng := range h.ranges {
+		ranges = append(ranges, rng)
+	}
+
+	sort.Slice(ranges, func(i, j int) bool {
+		if ranges[i].StartHeight != ranges[j].StartHeight {
+			return ranges[i].StartHeight < ranges[j].StartHeight
+		}
+
+		return ranges[i].ID < ranges[j].ID
+	})
+
+	return ranges
+}
+
+// CanPlanRange returns true when both boundary anchors are confirmed.
+func (h *HeaderSyncFSM) CanPlanRange(startHeight,
+	stopHeight uint32) bool {
+
+	if startHeight >= stopHeight {
+		return false
+	}
+	if stopHeight-startHeight > h.cfg.MaxRangeHeaders {
+		return false
+	}
+
+	startAnchor, startOK := h.anchors[startHeight]
+	stopAnchor, stopOK := h.anchors[stopHeight]
+
+	return startOK && stopOK && h.anchorConfirmed(startAnchor) &&
+		h.anchorConfirmed(stopAnchor)
+}
+
+// PlanRange creates queued work between two confirmed anchors. The range uses
+// interval semantics (start_height, stop_height], so the start anchor is the
+// locator boundary and the stop anchor is the final expected header hash.
+func (h *HeaderSyncFSM) PlanRange(id RangeID, startHeight,
+	stopHeight uint32) (HeaderRange, bool, error) {
+
+	if id == NoRange {
+		return HeaderRange{}, false, fmt.Errorf("%w: zero range id",
+			ErrInvalidRange)
+	}
+	if _, ok := h.ranges[id]; ok {
+		return HeaderRange{}, false, fmt.Errorf("%w: %d",
+			ErrDuplicateRange, id)
+	}
+	if startHeight >= stopHeight {
+		return HeaderRange{}, false, fmt.Errorf("%w: start %d stop %d",
+			ErrInvalidRange, startHeight, stopHeight)
+	}
+	if !h.CanPlanRange(startHeight, stopHeight) {
+		return HeaderRange{}, false, nil
+	}
+	if h.rangeOverlaps(startHeight, stopHeight) {
+		return HeaderRange{}, false, fmt.Errorf(
+			"%w: overlapping range %d-%d", ErrInvalidRange,
+			startHeight, stopHeight,
+		)
+	}
+
+	startAnchor := h.anchors[startHeight]
+	stopAnchor := h.anchors[stopHeight]
+	rng := HeaderRange{
+		ID:          id,
+		StartHeight: startHeight,
+		StartHash:   startAnchor.Hash,
+		StopHeight:  stopHeight,
+		StopHash:    stopAnchor.Hash,
+		State:       RangeQueued,
+	}
+
+	h.ranges[id] = rng
+	h.rangeKeys = append(h.rangeKeys, id)
+	h.metrics.RangesPlanned++
+
+	return rng, true, nil
+}
+
+// StageDiscoveredRange creates staged work from a confirmed anchor-discovery
+// response. Discovery has already fetched the headers for this span, so the
+// caller can skip a second getheaders round trip and let ordered commit drain
+// the range when it becomes contiguous.
+func (h *HeaderSyncFSM) StageDiscoveredRange(id RangeID, peerID string,
+	startHeight, stopHeight uint32, now time.Time) (HeaderRange, bool, error) {
+
+	if existing, ok := h.rangeBySpan(startHeight, stopHeight); ok {
+		switch existing.State {
+		case RangeStaged, RangeCommitted:
+			return existing, false, nil
+
+		case RangeQueued, RangeOwned, RangeActive:
+			return h.stageRangeFromDiscovery(existing, peerID, now),
+				true, nil
+		}
+	}
+
+	rng, ok, err := h.PlanRange(id, startHeight, stopHeight)
+	if err != nil || !ok {
+		return rng, ok, err
+	}
+
+	return h.stageRangeFromDiscovery(rng, peerID, now), true, nil
+}
+
+func (h *HeaderSyncFSM) stageRangeFromDiscovery(rng HeaderRange,
+	peerID string, now time.Time) HeaderRange {
+
+	h.detachRangeFromPeers(rng.ID)
+
+	rng.LeaseEpoch++
+	rng.OwnerPeer = peerID
+	rng.State = RangeStaged
+	rng.Valid = true
+	rng.StagedAt = now
+
+	h.ranges[rng.ID] = rng
+	h.metrics.RangesStaged++
+
+	return rng
+}
+
+func (h *HeaderSyncFSM) detachRangeFromPeers(rangeID RangeID) {
+	for id, peer := range h.peers {
+		peer.LocalRanges = removeRangeID(peer.LocalRanges, rangeID)
+		if peer.ActiveRange == rangeID {
+			peer.ActiveRange = NoRange
+			if peer.State == PeerBusy {
+				peer.State = PeerReady
+			}
+		}
+
+		h.peers[id] = peer
+	}
+}
+
+func (h *HeaderSyncFSM) rangeOverlaps(startHeight,
+	stopHeight uint32) bool {
+
+	for _, rng := range h.ranges {
+		if rng.State == RangeFailed || rng.State == RangeStale {
+			continue
+		}
+		if startHeight < rng.StopHeight && stopHeight > rng.StartHeight {
+			return true
+		}
+	}
+
+	return false
+}
+
+// AssignNextQueuedRange moves the earliest queued range into the selected
+// peer's bounded local range queue.
+func (h *HeaderSyncFSM) AssignNextQueuedRange() (RangeAssignment, bool) {
+	owner, ok := h.selectRangeOwner()
+	if !ok {
+		h.metrics.FailedAssignments++
+		return RangeAssignment{}, false
+	}
+
+	rangeID, ok := h.nextQueuedRange()
+	if !ok {
+		h.metrics.FailedAssignments++
+		return RangeAssignment{}, false
+	}
+
+	assignment, ok, err := h.AssignQueuedRangeToPeer(rangeID, owner.ID)
+	if err != nil || !ok {
+		return RangeAssignment{}, false
+	}
+
+	return assignment, true
+}
+
+// AssignQueuedRangeToPeer moves a specific queued range into a specific peer's
+// bounded local range queue. This is used when a shared dispatch actor has
+// already made the peer selection.
+func (h *HeaderSyncFSM) AssignQueuedRangeToPeer(rangeID RangeID,
+	peerID string) (RangeAssignment, bool, error) {
+
+	owner, ok := h.peers[peerID]
+	if !ok {
+		return RangeAssignment{}, false, fmt.Errorf("%w: %s",
+			ErrUnknownPeer, peerID)
+	}
+	if !h.peerCanOwnRange(owner) {
+		h.metrics.FailedAssignments++
+		return RangeAssignment{}, false, nil
+	}
+
+	rng, ok := h.ranges[rangeID]
+	if !ok {
+		return RangeAssignment{}, false, fmt.Errorf("%w: %d",
+			ErrUnknownRange, rangeID)
+	}
+	if rng.State != RangeQueued {
+		h.metrics.FailedAssignments++
+		return RangeAssignment{}, false, nil
+	}
+
+	rng.OwnerPeer = owner.ID
+	rng.LeaseEpoch++
+	rng.State = RangeOwned
+	rng.Valid = false
+	rng.StagedAt = time.Time{}
+
+	owner.LocalRanges = append(owner.LocalRanges, rng.ID)
+
+	h.ranges[rng.ID] = rng
+	h.peers[owner.ID] = owner
+	h.metrics.RangesAssigned++
+
+	return assignmentFromRange(rng), true, nil
+}
+
+func (h *HeaderSyncFSM) nextQueuedRange() (RangeID, bool) {
+	var (
+		best  HeaderRange
+		found bool
+	)
+
+	for _, rng := range h.ranges {
+		if rng.State != RangeQueued {
+			continue
+		}
+		if !found || rng.StartHeight < best.StartHeight ||
+			(rng.StartHeight == best.StartHeight && rng.ID < best.ID) {
+
+			best = rng
+			found = true
+		}
+	}
+
+	if !found {
+		return NoRange, false
+	}
+
+	return best.ID, true
+}
+
+func (h *HeaderSyncFSM) selectRangeOwner() (PeerSnapshot, bool) {
+	var (
+		best  PeerSnapshot
+		found bool
+	)
+
+	for _, peer := range h.peers {
+		if !h.peerCanOwnRange(peer) {
+			continue
+		}
+
+		if !found || h.localOwnerOrdersBefore(peer, best) {
+			best = peer
+			found = true
+		}
+	}
+
+	return best.clone(), found
+}
+
+func (h *HeaderSyncFSM) peerCanOwnRange(peer PeerSnapshot) bool {
+	if peer.State != PeerReady && peer.State != PeerBusy {
+		return false
+	}
+
+	return h.peerOutstandingRanges(peer) < h.cfg.MaxPeerOutstandingRanges
+}
+
+func (h *HeaderSyncFSM) peerOutstandingRanges(peer PeerSnapshot) int {
+	count := len(peer.LocalRanges)
+	if peer.ActiveRange != NoRange {
+		count++
+	}
+
+	return count
+}
+
+func (h *HeaderSyncFSM) localOwnerOrdersBefore(peer,
+	candidate PeerSnapshot) bool {
+
+	peerLoad := h.peerOutstandingRanges(peer)
+	candidateLoad := h.peerOutstandingRanges(candidate)
+	if peerLoad != candidateLoad {
+		return peerLoad < candidateLoad
+	}
+
+	return peerOrdersBefore(peer, candidate)
+}
+
+func peerOrdersBefore(peer, candidate PeerSnapshot) bool {
+	if peer.Rank != candidate.Rank {
+		return peer.Rank < candidate.Rank
+	}
+	if peer.RTT != candidate.RTT {
+		return peer.RTT < candidate.RTT
+	}
+
+	return peer.ID < candidate.ID
+}
+
+// StartPeerRange moves the next locally owned range into the peer active slot.
+func (h *HeaderSyncFSM) StartPeerRange(peerID string) (
+	RangeAssignment, bool, error) {
+
+	peer, ok := h.peers[peerID]
+	if !ok {
+		return RangeAssignment{}, false, fmt.Errorf("%w: %s",
+			ErrUnknownPeer, peerID)
+	}
+	if !peerCanStartRange(peer) {
+		return RangeAssignment{}, false, nil
+	}
+
+	rangeID := peer.LocalRanges[0]
+	rng, ok := h.ranges[rangeID]
+	if !ok {
+		return RangeAssignment{}, false, fmt.Errorf("%w: %d",
+			ErrUnknownRange, rangeID)
+	}
+	if rng.State != RangeOwned || rng.OwnerPeer != peerID {
+		return RangeAssignment{}, false, nil
+	}
+
+	peer.LocalRanges = dropFirstRangeID(peer.LocalRanges)
+	peer.ActiveRange = rangeID
+	peer.State = PeerBusy
+
+	rng.State = RangeActive
+
+	h.peers[peerID] = peer
+	h.ranges[rangeID] = rng
+	h.metrics.RangesStarted++
+
+	return assignmentFromRange(rng), true, nil
+}
+
+func peerCanStartRange(peer PeerSnapshot) bool {
+	return peer.State == PeerReady && peer.ActiveRange == NoRange &&
+		len(peer.LocalRanges) > 0
+}
+
+// StealRange transfers an owned or active range lease to another peer. Timeout
+// and donor-failure policy lives above this pure transition; this method
+// enforces the safety rule that stealing increments the lease epoch.
+func (h *HeaderSyncFSM) StealRange(thiefID string,
+	rangeID RangeID) (StealResult, bool, error) {
+
+	return h.stealRange(thiefID, rangeID, StealReasonExplicit)
+}
+
+func (h *HeaderSyncFSM) stealRange(thiefID string, rangeID RangeID,
+	reason StealReason) (StealResult, bool, error) {
+
+	thief, ok := h.peers[thiefID]
+	if !ok {
+		return StealResult{}, false, fmt.Errorf("%w: %s",
+			ErrUnknownPeer, thiefID)
+	}
+	rng, ok := h.ranges[rangeID]
+	if !ok {
+		return StealResult{}, false, fmt.Errorf("%w: %d",
+			ErrUnknownRange, rangeID)
+	}
+	if !h.peerCanOwnRange(thief) || rng.OwnerPeer == NoPeer ||
+		rng.OwnerPeer == thiefID || (rng.State != RangeOwned &&
+		rng.State != RangeActive) {
+
+		h.metrics.FailedStealActions++
+		return StealResult{}, false, nil
+	}
+
+	donor, ok := h.peers[rng.OwnerPeer]
+	if !ok {
+		return StealResult{}, false, fmt.Errorf("%w: %s",
+			ErrUnknownPeer, rng.OwnerPeer)
+	}
+
+	oldLeaseEpoch := rng.LeaseEpoch
+	donor.LocalRanges = removeRangeID(donor.LocalRanges, rangeID)
+	if donor.ActiveRange == rangeID {
+		donor.ActiveRange = NoRange
+		if donor.State == PeerBusy {
+			donor.State = PeerReady
+		}
+	}
+
+	thief.LocalRanges = append(thief.LocalRanges, rangeID)
+	rng.LeaseEpoch++
+	rng.OwnerPeer = thiefID
+	rng.State = RangeOwned
+	rng.Valid = false
+	rng.StagedAt = time.Time{}
+
+	h.peers[donor.ID] = donor
+	h.peers[thief.ID] = thief
+	h.ranges[rangeID] = rng
+	h.metrics.RangesStolen++
+
+	return StealResult{
+		ThiefID:       thief.ID,
+		DonorID:       donor.ID,
+		RangeID:       rangeID,
+		OldLeaseEpoch: oldLeaseEpoch,
+		LeaseEpoch:    rng.LeaseEpoch,
+		Reason:        reason,
+	}, true, nil
+}
+
+// StealNextRange selects one stealable range for the thief. It only steals
+// active ranges from blocked or quarantined donors; active work from a merely
+// busy peer requires an explicit timeout decision by the caller through
+// StealRange.
+func (h *HeaderSyncFSM) StealNextRange(thiefID string) (
+	StealResult, bool, error) {
+
+	thief, ok := h.peers[thiefID]
+	if !ok {
+		return StealResult{}, false, fmt.Errorf("%w: %s",
+			ErrUnknownPeer, thiefID)
+	}
+	if !h.peerCanOwnRange(thief) {
+		h.metrics.FailedStealActions++
+		return StealResult{}, false, nil
+	}
+
+	rangeID, reason, ok := h.selectStealableRange(thiefID)
+	if !ok {
+		h.metrics.FailedStealActions++
+		return StealResult{}, false, nil
+	}
+
+	return h.stealRange(thiefID, rangeID, reason)
+}
+
+func (h *HeaderSyncFSM) selectStealableRange(thiefID string) (
+	RangeID, StealReason, bool) {
+
+	var (
+		best      HeaderRange
+		bestDonor PeerSnapshot
+		found     bool
+	)
+
+	for _, rng := range h.ranges {
+		if rng.OwnerPeer == NoPeer || rng.OwnerPeer == thiefID {
+			continue
+		}
+
+		donor, ok := h.peers[rng.OwnerPeer]
+		if !ok || !h.rangeCanBeAutoStolen(rng, donor) {
+			continue
+		}
+
+		if !found || h.stealCandidateOrdersBefore(
+			rng, donor, best, bestDonor,
+		) {
+			best = rng
+			bestDonor = donor
+			found = true
+		}
+	}
+
+	if !found {
+		return NoRange, "", false
+	}
+
+	return best.ID, stealReasonForCandidate(best, bestDonor), true
+}
+
+func stealReasonForCandidate(rng HeaderRange,
+	donor PeerSnapshot) StealReason {
+
+	switch rng.State {
+	case RangeActive:
+		if donor.State == PeerQuarantined {
+			return StealReasonActiveQuarantined
+		}
+
+		return StealReasonActiveBlocked
+
+	case RangeOwned:
+		switch donor.State {
+		case PeerBlocked:
+			return StealReasonQueuedBlocked
+
+		case PeerQuarantined:
+			return StealReasonQueuedQuarantined
+
+		default:
+			return StealReasonQueuedOverloaded
+		}
+
+	default:
+		return StealReasonExplicit
+	}
+}
+
+func (h *HeaderSyncFSM) rangeCanBeAutoStolen(rng HeaderRange,
+	donor PeerSnapshot) bool {
+
+	switch rng.State {
+	case RangeOwned:
+		switch donor.State {
+		case PeerBlocked, PeerQuarantined:
+			return true
+
+		case PeerReady, PeerBusy:
+			return len(donor.LocalRanges) > 1
+
+		default:
+			return false
+		}
+
+	case RangeActive:
+		return donor.State == PeerBlocked ||
+			donor.State == PeerQuarantined
+
+	default:
+		return false
+	}
+}
+
+func (h *HeaderSyncFSM) stealCandidateOrdersBefore(rng HeaderRange,
+	donor PeerSnapshot, candidate HeaderRange,
+	candidateDonor PeerSnapshot) bool {
+
+	donorPriority := stealDonorPriority(donor)
+	candidatePriority := stealDonorPriority(candidateDonor)
+	if donorPriority != candidatePriority {
+		return donorPriority > candidatePriority
+	}
+
+	donorLoad := h.peerOutstandingRanges(donor)
+	candidateLoad := h.peerOutstandingRanges(candidateDonor)
+	if donorLoad != candidateLoad {
+		return donorLoad > candidateLoad
+	}
+
+	if donor.Rank != candidateDonor.Rank {
+		return donor.Rank > candidateDonor.Rank
+	}
+
+	if rng.StartHeight != candidate.StartHeight {
+		return rng.StartHeight < candidate.StartHeight
+	}
+
+	return rng.ID < candidate.ID
+}
+
+func stealDonorPriority(peer PeerSnapshot) int {
+	switch peer.State {
+	case PeerBlocked, PeerQuarantined:
+		return 3
+
+	case PeerReady, PeerBusy:
+		return 2
+
+	default:
+		return 0
+	}
+}
+
+// CompleteRange records an active range response.
+func (h *HeaderSyncFSM) CompleteRange(peerID string, rangeID RangeID,
+	leaseEpoch uint64, valid bool) (CompleteResult, error) {
+
+	return h.CompleteRangeAt(peerID, rangeID, leaseEpoch, valid, time.Now())
+}
+
+// CompleteRangeAt records an active range response with an explicit timestamp
+// so deterministic tests can inspect staged-range age.
+func (h *HeaderSyncFSM) CompleteRangeAt(peerID string, rangeID RangeID,
+	leaseEpoch uint64, valid bool, now time.Time) (CompleteResult, error) {
+
+	rng, ok := h.ranges[rangeID]
+	if !ok {
+		return CompleteResult{}, fmt.Errorf("%w: %d",
+			ErrUnknownRange, rangeID)
+	}
+
+	if rng.OwnerPeer != peerID || rng.LeaseEpoch != leaseEpoch ||
+		rng.State != RangeActive {
+
+		h.metrics.StaleCompletions++
+		return CompleteResult{
+			RangeID:    rangeID,
+			Stale:      true,
+			RangeState: rng.State,
+		}, nil
+	}
+
+	peer, ok := h.peers[peerID]
+	if !ok {
+		return CompleteResult{}, fmt.Errorf("%w: %s",
+			ErrUnknownPeer, peerID)
+	}
+
+	if peer.ActiveRange == rangeID {
+		peer.ActiveRange = NoRange
+		if peer.State == PeerBusy {
+			peer.State = PeerReady
+		}
+	}
+
+	if valid {
+		rng.State = RangeStaged
+		rng.Valid = true
+		rng.StagedAt = now
+		h.metrics.RangesStaged++
+	} else {
+		rng.State = RangeFailed
+		rng.Valid = false
+		rng.StagedAt = time.Time{}
+		h.metrics.RangesFailed++
+	}
+
+	h.peers[peerID] = peer
+	h.ranges[rangeID] = rng
+
+	return CompleteResult{
+		RangeID:    rangeID,
+		Accepted:   true,
+		Valid:      valid,
+		RangeState: rng.State,
+	}, nil
+}
+
+// CommitReadyRanges drains all staged ranges that connect to the visible tip.
+func (h *HeaderSyncFSM) CommitReadyRanges() CommitResult {
+	result := CommitResult{
+		TipHeight: h.committedTip,
+		TipHash:   h.committedHash,
+	}
+
+	for {
+		next, ok := h.nextCommittableRange()
+		if !ok {
+			return result
+		}
+
+		next.State = RangeCommitted
+		next.Valid = true
+		next.StagedAt = time.Time{}
+
+		h.ranges[next.ID] = next
+		h.committedTip = next.StopHeight
+		h.committedHash = next.StopHash
+		h.commitLog = append(h.commitLog, next.ID)
+		h.metrics.RangesCommitted++
+
+		result.Committed = append(result.Committed, next.ID)
+		result.TipHeight = h.committedTip
+		result.TipHash = h.committedHash
+	}
+}
+
+// ReadyRanges returns the staged ranges that can be committed without mutating
+// the FSM. Callers that need to persist side effects before advancing visible
+// header state can use this as a preflight before CommitReadyRanges.
+func (h *HeaderSyncFSM) ReadyRanges() []RangeID {
+	var (
+		tipHeight = h.committedTip
+		tipHash   = h.committedHash
+		ready     []RangeID
+	)
+
+	for {
+		next, ok := h.nextCommittableRangeFrom(tipHeight, tipHash)
+		if !ok {
+			return ready
+		}
+
+		ready = append(ready, next.ID)
+		tipHeight = next.StopHeight
+		tipHash = next.StopHash
+	}
+}
+
+func (h *HeaderSyncFSM) nextCommittableRange() (HeaderRange, bool) {
+	return h.nextCommittableRangeFrom(h.committedTip, h.committedHash)
+}
+
+func (h *HeaderSyncFSM) nextCommittableRangeFrom(tipHeight uint32,
+	tipHash Hash) (HeaderRange, bool) {
+
+	var (
+		best  HeaderRange
+		found bool
+	)
+
+	for _, rng := range h.ranges {
+		if rng.State != RangeStaged || !rng.Valid ||
+			rng.StartHeight != tipHeight ||
+			rng.StartHash != tipHash {
+
+			continue
+		}
+
+		if !found || rng.StopHeight < best.StopHeight ||
+			(rng.StopHeight == best.StopHeight && rng.ID < best.ID) {
+
+			best = rng
+			found = true
+		}
+	}
+
+	return best, found
+}
+
+// CommitStats returns staged-range pressure relative to the current visible tip.
+func (h *HeaderSyncFSM) CommitStats(now time.Time) CommitStats {
+	var stats CommitStats
+	var oldest time.Time
+
+	for _, rng := range h.ranges {
+		if rng.State != RangeStaged || !rng.Valid {
+			continue
+		}
+
+		stats.StagedCount++
+		if rng.StopHeight > h.committedTip &&
+			rng.StopHeight-h.committedTip > stats.CommitLag {
+
+			stats.CommitLag = rng.StopHeight - h.committedTip
+		}
+		if !rng.StagedAt.IsZero() &&
+			(oldest.IsZero() || rng.StagedAt.Before(oldest)) {
+
+			oldest = rng.StagedAt
+		}
+	}
+
+	if !oldest.IsZero() && now.After(oldest) {
+		stats.OldestStagedAge = now.Sub(oldest)
+	}
+
+	return stats
+}
+
+func assignmentFromRange(rng HeaderRange) RangeAssignment {
+	return RangeAssignment{
+		PeerID:      rng.OwnerPeer,
+		RangeID:     rng.ID,
+		LeaseEpoch:  rng.LeaseEpoch,
+		StartHeight: rng.StartHeight,
+		StopHeight:  rng.StopHeight,
+		StartHash:   rng.StartHash,
+		StopHash:    rng.StopHash,
+	}
+}
+
+func dropFirstRangeID(ids []RangeID) []RangeID {
+	if len(ids) <= 1 {
+		return nil
+	}
+
+	return append([]RangeID(nil), ids[1:]...)
+}
+
+func removeRangeID(ids []RangeID, id RangeID) []RangeID {
+	result := make([]RangeID, 0, len(ids))
+	for _, existing := range ids {
+		if existing != id {
+			result = append(result, existing)
+		}
+	}
+
+	return result
+}

--- a/headersync/fsm_test.go
+++ b/headersync/fsm_test.go
@@ -1,0 +1,592 @@
+package headersync
+
+import (
+	"reflect"
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanRangeRequiresConfirmedAnchors(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	fsm.AddOrConfirmAnchor(100, testHash(200), false)
+
+	_, ok, err := fsm.PlanRange(1, 0, 100)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, fsm.Ranges())
+
+	fsm.AddOrConfirmAnchor(100, testHash(200), false)
+	rng, ok, err := fsm.PlanRange(1, 0, 100)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.EqualValues(t, 1, rng.ID)
+	require.Equal(t, RangeQueued, rng.State)
+}
+
+func TestOutOfOrderCompletionStagesUntilGapFilled(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	addTrustedAnchor(t, fsm, 10, 110)
+	addTrustedAnchor(t, fsm, 20, 120)
+	addPeer(t, fsm, "peer1")
+	addPeer(t, fsm, "peer2")
+	mustPlanRange(t, fsm, 1, 0, 10)
+	mustPlanRange(t, fsm, 2, 10, 20)
+	mustAssignRange(t, fsm)
+	mustAssignRange(t, fsm)
+	first := mustStartRange(t, fsm, "peer1")
+	second := mustStartRange(t, fsm, "peer2")
+
+	now := time.Unix(100, 0)
+	result, err := fsm.CompleteRangeAt(
+		"peer2", second.RangeID, second.LeaseEpoch, true, now,
+	)
+	require.NoError(t, err)
+	require.True(t, result.Accepted)
+	commit := fsm.CommitReadyRanges()
+	require.Empty(t, commit.Committed)
+	require.EqualValues(t, 0, fsm.CommittedTip())
+
+	stats := fsm.CommitStats(now.Add(5 * time.Second))
+	require.Equal(t, 1, stats.StagedCount)
+	require.EqualValues(t, 20, stats.CommitLag)
+	require.Equal(t, 5*time.Second, stats.OldestStagedAge)
+
+	_, err = fsm.CompleteRangeAt(
+		"peer1", first.RangeID, first.LeaseEpoch, true,
+		now.Add(time.Second),
+	)
+	require.NoError(t, err)
+	commit = fsm.CommitReadyRanges()
+	require.Equal(t, []RangeID{1, 2}, commit.Committed)
+	require.EqualValues(t, 20, fsm.CommittedTip())
+	require.Equal(t, []RangeID{1, 2}, fsm.CommitLog())
+}
+
+func TestReadyRangesDoesNotAdvanceCommittedTip(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	addTrustedAnchor(t, fsm, 10, 110)
+	addPeer(t, fsm, "peer")
+	mustPlanRange(t, fsm, 1, 0, 10)
+	mustAssignRange(t, fsm)
+	started := mustStartRange(t, fsm, "peer")
+
+	_, err := fsm.CompleteRange(
+		"peer", started.RangeID, started.LeaseEpoch, true,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, []RangeID{1}, fsm.ReadyRanges())
+	require.EqualValues(t, 0, fsm.CommittedTip())
+	require.Empty(t, fsm.CommitLog())
+
+	commit := fsm.CommitReadyRanges()
+	require.Equal(t, []RangeID{1}, commit.Committed)
+	require.EqualValues(t, 10, fsm.CommittedTip())
+}
+
+func TestStageDiscoveredRangeUsesConfirmedAnchors(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	fsm.SeedCommittedAnchor()
+	addTrustedAnchor(t, fsm, 10, 110)
+
+	rng, ok, err := fsm.StageDiscoveredRange(
+		1, "peer-a", 0, 10, time.Unix(1, 0),
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, RangeStaged, rng.State)
+	require.True(t, rng.Valid)
+	require.Equal(t, "peer-a", rng.OwnerPeer)
+	require.EqualValues(t, 1, rng.LeaseEpoch)
+	require.EqualValues(t, 1, fsm.Metrics().RangesStaged)
+
+	again, ok, err := fsm.StageDiscoveredRange(
+		2, "peer-b", 0, 10, time.Unix(2, 0),
+	)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.EqualValues(t, 1, again.ID)
+	require.EqualValues(t, 1, fsm.Metrics().RangesStaged)
+}
+
+func TestStageDiscoveredRangeStagesExistingQueuedRange(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	fsm.SeedCommittedAnchor()
+	addTrustedAnchor(t, fsm, 10, 110)
+
+	planned := mustPlanRange(t, fsm, 7, 0, 10)
+	require.Equal(t, RangeQueued, planned.State)
+
+	rng, ok, err := fsm.StageDiscoveredRange(
+		99, "peer-a", 0, 10, time.Unix(1, 0),
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.EqualValues(t, 7, rng.ID)
+	require.Equal(t, RangeStaged, rng.State)
+	require.True(t, rng.Valid)
+	require.Equal(t, "peer-a", rng.OwnerPeer)
+	require.EqualValues(t, 1, rng.LeaseEpoch)
+	require.EqualValues(t, 1, fsm.Metrics().RangesPlanned)
+	require.EqualValues(t, 1, fsm.Metrics().RangesStaged)
+}
+
+func TestStageDiscoveredRangeDetachesExistingActiveRange(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	fsm.SeedCommittedAnchor()
+	addTrustedAnchor(t, fsm, 10, 110)
+	addPeer(t, fsm, "owner")
+
+	mustPlanRange(t, fsm, 1, 0, 10)
+	mustAssignRange(t, fsm)
+	started := mustStartRange(t, fsm, "owner")
+
+	rng, ok, err := fsm.StageDiscoveredRange(
+		2, "discoverer", 0, 10, time.Unix(1, 0),
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.EqualValues(t, 1, rng.ID)
+	require.Equal(t, RangeStaged, rng.State)
+	require.Equal(t, "discoverer", rng.OwnerPeer)
+	require.EqualValues(t, started.LeaseEpoch+1, rng.LeaseEpoch)
+
+	owner, ok := fsm.SnapshotPeer("owner")
+	require.True(t, ok)
+	require.Equal(t, PeerReady, owner.State)
+	require.Equal(t, NoRange, owner.ActiveRange)
+	require.Empty(t, owner.LocalRanges)
+
+	result, err := fsm.CompleteRangeAt(
+		"owner", started.RangeID, started.LeaseEpoch, true,
+		time.Unix(2, 0),
+	)
+	require.NoError(t, err)
+	require.True(t, result.Stale)
+	require.False(t, result.Accepted)
+	require.EqualValues(t, 1, fsm.Metrics().StaleCompletions)
+	require.EqualValues(t, 1, fsm.Metrics().RangesStaged)
+}
+
+func TestStaleCompletionCannotOverwriteStolenLease(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	addTrustedAnchor(t, fsm, 10, 110)
+	addPeer(t, fsm, "peer1")
+	addPeer(t, fsm, "peer2")
+	mustPlanRange(t, fsm, 1, 0, 10)
+	mustAssignRange(t, fsm)
+	started := mustStartRange(t, fsm, "peer1")
+
+	steal, ok, err := fsm.StealRange("peer2", 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, StealReasonExplicit, steal.Reason)
+	require.EqualValues(t, started.LeaseEpoch, steal.OldLeaseEpoch)
+	require.EqualValues(t, started.LeaseEpoch+1, steal.LeaseEpoch)
+
+	result, err := fsm.CompleteRange(
+		"peer1", 1, started.LeaseEpoch, false,
+	)
+	require.NoError(t, err)
+	require.True(t, result.Stale)
+	require.False(t, result.Accepted)
+
+	rng, ok := fsm.RangeByID(1)
+	require.True(t, ok)
+	require.Equal(t, "peer2", rng.OwnerPeer)
+	require.Equal(t, RangeOwned, rng.State)
+	require.EqualValues(t, 1, fsm.Metrics().StaleCompletions)
+
+	current := mustStartRange(t, fsm, "peer2")
+	_, err = fsm.CompleteRange(
+		"peer2", current.RangeID, current.LeaseEpoch, true,
+	)
+	require.NoError(t, err)
+	commit := fsm.CommitReadyRanges()
+	require.Equal(t, []RangeID{1}, commit.Committed)
+	require.EqualValues(t, 10, fsm.CommittedTip())
+}
+
+func TestInvalidCompletionDoesNotCommit(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	addTrustedAnchor(t, fsm, 10, 110)
+	addPeer(t, fsm, "peer")
+	mustPlanRange(t, fsm, 1, 0, 10)
+	mustAssignRange(t, fsm)
+	started := mustStartRange(t, fsm, "peer")
+
+	result, err := fsm.CompleteRange(
+		"peer", started.RangeID, started.LeaseEpoch, false,
+	)
+	require.NoError(t, err)
+	require.True(t, result.Accepted)
+	require.False(t, result.Valid)
+	require.Equal(t, RangeFailed, result.RangeState)
+
+	commit := fsm.CommitReadyRanges()
+	require.Empty(t, commit.Committed)
+	require.EqualValues(t, 0, fsm.CommittedTip())
+	require.EqualValues(t, 1, fsm.Metrics().RangesFailed)
+}
+
+func TestActiveRangeCanBeStolen(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	addTrustedAnchor(t, fsm, 10, 110)
+	addPeer(t, fsm, "peer1")
+	addPeer(t, fsm, "peer2")
+	mustPlanRange(t, fsm, 1, 0, 10)
+	mustAssignRange(t, fsm)
+	started := mustStartRange(t, fsm, "peer1")
+
+	steal, ok, err := fsm.StealRange("peer2", 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "peer1", steal.DonorID)
+	require.Equal(t, "peer2", steal.ThiefID)
+	require.Equal(t, StealReasonExplicit, steal.Reason)
+	require.EqualValues(t, started.LeaseEpoch, steal.OldLeaseEpoch)
+	require.EqualValues(t, started.LeaseEpoch+1, steal.LeaseEpoch)
+
+	donor, ok := fsm.SnapshotPeer("peer1")
+	require.True(t, ok)
+	require.Equal(t, PeerReady, donor.State)
+	require.Equal(t, NoRange, donor.ActiveRange)
+	require.Empty(t, donor.LocalRanges)
+
+	thief, ok := fsm.SnapshotPeer("peer2")
+	require.True(t, ok)
+	require.Equal(t, []RangeID{1}, thief.LocalRanges)
+	require.EqualValues(t, 1, fsm.Metrics().RangesStolen)
+}
+
+func TestStealNextRangePrefersBlockedDonor(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	addTrustedAnchor(t, fsm, 10, 110)
+	addTrustedAnchor(t, fsm, 20, 120)
+	addTrustedAnchor(t, fsm, 30, 130)
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:          "ready-donor",
+		Rank:        100,
+		State:       PeerReady,
+		LocalRanges: []RangeID{1},
+	}))
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:          "blocked-donor",
+		Rank:        0,
+		State:       PeerBlocked,
+		LocalRanges: []RangeID{2},
+	}))
+	addPeer(t, fsm, "thief")
+	mustPlanRange(t, fsm, 1, 0, 10)
+	mustPlanRange(t, fsm, 2, 10, 20)
+
+	rng1, ok := fsm.ranges[1]
+	require.True(t, ok)
+	rng1.OwnerPeer = "ready-donor"
+	rng1.LeaseEpoch = 1
+	rng1.State = RangeOwned
+	fsm.ranges[1] = rng1
+
+	rng2, ok := fsm.ranges[2]
+	require.True(t, ok)
+	rng2.OwnerPeer = "blocked-donor"
+	rng2.LeaseEpoch = 1
+	rng2.State = RangeOwned
+	fsm.ranges[2] = rng2
+
+	steal, ok, err := fsm.StealNextRange("thief")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "blocked-donor", steal.DonorID)
+	require.EqualValues(t, 2, steal.RangeID)
+	require.Equal(t, StealReasonQueuedBlocked, steal.Reason)
+}
+
+func TestStealNextRangeLeavesReadySingletonDonor(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	addTrustedAnchor(t, fsm, 10, 110)
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:          "donor",
+		State:       PeerReady,
+		LocalRanges: []RangeID{1},
+	}))
+	addPeer(t, fsm, "thief")
+	mustPlanRange(t, fsm, 1, 0, 10)
+
+	rng, ok := fsm.ranges[1]
+	require.True(t, ok)
+	rng.OwnerPeer = "donor"
+	rng.LeaseEpoch = 1
+	rng.State = RangeOwned
+	fsm.ranges[1] = rng
+
+	_, ok, err := fsm.StealNextRange("thief")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	donor, ok := fsm.SnapshotPeer("donor")
+	require.True(t, ok)
+	require.Equal(t, []RangeID{1}, donor.LocalRanges)
+}
+
+func TestAssignRangeBalancesLocalQueues(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	addTrustedAnchor(t, fsm, 10, 110)
+	addTrustedAnchor(t, fsm, 20, 120)
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:          "loaded",
+		State:       PeerReady,
+		LocalRanges: []RangeID{99, 100},
+	}))
+	addPeer(t, fsm, "empty")
+	mustPlanRange(t, fsm, 1, 0, 10)
+	mustPlanRange(t, fsm, 2, 10, 20)
+
+	assignment := mustAssignRange(t, fsm)
+	require.Equal(t, "empty", assignment.PeerID)
+}
+
+func TestRecoveredPeerCanOwnRangeAgain(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	addTrustedAnchor(t, fsm, 10, 110)
+	addPeer(t, fsm, "peer")
+	mustPlanRange(t, fsm, 1, 0, 10)
+
+	require.NoError(t, fsm.UpdatePeerState("peer", PeerBlocked))
+	_, ok := fsm.AssignNextQueuedRange()
+	require.False(t, ok)
+
+	require.NoError(t, fsm.UpdatePeerState("peer", PeerReady))
+	assignment := mustAssignRange(t, fsm)
+	require.Equal(t, "peer", assignment.PeerID)
+}
+
+func TestRemovePeerRequeuesOwnedAndActiveRanges(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	addTrustedAnchor(t, fsm, 10, 110)
+	addTrustedAnchor(t, fsm, 20, 120)
+	addPeer(t, fsm, "donor")
+	addPeer(t, fsm, "thief")
+	mustPlanRange(t, fsm, 1, 0, 10)
+	mustPlanRange(t, fsm, 2, 10, 20)
+
+	owned, ok, err := fsm.AssignQueuedRangeToPeer(1, "donor")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	active := mustStartRange(t, fsm, "donor")
+	require.Equal(t, owned.RangeID, active.RangeID)
+
+	_, ok, err = fsm.AssignQueuedRangeToPeer(2, "donor")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	fsm.RemovePeer("donor")
+
+	for _, rangeID := range []RangeID{1, 2} {
+		rng, ok := fsm.RangeByID(rangeID)
+		require.True(t, ok)
+		require.Equal(t, RangeQueued, rng.State)
+		require.Equal(t, NoPeer, rng.OwnerPeer)
+		require.Equal(t, uint64(2), rng.LeaseEpoch)
+	}
+
+	assignment := mustAssignRange(t, fsm)
+	require.Equal(t, "thief", assignment.PeerID)
+	require.Equal(t, RangeID(1), assignment.RangeID)
+}
+
+func TestPlanRangeRejectsOverlappingWork(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	addTrustedAnchor(t, fsm, 10, 110)
+	addTrustedAnchor(t, fsm, 20, 120)
+	mustPlanRange(t, fsm, 1, 0, 20)
+
+	_, ok, err := fsm.PlanRange(2, 0, 10)
+	require.ErrorIs(t, err, ErrInvalidRange)
+	require.False(t, ok)
+}
+
+func TestQuickOutOfOrderCommitPreservesContiguousTip(t *testing.T) {
+	property := func(raw []uint8) bool {
+		const numRanges = 5
+
+		fsm := newTestFSM(0, 100)
+		for i := uint32(0); i <= numRanges; i++ {
+			addTrustedAnchorNoRequire(fsm, i*10, 100+i)
+		}
+		for i := 1; i <= numRanges; i++ {
+			addPeerNoRequire(fsm, peerID(i))
+			if _, ok, err := fsm.PlanRange(
+				RangeID(i), uint32((i-1)*10), uint32(i*10),
+			); err != nil || !ok {
+				return false
+			}
+		}
+		for i := 0; i < numRanges; i++ {
+			if _, ok := fsm.AssignNextQueuedRange(); !ok {
+				return false
+			}
+		}
+
+		started := make(map[RangeID]RangeAssignment, numRanges)
+		for i := 1; i <= numRanges; i++ {
+			assignment, ok, err := fsm.StartPeerRange(peerID(i))
+			if err != nil || !ok {
+				return false
+			}
+			started[RangeID(i)] = assignment
+		}
+
+		order := permutedRangeOrder(numRanges, raw)
+		completed := make(map[RangeID]bool, numRanges)
+		for _, rangeID := range order {
+			assignment := started[rangeID]
+			if _, err := fsm.CompleteRangeAt(
+				assignment.PeerID, rangeID, assignment.LeaseEpoch,
+				true, time.Unix(int64(rangeID), 0),
+			); err != nil {
+				return false
+			}
+			completed[rangeID] = true
+
+			fsm.CommitReadyRanges()
+			expectedTip := uint32(0)
+			for i := 1; i <= numRanges; i++ {
+				if !completed[RangeID(i)] {
+					break
+				}
+				expectedTip = uint32(i * 10)
+			}
+
+			if fsm.CommittedTip() != expectedTip {
+				return false
+			}
+			if !commitLogStrictlyIncreasing(fsm.CommitLog()) {
+				return false
+			}
+		}
+
+		return reflect.DeepEqual(
+			fsm.CommitLog(), []RangeID{1, 2, 3, 4, 5},
+		)
+	}
+
+	require.NoError(t, quick.Check(property, &quick.Config{MaxCount: 100}))
+}
+
+func newTestFSM(tip uint32, hashByte byte) *HeaderSyncFSM {
+	return NewHeaderSyncFSM(tip, testHash(hashByte), DefaultConfig())
+}
+
+func addTrustedAnchor(t *testing.T, fsm *HeaderSyncFSM, height uint32,
+	hashByte byte) {
+
+	t.Helper()
+	anchor, ok := fsm.AddOrConfirmAnchor(height, testHash(hashByte), true)
+	require.True(t, ok)
+	require.True(t, fsm.AnchorConfirmed(anchor))
+}
+
+func addTrustedAnchorNoRequire(fsm *HeaderSyncFSM, height uint32,
+	hashByte uint32) {
+
+	fsm.AddOrConfirmAnchor(height, testHash(byte(hashByte)), true)
+}
+
+func addPeer(t *testing.T, fsm *HeaderSyncFSM, id string) {
+	t.Helper()
+	addPeerNoRequire(fsm, id)
+}
+
+func addPeerNoRequire(fsm *HeaderSyncFSM, id string) {
+	_ = fsm.AddPeer(PeerSnapshot{
+		ID:    id,
+		State: PeerReady,
+	})
+}
+
+func mustPlanRange(t *testing.T, fsm *HeaderSyncFSM, id RangeID,
+	startHeight, stopHeight uint32) HeaderRange {
+
+	t.Helper()
+	rng, ok, err := fsm.PlanRange(id, startHeight, stopHeight)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	return rng
+}
+
+func mustAssignRange(t *testing.T, fsm *HeaderSyncFSM) RangeAssignment {
+	t.Helper()
+	assignment, ok := fsm.AssignNextQueuedRange()
+	require.True(t, ok)
+
+	return assignment
+}
+
+func mustStartRange(t *testing.T, fsm *HeaderSyncFSM,
+	peerID string) RangeAssignment {
+
+	t.Helper()
+	assignment, ok, err := fsm.StartPeerRange(peerID)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	return assignment
+}
+
+func testHash(value byte) Hash {
+	var hash Hash
+	hash[0] = value
+
+	return hash
+}
+
+func peerID(index int) string {
+	return string(rune('a' + index - 1))
+}
+
+func permutedRangeOrder(numRanges int, raw []uint8) []RangeID {
+	order := make([]RangeID, numRanges)
+	for i := range order {
+		order[i] = RangeID(i + 1)
+	}
+
+	if len(raw) == 0 {
+		return order
+	}
+
+	for i, value := range raw {
+		left := i % len(order)
+		right := int(value) % len(order)
+		order[left], order[right] = order[right], order[left]
+	}
+
+	return order
+}
+
+func commitLogStrictlyIncreasing(log []RangeID) bool {
+	for i := 1; i < len(log); i++ {
+		if log[i] <= log[i-1] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/headersync/model_bridge_test.go
+++ b/headersync/model_bridge_test.go
@@ -1,0 +1,26 @@
+package headersync
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPModelBridgeFixtures(t *testing.T) {
+	data, err := os.ReadFile(
+		"../p-models/neutrinoheadersync/bridge/scenarios.json",
+	)
+	require.NoError(t, err)
+
+	fixtures, err := DecodeBridgeFixtures(data)
+	require.NoError(t, err)
+
+	for _, scenario := range fixtures.Scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			got, err := RunBridgeScenario(scenario)
+			require.NoError(t, err)
+			require.Equal(t, scenario.Expect, got)
+		})
+	}
+}

--- a/headersync/planner.go
+++ b/headersync/planner.go
@@ -1,0 +1,139 @@
+package headersync
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/btcsuite/btcd/chaincfg"
+)
+
+// PlanRangesResult describes the ranges created by one anchor-planning pass.
+type PlanRangesResult struct {
+	Ranges          []HeaderRange
+	NextID          RangeID
+	SkippedExisting int
+}
+
+// SeedCommittedAnchor makes the current committed tip available as a trusted
+// start boundary for future range planning.
+func (h *HeaderSyncFSM) SeedCommittedAnchor() Anchor {
+	anchor, _ := h.AddOrConfirmAnchor(
+		h.committedTip, h.committedHash, true,
+	)
+
+	return anchor
+}
+
+// AddCheckpointAnchors adds chain checkpoints as trusted range boundaries.
+func (h *HeaderSyncFSM) AddCheckpointAnchors(
+	checkpoints []chaincfg.Checkpoint) int {
+
+	var added int
+	for _, checkpoint := range checkpoints {
+		if checkpoint.Height < 0 || checkpoint.Hash == nil {
+			continue
+		}
+
+		if _, ok := h.anchors[uint32(checkpoint.Height)]; !ok {
+			added++
+		}
+		h.AddOrConfirmAnchor(
+			uint32(checkpoint.Height), *checkpoint.Hash, true,
+		)
+	}
+
+	return added
+}
+
+// AddDiscoveredAnchor records an untrusted peer-discovered boundary. The
+// returned anchor is usable only once AnchorConfirmed returns true.
+func (h *HeaderSyncFSM) AddDiscoveredAnchor(height uint32,
+	hash Hash) (Anchor, bool) {
+
+	return h.AddOrConfirmAnchor(height, hash, false)
+}
+
+// PlanConfirmedAnchorRanges plans work between adjacent confirmed anchors in
+// [startHeight, stopHeight]. This does not invent split points; if no confirmed
+// anchor exists at a height, no range boundary is created there.
+func (h *HeaderSyncFSM) PlanConfirmedAnchorRanges(nextID RangeID,
+	startHeight, stopHeight uint32) (PlanRangesResult, error) {
+
+	if nextID == NoRange {
+		return PlanRangesResult{}, fmt.Errorf("%w: zero next id",
+			ErrInvalidRange)
+	}
+	if startHeight >= stopHeight {
+		return PlanRangesResult{}, fmt.Errorf("%w: start %d stop %d",
+			ErrInvalidRange, startHeight, stopHeight)
+	}
+
+	anchors := h.confirmedAnchorsInRange(startHeight, stopHeight)
+	if len(anchors) < 2 || anchors[0].Height != startHeight {
+		return PlanRangesResult{NextID: nextID}, nil
+	}
+
+	result := PlanRangesResult{NextID: nextID}
+	for i := 1; i < len(anchors); i++ {
+		start := anchors[i-1]
+		stop := anchors[i]
+		if _, ok := h.rangeBySpan(start.Height, stop.Height); ok {
+			result.SkippedExisting++
+			continue
+		}
+
+		rng, ok, err := h.PlanRange(
+			result.NextID, start.Height, stop.Height,
+		)
+		if err != nil {
+			return result, err
+		}
+		if !ok {
+			continue
+		}
+
+		result.Ranges = append(result.Ranges, rng)
+		result.NextID++
+		if result.NextID == NoRange {
+			return result, fmt.Errorf("%w: range id overflow",
+				ErrInvalidRange)
+		}
+	}
+
+	return result, nil
+}
+
+func (h *HeaderSyncFSM) confirmedAnchorsInRange(startHeight,
+	stopHeight uint32) []Anchor {
+
+	anchors := make([]Anchor, 0, len(h.anchors))
+	for _, anchor := range h.anchors {
+		if anchor.Height < startHeight || anchor.Height > stopHeight ||
+			!h.anchorConfirmed(anchor) {
+
+			continue
+		}
+
+		anchors = append(anchors, anchor)
+	}
+
+	sort.Slice(anchors, func(i, j int) bool {
+		return anchors[i].Height < anchors[j].Height
+	})
+
+	return anchors
+}
+
+func (h *HeaderSyncFSM) rangeBySpan(startHeight,
+	stopHeight uint32) (HeaderRange, bool) {
+
+	for _, rng := range h.ranges {
+		if rng.StartHeight == startHeight && rng.StopHeight == stopHeight &&
+			rng.State != RangeFailed && rng.State != RangeStale {
+
+			return rng, true
+		}
+	}
+
+	return HeaderRange{}, false
+}

--- a/headersync/planner_test.go
+++ b/headersync/planner_test.go
@@ -1,0 +1,76 @@
+package headersync
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckpointAnchorsPlanAdjacentRanges(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	fsm.SeedCommittedAnchor()
+	added := fsm.AddCheckpointAnchors([]chaincfg.Checkpoint{
+		{Height: 10, Hash: hashPtr(testHash(110))},
+		{Height: 20, Hash: hashPtr(testHash(120))},
+	})
+	require.Equal(t, 2, added)
+
+	result, err := fsm.PlanConfirmedAnchorRanges(1, 0, 20)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, result.NextID)
+	require.Len(t, result.Ranges, 2)
+	require.EqualValues(t, 0, result.Ranges[0].StartHeight)
+	require.EqualValues(t, 10, result.Ranges[0].StopHeight)
+	require.EqualValues(t, 10, result.Ranges[1].StartHeight)
+	require.EqualValues(t, 20, result.Ranges[1].StopHeight)
+}
+
+func TestDiscoveredAnchorRequiresConfirmationBeforePlanning(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	fsm.SeedCommittedAnchor()
+	fsm.AddDiscoveredAnchor(10, testHash(110))
+
+	result, err := fsm.PlanConfirmedAnchorRanges(1, 0, 10)
+	require.NoError(t, err)
+	require.Empty(t, result.Ranges)
+
+	fsm.AddDiscoveredAnchor(10, testHash(110))
+	result, err = fsm.PlanConfirmedAnchorRanges(1, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, result.Ranges, 1)
+	require.EqualValues(t, 0, result.Ranges[0].StartHeight)
+	require.EqualValues(t, 10, result.Ranges[0].StopHeight)
+}
+
+func TestPlanConfirmedAnchorRangesSkipsExistingSpan(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	fsm.SeedCommittedAnchor()
+	addTrustedAnchor(t, fsm, 10, 110)
+	mustPlanRange(t, fsm, 1, 0, 10)
+
+	result, err := fsm.PlanConfirmedAnchorRanges(2, 0, 10)
+	require.NoError(t, err)
+	require.Empty(t, result.Ranges)
+	require.Equal(t, 1, result.SkippedExisting)
+	require.EqualValues(t, 2, result.NextID)
+}
+
+func TestPlanConfirmedAnchorRangesSkipsOversizedSpan(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	fsm.SeedCommittedAnchor()
+	addTrustedAnchor(t, fsm, DefaultMaxRangeHeaders+1, 110)
+
+	result, err := fsm.PlanConfirmedAnchorRanges(
+		1, 0, DefaultMaxRangeHeaders+1,
+	)
+	require.NoError(t, err)
+	require.Empty(t, result.Ranges)
+	require.EqualValues(t, 1, result.NextID)
+}
+
+func hashPtr(hash Hash) *Hash {
+	hashCopy := hash
+
+	return &hashCopy
+}

--- a/headersync/querydispatch/dispatch.go
+++ b/headersync/querydispatch/dispatch.go
@@ -1,0 +1,169 @@
+package querydispatch
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lightninglabs/neutrino/headersync"
+	"github.com/lightninglabs/neutrino/querysync"
+)
+
+// Controller adapts querysync's actor-backed scheduler to headersync's generic
+// dispatch interface. Header range validation, lease epochs, active timeout
+// stealing, staging, and ordered commit stay in headersync.
+type Controller struct {
+	manager *querysync.ManagerActor
+}
+
+var _ headersync.DispatchController = (*Controller)(nil)
+
+// New creates a querysync-backed header range dispatch controller.
+func New(manager *querysync.ManagerActor) *Controller {
+	return &Controller{manager: manager}
+}
+
+// AddPeer mirrors a header peer into the querysync scheduler.
+func (c *Controller) AddPeer(ctx context.Context,
+	peer headersync.PeerSnapshot) error {
+
+	return c.manager.AddPeer(ctx, toQueryPeer(peer))
+}
+
+// RemovePeer removes a mirrored header peer.
+func (c *Controller) RemovePeer(ctx context.Context, id string) error {
+	return c.manager.RemovePeer(ctx, id)
+}
+
+// UpdatePeerState mirrors peer scheduling state.
+func (c *Controller) UpdatePeerState(ctx context.Context, id string,
+	state headersync.PeerState) error {
+
+	return c.manager.UpdatePeerState(ctx, id, toQueryPeerState(state))
+}
+
+// UpdatePeerRTT mirrors peer RTT.
+func (c *Controller) UpdatePeerRTT(ctx context.Context, id string,
+	rtt time.Duration) error {
+
+	return c.manager.UpdatePeerRTT(ctx, id, rtt)
+}
+
+// AssignRange asks querysync to assign unstarted header range ownership.
+func (c *Controller) AssignRange(ctx context.Context,
+	rangeID headersync.RangeID) (headersync.DispatchAssignment, bool,
+	error) {
+
+	assignment, ok, err := c.manager.AskAssignLocalTask(
+		ctx, querysync.Task{ID: toTaskID(rangeID)},
+	)
+	if err != nil || !ok {
+		return headersync.DispatchAssignment{}, ok, err
+	}
+
+	return headersync.DispatchAssignment{
+		PeerID:  assignment.PeerID,
+		RangeID: fromTaskID(assignment.TaskID),
+	}, true, nil
+}
+
+// StartRange mirrors the peer's local queue after headersync has moved the
+// range into the active slot, then marks the peer busy in querysync.
+func (c *Controller) StartRange(ctx context.Context,
+	peer headersync.PeerSnapshot) error {
+
+	if err := c.SyncPeer(ctx, peer); err != nil {
+		return err
+	}
+
+	return c.manager.UpdatePeerState(
+		ctx, peer.ID, querysync.PeerBusy,
+	)
+}
+
+// CompleteRange marks a mirrored active range finished.
+func (c *Controller) CompleteRange(ctx context.Context,
+	peerID string) error {
+
+	return c.manager.CompletePeerWork(ctx, peerID)
+}
+
+// SyncPeer replaces the mirrored peer snapshot.
+func (c *Controller) SyncPeer(ctx context.Context,
+	peer headersync.PeerSnapshot) error {
+
+	return c.manager.AddPeer(ctx, toQueryPeer(peer))
+}
+
+// StealRange asks querysync to move unstarted range ownership to the thief.
+func (c *Controller) StealRange(ctx context.Context,
+	thiefID string) (headersync.DispatchStealResult, bool, error) {
+
+	result, ok, err := c.manager.AskSteal(ctx, thiefID)
+	if err != nil || !ok {
+		return headersync.DispatchStealResult{}, ok, err
+	}
+
+	rangeIDs := make([]headersync.RangeID, 0, len(result.TaskIDs))
+	for _, taskID := range result.TaskIDs {
+		rangeIDs = append(rangeIDs, fromTaskID(taskID))
+	}
+	if len(rangeIDs) == 0 && result.TaskID != 0 {
+		rangeIDs = append(rangeIDs, fromTaskID(result.TaskID))
+	}
+	if len(rangeIDs) == 0 {
+		return headersync.DispatchStealResult{}, false,
+			fmt.Errorf("querysync steal returned no task ids")
+	}
+
+	return headersync.DispatchStealResult{
+		ThiefID:  result.ThiefID,
+		DonorID:  result.DonorID,
+		RangeID:  rangeIDs[0],
+		RangeIDs: rangeIDs,
+	}, true, nil
+}
+
+func toQueryPeer(peer headersync.PeerSnapshot) querysync.PeerSnapshot {
+	return querysync.PeerSnapshot{
+		ID:        peer.ID,
+		Rank:      peer.Rank,
+		RTT:       peer.RTT,
+		State:     toQueryPeerState(peer.State),
+		LocalWork: toTaskIDs(peer.LocalRanges),
+	}
+}
+
+func toQueryPeerState(state headersync.PeerState) querysync.PeerState {
+	switch state {
+	case headersync.PeerReady:
+		return querysync.PeerReady
+	case headersync.PeerBusy:
+		return querysync.PeerBusy
+	case headersync.PeerBlocked:
+		return querysync.PeerBlocked
+	case headersync.PeerQuarantined:
+		return querysync.PeerQuarantined
+	case headersync.PeerDown:
+		return querysync.PeerDown
+	default:
+		return querysync.PeerDown
+	}
+}
+
+func toTaskIDs(rangeIDs []headersync.RangeID) []querysync.TaskID {
+	taskIDs := make([]querysync.TaskID, 0, len(rangeIDs))
+	for _, rangeID := range rangeIDs {
+		taskIDs = append(taskIDs, toTaskID(rangeID))
+	}
+
+	return taskIDs
+}
+
+func toTaskID(rangeID headersync.RangeID) querysync.TaskID {
+	return querysync.TaskID(rangeID)
+}
+
+func fromTaskID(taskID querysync.TaskID) headersync.RangeID {
+	return headersync.RangeID(taskID)
+}

--- a/headersync/querydispatch/dispatch_test.go
+++ b/headersync/querydispatch/dispatch_test.go
@@ -1,0 +1,242 @@
+package querydispatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/neutrino/headersync"
+	"github.com/lightninglabs/neutrino/querysync"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeadersyncAssignsThroughQuerysync(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	headerManager, queryManager := newManagers(t, ctx)
+	addAnchor(t, ctx, headerManager, 0, 100)
+	addAnchor(t, ctx, headerManager, 10, 110)
+	addAnchor(t, ctx, headerManager, 20, 120)
+
+	require.NoError(t, headerManager.AddPeer(ctx, headersync.PeerSnapshot{
+		ID:          "loaded",
+		Rank:        0,
+		State:       headersync.PeerReady,
+		LocalRanges: []headersync.RangeID{99, 100},
+	}))
+	require.NoError(t, headerManager.AddPeer(ctx, headersync.PeerSnapshot{
+		ID:    "empty",
+		Rank:  10,
+		State: headersync.PeerReady,
+	}))
+	planRange(t, ctx, headerManager, 1, 0, 10)
+	planRange(t, ctx, headerManager, 2, 10, 20)
+
+	assignment, ok, err := headerManager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "empty", assignment.PeerID)
+
+	headerPeer, ok, err := headerManager.SnapshotPeer(ctx, "empty")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []headersync.RangeID{1}, headerPeer.LocalRanges)
+
+	queryPeer, ok, err := queryManager.SnapshotPeer(ctx, "empty")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []querysync.TaskID{1}, queryPeer.LocalWork)
+}
+
+func TestHeadersyncStealsThroughQuerysync(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	headerManager, queryManager := newManagers(t, ctx)
+	addAnchor(t, ctx, headerManager, 0, 100)
+	addAnchor(t, ctx, headerManager, 10, 110)
+	addAnchor(t, ctx, headerManager, 20, 120)
+	addAnchor(t, ctx, headerManager, 30, 130)
+
+	require.NoError(t, headerManager.AddPeer(ctx, headersync.PeerSnapshot{
+		ID:    "donor",
+		Rank:  0,
+		State: headersync.PeerReady,
+	}))
+	planRange(t, ctx, headerManager, 1, 0, 10)
+	planRange(t, ctx, headerManager, 2, 10, 20)
+	planRange(t, ctx, headerManager, 3, 20, 30)
+
+	for i := 0; i < 3; i++ {
+		_, ok, err := headerManager.AssignNextQueuedRange(ctx)
+		require.NoError(t, err)
+		require.True(t, ok)
+	}
+	require.NoError(t, headerManager.AddPeer(ctx, headersync.PeerSnapshot{
+		ID:    "thief",
+		Rank:  10,
+		State: headersync.PeerReady,
+	}))
+
+	result, ok, err := headerManager.StealNextRange(ctx, "thief")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "donor", result.DonorID)
+	require.Equal(t, "thief", result.ThiefID)
+	require.EqualValues(t, 1, result.RangeID)
+	require.Equal(t, headersync.StealReasonDispatch, result.Reason)
+
+	headerThief, ok, err := headerManager.SnapshotPeer(ctx, "thief")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []headersync.RangeID{1, 2}, headerThief.LocalRanges)
+
+	queryThief, ok, err := queryManager.SnapshotPeer(ctx, "thief")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []querysync.TaskID{1, 2}, queryThief.LocalWork)
+}
+
+func TestHeadersyncActiveStealFallsBackToFSM(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	headerManager, queryManager := newManagers(t, ctx)
+	addAnchor(t, ctx, headerManager, 0, 100)
+	addAnchor(t, ctx, headerManager, 10, 110)
+
+	require.NoError(t, headerManager.AddPeer(ctx, headersync.PeerSnapshot{
+		ID:    "donor",
+		Rank:  0,
+		State: headersync.PeerReady,
+	}))
+	require.NoError(t, headerManager.AddPeer(ctx, headersync.PeerSnapshot{
+		ID:    "thief",
+		Rank:  10,
+		State: headersync.PeerReady,
+	}))
+	planRange(t, ctx, headerManager, 1, 0, 10)
+
+	_, ok, err := headerManager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	started, ok, err := headerManager.StartPeerRange(ctx, "donor")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.EqualValues(t, 1, started.RangeID)
+
+	require.NoError(t, headerManager.UpdatePeerState(
+		ctx, "donor", headersync.PeerQuarantined,
+	))
+
+	result, ok, err := headerManager.StealNextRange(ctx, "thief")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "donor", result.DonorID)
+	require.Equal(t, "thief", result.ThiefID)
+	require.EqualValues(t, 1, result.RangeID)
+	require.EqualValues(t, started.LeaseEpoch, result.OldLeaseEpoch)
+	require.EqualValues(t, started.LeaseEpoch+1, result.LeaseEpoch)
+	require.Equal(t, headersync.StealReasonActiveQuarantined, result.Reason)
+
+	headerThief, ok, err := headerManager.SnapshotPeer(ctx, "thief")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []headersync.RangeID{1}, headerThief.LocalRanges)
+
+	queryThief, ok, err := queryManager.SnapshotPeer(ctx, "thief")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []querysync.TaskID{1}, queryThief.LocalWork)
+}
+
+func TestHeadersyncStartAndCompleteMirrorQuerysyncState(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	headerManager, queryManager := newManagers(t, ctx)
+	addAnchor(t, ctx, headerManager, 0, 100)
+	addAnchor(t, ctx, headerManager, 10, 110)
+	require.NoError(t, headerManager.AddPeer(ctx, headersync.PeerSnapshot{
+		ID:    "peer",
+		State: headersync.PeerReady,
+	}))
+	planRange(t, ctx, headerManager, 1, 0, 10)
+	_, ok, err := headerManager.AssignNextQueuedRange(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	assignment, ok, err := headerManager.StartPeerRange(ctx, "peer")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	queryPeer, ok, err := queryManager.SnapshotPeer(ctx, "peer")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, querysync.PeerBusy, queryPeer.State)
+	require.Empty(t, queryPeer.LocalWork)
+
+	_, err = headerManager.CompleteRange(
+		ctx, "peer", assignment.RangeID, assignment.LeaseEpoch, true,
+		time.Unix(100, 0),
+	)
+	require.NoError(t, err)
+
+	queryPeer, ok, err = queryManager.SnapshotPeer(ctx, "peer")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, querysync.PeerReady, queryPeer.State)
+	require.Empty(t, queryPeer.LocalWork)
+}
+
+func newManagers(t *testing.T, ctx context.Context) (
+	*headersync.ManagerActor, *querysync.ManagerActor) {
+
+	t.Helper()
+
+	queryManager := querysync.NewManagerActor(
+		querysync.NewSchedulerFSM(querysync.DefaultConfig()), 8,
+	)
+	queryManager.Start(ctx)
+	t.Cleanup(queryManager.Stop)
+
+	headerManager := headersync.NewManagerActor(
+		headersync.NewHeaderSyncFSM(0, testHash(100),
+			headersync.DefaultConfig()), 8,
+	)
+	headerManager.SetDispatchController(New(queryManager))
+	headerManager.Start(ctx)
+	t.Cleanup(headerManager.Stop)
+
+	return headerManager, queryManager
+}
+
+func addAnchor(t *testing.T, ctx context.Context,
+	manager *headersync.ManagerActor, height uint32, hashByte byte) {
+
+	t.Helper()
+
+	_, ok, err := manager.AddAnchor(ctx, height, testHash(hashByte), true)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func planRange(t *testing.T, ctx context.Context,
+	manager *headersync.ManagerActor, id headersync.RangeID,
+	startHeight, stopHeight uint32) {
+
+	t.Helper()
+
+	_, ok, err := manager.PlanRange(ctx, id, startHeight, stopHeight)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func testHash(value byte) chainhash.Hash {
+	var hash chainhash.Hash
+	hash[0] = value
+
+	return hash
+}

--- a/headersync/session.go
+++ b/headersync/session.go
@@ -1,0 +1,364 @@
+package headersync
+
+import (
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+// RangeRequest tracks an in-flight getheaders request for a leased header
+// range. The timer remains owned here so callers can stop and replace requests
+// without leaking timeout callbacks.
+type RangeRequest struct {
+	Assignment RangeAssignment
+	RequestID  uint64
+	Timer      *time.Timer
+}
+
+// AnchorRequest tracks an in-flight anchor-discovery getheaders request. Anchor
+// discovery is separate from range download because long checkpoint spans must
+// first learn trustworthy intermediate boundary hashes.
+type AnchorRequest struct {
+	StartHeight uint32
+	StartHash   Hash
+	StopHeight  uint32
+	StopHash    Hash
+	RequestID   uint64
+	Timer       *time.Timer
+}
+
+// StaleRequest remembers a timed-out range request long enough to classify a
+// late response as stale instead of handing it to the legacy serial path.
+type StaleRequest struct {
+	Assignment RangeAssignment
+	ExpiresAt  time.Time
+}
+
+// StagedRange stores a completed-but-not-yet-committed range. Parallel peers
+// can complete ranges out of order, so completed headers are staged until the
+// manager marks the next contiguous range ready to commit.
+type StagedRange struct {
+	Headers []*wire.BlockHeader
+	PeerID  string
+}
+
+// Session owns production header-sync request bookkeeping that is not chain
+// storage state: in-flight range requests, anchor discovery requests, stale
+// completions, staged headers, and deterministic range ID allocation.
+type Session struct {
+	rangeRequests  map[string]RangeRequest
+	anchorRequests map[string]AnchorRequest
+	staleRequests  map[string]StaleRequest
+	stagedRanges   map[RangeID]StagedRange
+	cooldowns      map[string]time.Time
+	nextRangeID    RangeID
+}
+
+// NewSession creates empty request state with range IDs starting at one. Range
+// zero is reserved as NoRange.
+func NewSession() *Session {
+	s := &Session{}
+	s.Reset()
+
+	return s
+}
+
+// Reset stops outstanding timers and clears all request/staging state.
+func (s *Session) Reset() {
+	s.StopAll()
+
+	s.rangeRequests = make(map[string]RangeRequest)
+	s.anchorRequests = make(map[string]AnchorRequest)
+	s.staleRequests = make(map[string]StaleRequest)
+	s.stagedRanges = make(map[RangeID]StagedRange)
+	if s.cooldowns == nil {
+		s.cooldowns = make(map[string]time.Time)
+	}
+	s.nextRangeID = 1
+}
+
+// StopAll stops outstanding timers and clears in-flight request maps. It keeps
+// the Session object reusable by Reset or future Track calls.
+func (s *Session) StopAll() {
+	if s == nil {
+		return
+	}
+
+	for peerID, request := range s.rangeRequests {
+		stopTimer(request.Timer)
+		delete(s.rangeRequests, peerID)
+	}
+	for peerID, request := range s.anchorRequests {
+		stopTimer(request.Timer)
+		delete(s.anchorRequests, peerID)
+	}
+	for peerID := range s.staleRequests {
+		delete(s.staleRequests, peerID)
+	}
+}
+
+// NextRangeID returns the next deterministic range ID to pass into the FSM.
+func (s *Session) NextRangeID() RangeID {
+	return s.nextRangeID
+}
+
+// SetNextRangeID records the next range ID after a planning batch.
+func (s *Session) SetNextRangeID(next RangeID) {
+	s.nextRangeID = next
+}
+
+// AllocateRangeID reserves and returns one range ID.
+func (s *Session) AllocateRangeID() RangeID {
+	id := s.nextRangeID
+	s.nextRangeID++
+
+	return id
+}
+
+// TrackRange records an in-flight range request for a peer.
+func (s *Session) TrackRange(peerID string, request RangeRequest) {
+	if existing, ok := s.rangeRequests[peerID]; ok {
+		stopTimer(existing.Timer)
+	}
+
+	delete(s.staleRequests, peerID)
+	s.rangeRequests[peerID] = request
+}
+
+// FinishRange removes and stops an in-flight range request.
+func (s *Session) FinishRange(peerID string) (RangeRequest, bool) {
+	request, ok := s.rangeRequests[peerID]
+	if !ok {
+		return RangeRequest{}, false
+	}
+
+	stopTimer(request.Timer)
+	delete(s.rangeRequests, peerID)
+
+	return request, true
+}
+
+// TimeoutRange removes an in-flight range request only if the timeout still
+// matches the active request identity.
+func (s *Session) TimeoutRange(peerID string, requestID uint64,
+	rangeID RangeID, leaseEpoch uint64) (RangeRequest, bool) {
+
+	request, ok := s.rangeRequests[peerID]
+	if !ok || request.RequestID != requestID ||
+		request.Assignment.RangeID != rangeID ||
+		request.Assignment.LeaseEpoch != leaseEpoch {
+
+		return RangeRequest{}, false
+	}
+
+	delete(s.rangeRequests, peerID)
+
+	return request, true
+}
+
+// RangeActive returns true when a peer already has an in-flight range request.
+func (s *Session) RangeActive(peerID string) bool {
+	_, ok := s.rangeRequests[peerID]
+	return ok
+}
+
+// ActiveRangeCount returns the number of active range requests.
+func (s *Session) ActiveRangeCount() int {
+	return len(s.rangeRequests)
+}
+
+// MarkStale records a timed-out request so a late response can be classified.
+func (s *Session) MarkStale(peerID string, request StaleRequest) {
+	s.staleRequests[peerID] = request
+}
+
+// PopStale removes a stale request for a peer.
+func (s *Session) PopStale(peerID string) (StaleRequest, bool) {
+	request, ok := s.staleRequests[peerID]
+	if !ok {
+		return StaleRequest{}, false
+	}
+
+	delete(s.staleRequests, peerID)
+
+	return request, true
+}
+
+// ClearStale removes any stale response tracking for a peer.
+func (s *Session) ClearStale(peerID string) {
+	delete(s.staleRequests, peerID)
+}
+
+// TrackAnchor records an in-flight anchor-discovery request for a peer.
+func (s *Session) TrackAnchor(peerID string, request AnchorRequest) {
+	if existing, ok := s.anchorRequests[peerID]; ok {
+		stopTimer(existing.Timer)
+	}
+
+	s.anchorRequests[peerID] = request
+}
+
+// FinishAnchor removes and stops an in-flight anchor request.
+func (s *Session) FinishAnchor(peerID string) (AnchorRequest, bool) {
+	request, ok := s.anchorRequests[peerID]
+	if !ok {
+		return AnchorRequest{}, false
+	}
+
+	stopTimer(request.Timer)
+	delete(s.anchorRequests, peerID)
+
+	return request, true
+}
+
+// TimeoutAnchor removes an in-flight anchor request only if the timeout still
+// matches the active request identity.
+func (s *Session) TimeoutAnchor(peerID string, requestID uint64,
+	startHeight uint32) (AnchorRequest, bool) {
+
+	request, ok := s.anchorRequests[peerID]
+	if !ok || request.RequestID != requestID ||
+		request.StartHeight != startHeight {
+
+		return AnchorRequest{}, false
+	}
+
+	delete(s.anchorRequests, peerID)
+
+	return request, true
+}
+
+// AnchorActive returns true when a peer already has an in-flight anchor
+// discovery request.
+func (s *Session) AnchorActive(peerID string) bool {
+	_, ok := s.anchorRequests[peerID]
+	return ok
+}
+
+// ActiveAnchorCount returns the number of active anchor-discovery requests.
+func (s *Session) ActiveAnchorCount() int {
+	return len(s.anchorRequests)
+}
+
+// PruneAnchorsAtOrBefore drops in-flight anchor-discovery requests whose stop
+// height is already committed. Hedged discovery can leave duplicate requests for
+// an old span after the first peer commits it; those completions should not keep
+// the production scheduler waiting on obsolete work.
+func (s *Session) PruneAnchorsAtOrBefore(stopHeight uint32) int {
+	var pruned int
+	for peerID, request := range s.anchorRequests {
+		if request.StopHeight > stopHeight {
+			continue
+		}
+
+		stopTimer(request.Timer)
+		delete(s.anchorRequests, peerID)
+		pruned++
+	}
+
+	return pruned
+}
+
+// MatchingActiveAnchors returns the number of active anchor requests for the
+// same start/stop span.
+func (s *Session) MatchingActiveAnchors(startHeight uint32, startHash Hash,
+	stopHeight uint32) int {
+
+	var active int
+	for _, request := range s.anchorRequests {
+		if request.StartHeight == startHeight &&
+			request.StopHeight == stopHeight &&
+			request.StartHash == startHash {
+
+			active++
+		}
+	}
+
+	return active
+}
+
+// HasActiveWork returns true if there are in-flight range or anchor requests.
+func (s *Session) HasActiveWork() bool {
+	return len(s.rangeRequests) > 0 || len(s.anchorRequests) > 0
+}
+
+// StageRange stores a completed range until contiguous commit can drain it.
+func (s *Session) StageRange(rangeID RangeID, headers []*wire.BlockHeader,
+	peerID string) {
+
+	s.stagedRanges[rangeID] = StagedRange{
+		Headers: append([]*wire.BlockHeader(nil), headers...),
+		PeerID:  peerID,
+	}
+}
+
+// StagedRange returns a staged range by ID.
+func (s *Session) StagedRange(rangeID RangeID) (StagedRange, bool) {
+	staged, ok := s.stagedRanges[rangeID]
+	return staged, ok
+}
+
+// DeleteStagedRange removes a committed staged range.
+func (s *Session) DeleteStagedRange(rangeID RangeID) {
+	delete(s.stagedRanges, rangeID)
+}
+
+// TrackPeerCooldown updates the peer cooldown table based on a scheduling state
+// transition. Blocked and quarantined peers are held out of assignment until the
+// cooldown expires; ready peers clear any existing cooldown.
+func (s *Session) TrackPeerCooldown(peerID string, state PeerState,
+	now time.Time, cooldown time.Duration) (time.Time, bool) {
+
+	if s.cooldowns == nil {
+		s.cooldowns = make(map[string]time.Time)
+	}
+
+	switch state {
+	case PeerBlocked, PeerQuarantined:
+		until := now.Add(cooldown)
+		s.cooldowns[peerID] = until
+
+		return until, true
+
+	case PeerReady:
+		delete(s.cooldowns, peerID)
+	}
+
+	return time.Time{}, false
+}
+
+// CooldownUntil returns a peer's cooldown expiry when it is still active.
+func (s *Session) CooldownUntil(peerID string,
+	now time.Time) (time.Time, bool) {
+
+	until, ok := s.cooldowns[peerID]
+	if !ok || !now.Before(until) {
+		return time.Time{}, false
+	}
+
+	return until, true
+}
+
+// CooldownExpired returns true when a peer has a tracked cooldown that has
+// elapsed and should be moved back to ready if it has no active request.
+func (s *Session) CooldownExpired(peerID string, now time.Time) (time.Time,
+	bool) {
+
+	until, ok := s.cooldowns[peerID]
+	if !ok || now.Before(until) {
+		return time.Time{}, false
+	}
+
+	return until, true
+}
+
+// CooldownCount returns the number of peers with tracked cooldown state.
+func (s *Session) CooldownCount() int {
+	return len(s.cooldowns)
+}
+
+func stopTimer(timer *time.Timer) {
+	if timer != nil {
+		timer.Stop()
+	}
+}

--- a/headersync/session_test.go
+++ b/headersync/session_test.go
@@ -1,0 +1,162 @@
+package headersync
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionRangeLifecycle(t *testing.T) {
+	t.Parallel()
+
+	session := NewSession()
+	assignment := RangeAssignment{
+		PeerID:     "peer-a",
+		RangeID:    7,
+		LeaseEpoch: 2,
+	}
+
+	session.TrackRange("peer-a", RangeRequest{
+		Assignment: assignment,
+		RequestID:  11,
+	})
+	require.True(t, session.RangeActive("peer-a"))
+	require.Equal(t, 1, session.ActiveRangeCount())
+
+	_, ok := session.TimeoutRange("peer-a", 10, 7, 2)
+	require.False(t, ok)
+	require.True(t, session.RangeActive("peer-a"))
+
+	request, ok := session.TimeoutRange("peer-a", 11, 7, 2)
+	require.True(t, ok)
+	require.Equal(t, assignment, request.Assignment)
+	require.False(t, session.RangeActive("peer-a"))
+}
+
+func TestSessionAnchorLifecycle(t *testing.T) {
+	t.Parallel()
+
+	session := NewSession()
+	request := AnchorRequest{
+		StartHeight: 1,
+		StartHash:   testHash(1),
+		StopHeight:  10,
+		StopHash:    testHash(10),
+		RequestID:   13,
+	}
+
+	session.TrackAnchor("peer-a", request)
+	require.True(t, session.AnchorActive("peer-a"))
+	require.Equal(t, 1, session.ActiveAnchorCount())
+	require.Equal(t, 1, session.MatchingActiveAnchors(
+		request.StartHeight, request.StartHash, request.StopHeight,
+	))
+
+	_, ok := session.TimeoutAnchor("peer-a", 12, request.StartHeight)
+	require.False(t, ok)
+	require.True(t, session.AnchorActive("peer-a"))
+
+	finished, ok := session.FinishAnchor("peer-a")
+	require.True(t, ok)
+	require.Equal(t, request.StartHeight, finished.StartHeight)
+	require.False(t, session.AnchorActive("peer-a"))
+}
+
+func TestSessionPruneAnchorsAtOrBefore(t *testing.T) {
+	t.Parallel()
+
+	session := NewSession()
+	session.TrackAnchor("peer-a", AnchorRequest{
+		StartHeight: 1,
+		StopHeight:  10,
+		RequestID:   13,
+	})
+	session.TrackAnchor("peer-b", AnchorRequest{
+		StartHeight: 10,
+		StopHeight:  20,
+		RequestID:   14,
+	})
+	session.TrackAnchor("peer-c", AnchorRequest{
+		StartHeight: 20,
+		StopHeight:  30,
+		RequestID:   15,
+	})
+
+	pruned := session.PruneAnchorsAtOrBefore(20)
+	require.Equal(t, 2, pruned)
+	require.False(t, session.AnchorActive("peer-a"))
+	require.False(t, session.AnchorActive("peer-b"))
+	require.True(t, session.AnchorActive("peer-c"))
+	require.Equal(t, 1, session.ActiveAnchorCount())
+}
+
+func TestSessionStaleAndStaged(t *testing.T) {
+	t.Parallel()
+
+	session := NewSession()
+	assignment := RangeAssignment{PeerID: "peer-a", RangeID: 9}
+	expiresAt := time.Now().Add(time.Second)
+
+	session.MarkStale("peer-a", StaleRequest{
+		Assignment: assignment,
+		ExpiresAt:  expiresAt,
+	})
+
+	stale, ok := session.PopStale("peer-a")
+	require.True(t, ok)
+	require.Equal(t, assignment, stale.Assignment)
+	require.Equal(t, expiresAt, stale.ExpiresAt)
+
+	session.StageRange(assignment.RangeID, nil, "peer-a")
+	staged, ok := session.StagedRange(assignment.RangeID)
+	require.True(t, ok)
+	require.Equal(t, "peer-a", staged.PeerID)
+
+	session.DeleteStagedRange(assignment.RangeID)
+	_, ok = session.StagedRange(assignment.RangeID)
+	require.False(t, ok)
+}
+
+func TestSessionRangeIDAllocation(t *testing.T) {
+	t.Parallel()
+
+	session := NewSession()
+	require.Equal(t, RangeID(1), session.NextRangeID())
+	require.Equal(t, RangeID(1), session.AllocateRangeID())
+	require.Equal(t, RangeID(2), session.NextRangeID())
+
+	session.SetNextRangeID(99)
+	require.Equal(t, RangeID(99), session.AllocateRangeID())
+	require.Equal(t, RangeID(100), session.NextRangeID())
+}
+
+func TestSessionCooldownLifecycle(t *testing.T) {
+	t.Parallel()
+
+	session := NewSession()
+	now := time.Unix(100, 0)
+	until, ok := session.TrackPeerCooldown(
+		"peer-a", PeerQuarantined, now, time.Minute,
+	)
+	require.True(t, ok)
+	require.Equal(t, now.Add(time.Minute), until)
+	require.Equal(t, 1, session.CooldownCount())
+
+	activeUntil, ok := session.CooldownUntil(
+		"peer-a", now.Add(30*time.Second),
+	)
+	require.True(t, ok)
+	require.Equal(t, until, activeUntil)
+
+	expiredUntil, ok := session.CooldownExpired(
+		"peer-a", now.Add(time.Minute),
+	)
+	require.True(t, ok)
+	require.Equal(t, until, expiredUntil)
+
+	session.TrackPeerCooldown("peer-a", PeerReady, now, time.Minute)
+	require.Equal(t, 0, session.CooldownCount())
+	_, ok = session.CooldownUntil("peer-a", now.Add(time.Second))
+	require.False(t, ok)
+}

--- a/headersync/sim_test.go
+++ b/headersync/sim_test.go
@@ -1,0 +1,145 @@
+package headersync
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type simPeer struct {
+	id      string
+	stall   bool
+	active  RangeAssignment
+	started int
+}
+
+type headerSyncSim struct {
+	fsm     *HeaderSyncFSM
+	peers   map[string]*simPeer
+	tick    int
+	timeout int
+	latency int
+	steals  int
+}
+
+func newHeaderSyncSim(t *testing.T) *headerSyncSim {
+	t.Helper()
+
+	fsm := newTestFSM(0, 100)
+	for i := uint32(0); i <= 4; i++ {
+		addTrustedAnchorNoRequire(fsm, i*10, 100+i)
+	}
+
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "stalled",
+		Rank:  0,
+		State: PeerReady,
+	}))
+	require.NoError(t, fsm.AddPeer(PeerSnapshot{
+		ID:    "fast",
+		Rank:  1,
+		State: PeerReady,
+	}))
+
+	for i := 1; i <= 4; i++ {
+		_, ok, err := fsm.PlanRange(
+			RangeID(i), uint32((i-1)*10), uint32(i*10),
+		)
+		require.NoError(t, err)
+		require.True(t, ok)
+	}
+
+	return &headerSyncSim{
+		fsm: fsm,
+		peers: map[string]*simPeer{
+			"stalled": {id: "stalled", stall: true},
+			"fast":    {id: "fast"},
+		},
+		timeout: 2,
+		latency: 1,
+	}
+}
+
+func (s *headerSyncSim) step(t *testing.T) {
+	t.Helper()
+
+	for {
+		if _, ok := s.fsm.AssignNextQueuedRange(); !ok {
+			break
+		}
+	}
+
+	for _, peer := range s.peers {
+		if peer.active.RangeID != NoRange {
+			continue
+		}
+
+		assignment, ok, err := s.fsm.StartPeerRange(peer.id)
+		require.NoError(t, err)
+		if !ok {
+			continue
+		}
+
+		peer.active = assignment
+		peer.started = s.tick
+	}
+
+	for _, peer := range s.peers {
+		if peer.active.RangeID == NoRange || peer.stall {
+			continue
+		}
+		if s.tick-peer.started < s.latency {
+			continue
+		}
+
+		_, err := s.fsm.CompleteRangeAt(
+			peer.id, peer.active.RangeID, peer.active.LeaseEpoch,
+			true, time.Unix(int64(s.tick), 0),
+		)
+		require.NoError(t, err)
+		peer.active = RangeAssignment{}
+	}
+
+	for _, peer := range s.peers {
+		if peer.active.RangeID == NoRange || !peer.stall {
+			continue
+		}
+		if s.tick-peer.started < s.timeout {
+			continue
+		}
+
+		require.NoError(t, s.fsm.UpdatePeerState(peer.id, PeerBlocked))
+		result, ok, err := s.fsm.StealRange("fast", peer.active.RangeID)
+		require.NoError(t, err)
+		if ok {
+			require.Equal(t, "stalled", result.DonorID)
+			peer.active = RangeAssignment{}
+			s.steals++
+		}
+	}
+
+	if s.peers["fast"].active.RangeID == NoRange {
+		_, ok, err := s.fsm.StealNextRange("fast")
+		require.NoError(t, err)
+		if ok {
+			s.steals++
+		}
+	}
+
+	s.fsm.CommitReadyRanges()
+	s.tick++
+}
+
+func TestSimulationStalledPeerRangeIsStolenAndCommitted(t *testing.T) {
+	sim := newHeaderSyncSim(t)
+
+	for i := 0; i < 20 && sim.fsm.CommittedTip() < 40; i++ {
+		sim.step(t)
+	}
+
+	require.EqualValues(t, 40, sim.fsm.CommittedTip())
+	require.GreaterOrEqual(t, sim.steals, 1)
+	require.Equal(t, []RangeID{1, 2, 3, 4}, sim.fsm.CommitLog())
+	require.EqualValues(t, sim.steals, sim.fsm.Metrics().RangesStolen)
+}

--- a/headersync/types.go
+++ b/headersync/types.go
@@ -1,0 +1,339 @@
+package headersync
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+const (
+	// NoPeer is used when a range does not currently have an owner.
+	NoPeer = ""
+
+	// NoRange is used when a peer does not have an active range.
+	NoRange RangeID = 0
+
+	// DefaultAnchorConfirmationsRequired is the number of matching
+	// observations required before a discovered anchor can be used for
+	// parallel range planning. Trusted chain checkpoints bypass this.
+	DefaultAnchorConfirmationsRequired = 2
+
+	// DefaultMaxPeerOutstandingRanges bounds the amount of work a peer can
+	// own. This includes both its active range and unstarted local queue.
+	DefaultMaxPeerOutstandingRanges = 4
+
+	// DefaultMaxRangeHeaders matches the wire getheaders response cap. The FSM
+	// refuses to plan larger ranges unless a caller explicitly raises the cap.
+	DefaultMaxRangeHeaders = 2000
+)
+
+var (
+	// ErrActorStopped is returned when a caller sends a message to an actor
+	// that is shutting down or has not started yet.
+	ErrActorStopped = errors.New("header sync actor stopped")
+
+	// ErrInvalidPeer is returned when a malformed peer snapshot is added to
+	// the FSM.
+	ErrInvalidPeer = errors.New("invalid header sync peer")
+
+	// ErrUnknownPeer is returned when an event references an unknown peer.
+	ErrUnknownPeer = errors.New("unknown header sync peer")
+
+	// ErrInvalidRange is returned when a range cannot be planned safely.
+	ErrInvalidRange = errors.New("invalid header range")
+
+	// ErrUnknownRange is returned when an event references an unknown range.
+	ErrUnknownRange = errors.New("unknown header range")
+
+	// ErrDuplicateRange is returned when a range ID is reused.
+	ErrDuplicateRange = errors.New("duplicate header range")
+)
+
+// RangeID identifies a checkpoint/anchor-backed header range. Range zero is
+// reserved as the no-range sentinel.
+type RangeID uint64
+
+// Hash is the header hash type used by production. Keeping real hashes in the
+// pure FSM avoids a later adapter layer that could accidentally drop boundary
+// validation detail.
+type Hash = chainhash.Hash
+
+// PeerState is the scheduling state that matters for header sync.
+type PeerState uint8
+
+const (
+	PeerReady PeerState = iota
+	PeerBusy
+	PeerBlocked
+	PeerQuarantined
+	PeerDown
+)
+
+// String returns a stable lowercase form used by JSON bridge fixtures.
+func (p PeerState) String() string {
+	switch p {
+	case PeerReady:
+		return "ready"
+	case PeerBusy:
+		return "busy"
+	case PeerBlocked:
+		return "blocked"
+	case PeerQuarantined:
+		return "quarantined"
+	case PeerDown:
+		return "down"
+	default:
+		return fmt.Sprintf("unknown(%d)", p)
+	}
+}
+
+// ParsePeerState parses the stable fixture form of a peer state.
+func ParsePeerState(state string) (PeerState, error) {
+	switch state {
+	case "ready":
+		return PeerReady, nil
+	case "busy":
+		return PeerBusy, nil
+	case "blocked":
+		return PeerBlocked, nil
+	case "quarantined":
+		return PeerQuarantined, nil
+	case "down":
+		return PeerDown, nil
+	default:
+		return PeerDown, fmt.Errorf("unknown header peer state %q", state)
+	}
+}
+
+// RangeState tracks the lifecycle of a header range. Completion and commit are
+// deliberately separate because parallel peers can return later ranges before
+// the next contiguous range is available.
+type RangeState uint8
+
+const (
+	RangeQueued RangeState = iota
+	RangeOwned
+	RangeActive
+	RangeStaged
+	RangeCommitted
+	RangeFailed
+	RangeStale
+)
+
+// String returns a stable lowercase form used by JSON bridge fixtures.
+func (r RangeState) String() string {
+	switch r {
+	case RangeQueued:
+		return "queued"
+	case RangeOwned:
+		return "owned"
+	case RangeActive:
+		return "active"
+	case RangeStaged:
+		return "staged"
+	case RangeCommitted:
+		return "committed"
+	case RangeFailed:
+		return "failed"
+	case RangeStale:
+		return "stale"
+	default:
+		return fmt.Sprintf("unknown(%d)", r)
+	}
+}
+
+// ParseRangeState parses the stable fixture form of a range state.
+func ParseRangeState(state string) (RangeState, error) {
+	switch state {
+	case "queued":
+		return RangeQueued, nil
+	case "owned":
+		return RangeOwned, nil
+	case "active":
+		return RangeActive, nil
+	case "staged":
+		return RangeStaged, nil
+	case "committed":
+		return RangeCommitted, nil
+	case "failed":
+		return RangeFailed, nil
+	case "stale":
+		return RangeStale, nil
+	default:
+		return RangeFailed, fmt.Errorf("unknown header range state %q",
+			state)
+	}
+}
+
+// Anchor is a height/hash boundary that can be used to plan getheaders ranges
+// once it is trusted or sufficiently confirmed.
+type Anchor struct {
+	Height        uint32
+	Hash          Hash
+	Trusted       bool
+	Confirmations int
+	Rejected      bool
+}
+
+// HeaderRange is a unit of parallel header sync work. The interval is
+// (StartHeight, StopHeight], meaning StartHeight is the already-known locator
+// anchor and StopHeight is the expected boundary hash for validation.
+type HeaderRange struct {
+	ID          RangeID
+	StartHeight uint32
+	StartHash   Hash
+	StopHeight  uint32
+	StopHash    Hash
+	LeaseEpoch  uint64
+	OwnerPeer   string
+	State       RangeState
+	Valid       bool
+	StagedAt    time.Time
+}
+
+// PeerSnapshot is the pure FSM view of one header peer actor.
+type PeerSnapshot struct {
+	ID          string
+	Rank        int
+	RTT         time.Duration
+	State       PeerState
+	LocalRanges []RangeID
+	ActiveRange RangeID
+}
+
+func (p PeerSnapshot) clone() PeerSnapshot {
+	p.LocalRanges = append([]RangeID(nil), p.LocalRanges...)
+	return p
+}
+
+// RangeAssignment is returned when ownership or active work is assigned.
+type RangeAssignment struct {
+	PeerID      string
+	RangeID     RangeID
+	LeaseEpoch  uint64
+	StartHeight uint32
+	StopHeight  uint32
+	StartHash   Hash
+	StopHash    Hash
+}
+
+// StealReason records why a range lease moved. It is intentionally stable and
+// log-friendly because production diagnostics need to distinguish unstarted
+// queue rebalancing from timed-out active work.
+type StealReason string
+
+const (
+	StealReasonExplicit          StealReason = "explicit"
+	StealReasonDispatch          StealReason = "dispatch"
+	StealReasonQueuedBlocked     StealReason = "queued_donor_blocked"
+	StealReasonQueuedQuarantined StealReason = "queued_donor_quarantined"
+	StealReasonQueuedOverloaded  StealReason = "queued_donor_overloaded"
+	StealReasonActiveBlocked     StealReason = "active_donor_blocked"
+	StealReasonActiveQuarantined StealReason = "active_donor_quarantined"
+)
+
+// StealResult describes a successful range lease transfer.
+type StealResult struct {
+	ThiefID       string
+	DonorID       string
+	RangeID       RangeID
+	OldLeaseEpoch uint64
+	LeaseEpoch    uint64
+	Reason        StealReason
+}
+
+// CompleteResult describes how a completion was handled.
+type CompleteResult struct {
+	RangeID    RangeID
+	Accepted   bool
+	Stale      bool
+	Valid      bool
+	RangeState RangeState
+}
+
+// CommitResult describes the contiguous ranges committed by one drain pass.
+type CommitResult struct {
+	Committed []RangeID
+	TipHeight uint32
+	TipHash   Hash
+}
+
+// Metrics exposes counters useful for deterministic tests and production
+// telemetry.
+type Metrics struct {
+	AnchorsAdded       uint64
+	AnchorsConfirmed   uint64
+	AnchorsRejected    uint64
+	RangesPlanned      uint64
+	RangesAssigned     uint64
+	RangesStarted      uint64
+	RangesStolen       uint64
+	RangesStaged       uint64
+	RangesFailed       uint64
+	RangesCommitted    uint64
+	StaleCompletions   uint64
+	FailedAssignments  uint64
+	FailedStealActions uint64
+}
+
+// CommitStats summarizes out-of-order completion pressure.
+type CommitStats struct {
+	StagedCount     int
+	CommitLag       uint32
+	OldestStagedAge time.Duration
+}
+
+// Config holds deterministic scheduler parameters.
+type Config struct {
+	AnchorConfirmationsRequired int
+	AnchorRequestFanout         int
+	MaxPeerOutstandingRanges    int
+	MaxRangeHeaders             uint32
+}
+
+// DefaultConfig returns the default header sync FSM bounds.
+func DefaultConfig() Config {
+	return Config{
+		AnchorConfirmationsRequired: DefaultAnchorConfirmationsRequired,
+		AnchorRequestFanout:         DefaultAnchorConfirmationsRequired,
+		MaxPeerOutstandingRanges:    DefaultMaxPeerOutstandingRanges,
+		MaxRangeHeaders:             DefaultMaxRangeHeaders,
+	}
+}
+
+// ProductionConfig returns the header sync policy used by blockmanager. The
+// ordered commit path still validates proof-of-work, checkpoint boundaries, and
+// chain connectivity, so production can stage the first valid segment while
+// hedging requests across multiple peers to avoid one laggard setting the RTT
+// for every 2k-header turn.
+func ProductionConfig() Config {
+	cfg := DefaultConfig()
+	cfg.AnchorConfirmationsRequired = 1
+	cfg.AnchorRequestFanout = 4
+
+	return cfg
+}
+
+func (c Config) normalize() Config {
+	defaults := DefaultConfig()
+	if c.AnchorConfirmationsRequired <= 0 {
+		c.AnchorConfirmationsRequired =
+			defaults.AnchorConfirmationsRequired
+	}
+	if c.AnchorRequestFanout <= 0 {
+		c.AnchorRequestFanout = c.AnchorConfirmationsRequired
+	}
+	if c.AnchorRequestFanout < c.AnchorConfirmationsRequired {
+		c.AnchorRequestFanout = c.AnchorConfirmationsRequired
+	}
+	if c.MaxPeerOutstandingRanges <= 0 {
+		c.MaxPeerOutstandingRanges = defaults.MaxPeerOutstandingRanges
+	}
+	if c.MaxRangeHeaders == 0 {
+		c.MaxRangeHeaders = defaults.MaxRangeHeaders
+	}
+
+	return c
+}

--- a/headersync/validation.go
+++ b/headersync/validation.go
@@ -1,0 +1,132 @@
+package headersync
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+var (
+	// ErrNoHeaders is returned when a peer response contains no headers for
+	// a range that is expected to make progress.
+	ErrNoHeaders = errors.New("no headers in range response")
+
+	// ErrRangeStartMismatch is returned when the first returned header does
+	// not connect to the range start anchor.
+	ErrRangeStartMismatch = errors.New("header range start mismatch")
+
+	// ErrRangeDisconnected is returned when the response contains an
+	// internal gap.
+	ErrRangeDisconnected = errors.New("header range disconnected")
+
+	// ErrRangeStopMismatch is returned when the last returned header does
+	// not match the range stop anchor.
+	ErrRangeStopMismatch = errors.New("header range stop mismatch")
+
+	// ErrTooManyHeaders is returned when a peer sends more headers than the
+	// request can safely account for.
+	ErrTooManyHeaders = errors.New("too many headers in response")
+
+	// ErrRangeOvershoot is returned when a response would advance past the
+	// requested stop height.
+	ErrRangeOvershoot = errors.New("header range overshoot")
+)
+
+// AnchorResponse is the structurally validated result of one anchor discovery
+// response. A response only becomes trusted if it lands exactly on the requested
+// stop hash; otherwise it is an untrusted discovered intermediate anchor that
+// needs independent confirmation.
+type AnchorResponse struct {
+	Height      uint32
+	Hash        Hash
+	Trusted     bool
+	HeaderCount int
+}
+
+// ValidateHeaderRange checks the structural properties needed before a range
+// can be staged as complete. Contextual proof-of-work and median-time checks
+// remain the block manager's responsibility.
+func ValidateHeaderRange(rng HeaderRange, headers []*wire.BlockHeader) error {
+	if len(headers) == 0 {
+		return ErrNoHeaders
+	}
+
+	if headers[0].PrevBlock != rng.StartHash {
+		return fmt.Errorf("%w: range=%d start_height=%d",
+			ErrRangeStartMismatch, rng.ID, rng.StartHeight)
+	}
+
+	for i := 1; i < len(headers); i++ {
+		prevHash := headers[i-1].BlockHash()
+		if headers[i].PrevBlock != prevHash {
+			return fmt.Errorf("%w: range=%d index=%d",
+				ErrRangeDisconnected, rng.ID, i)
+		}
+	}
+
+	finalHash := headers[len(headers)-1].BlockHash()
+	if finalHash != rng.StopHash {
+		return fmt.Errorf("%w: range=%d stop_height=%d",
+			ErrRangeStopMismatch, rng.ID, rng.StopHeight)
+	}
+
+	return nil
+}
+
+// ValidateAnchorResponse checks the structural properties of an anchor
+// discovery response. It verifies that the response starts at the requested
+// locator hash, is internally connected, stays within the requested span, and
+// only treats the stop boundary as trusted when the final header hash matches
+// the requested stop hash.
+func ValidateAnchorResponse(request AnchorRequest,
+	headers []*wire.BlockHeader, maxHeaders uint32) (AnchorResponse, error) {
+
+	if len(headers) == 0 {
+		return AnchorResponse{}, ErrNoHeaders
+	}
+	if maxHeaders > 0 && uint32(len(headers)) > maxHeaders {
+		return AnchorResponse{}, fmt.Errorf("%w: got=%d max=%d",
+			ErrTooManyHeaders, len(headers), maxHeaders)
+	}
+
+	if headers[0].PrevBlock != request.StartHash {
+		return AnchorResponse{}, fmt.Errorf("%w: start_height=%d",
+			ErrRangeStartMismatch, request.StartHeight)
+	}
+
+	for i := 1; i < len(headers); i++ {
+		prevHash := headers[i-1].BlockHash()
+		if headers[i].PrevBlock != prevHash {
+			return AnchorResponse{}, fmt.Errorf("%w: index=%d",
+				ErrRangeDisconnected, i)
+		}
+	}
+
+	finalHeight := request.StartHeight + uint32(len(headers))
+	if finalHeight > request.StopHeight {
+		return AnchorResponse{}, fmt.Errorf("%w: final=%d stop=%d",
+			ErrRangeOvershoot, finalHeight, request.StopHeight)
+	}
+
+	finalHash := headers[len(headers)-1].BlockHash()
+	trustedStop := request.StopHash != (Hash{})
+	trusted := false
+	if finalHeight == request.StopHeight && trustedStop {
+		if finalHash != request.StopHash {
+			return AnchorResponse{}, fmt.Errorf(
+				"%w: stop_height=%d", ErrRangeStopMismatch,
+				request.StopHeight,
+			)
+		}
+
+		trusted = true
+	}
+
+	return AnchorResponse{
+		Height:      finalHeight,
+		Hash:        finalHash,
+		Trusted:     trusted,
+		HeaderCount: len(headers),
+	}, nil
+}

--- a/headersync/validation_test.go
+++ b/headersync/validation_test.go
@@ -1,0 +1,157 @@
+package headersync
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateHeaderRange(t *testing.T) {
+	start := testHash(100)
+	headers := makeTestHeaders(start, 3)
+	stop := headers[len(headers)-1].BlockHash()
+	rng := HeaderRange{
+		ID:          1,
+		StartHeight: 0,
+		StartHash:   start,
+		StopHeight:  3,
+		StopHash:    stop,
+	}
+
+	require.NoError(t, ValidateHeaderRange(rng, headers))
+}
+
+func TestValidateHeaderRangeRejectsStartMismatch(t *testing.T) {
+	headers := makeTestHeaders(testHash(101), 1)
+	rng := HeaderRange{
+		ID:        1,
+		StartHash: testHash(100),
+		StopHash:  headers[0].BlockHash(),
+	}
+
+	err := ValidateHeaderRange(rng, headers)
+	require.True(t, errors.Is(err, ErrRangeStartMismatch))
+}
+
+func TestValidateHeaderRangeRejectsDisconnectedHeaders(t *testing.T) {
+	start := testHash(100)
+	headers := makeTestHeaders(start, 2)
+	headers[1].PrevBlock = testHash(200)
+	rng := HeaderRange{
+		ID:        1,
+		StartHash: start,
+		StopHash:  headers[1].BlockHash(),
+	}
+
+	err := ValidateHeaderRange(rng, headers)
+	require.True(t, errors.Is(err, ErrRangeDisconnected))
+}
+
+func TestValidateHeaderRangeRejectsStopMismatch(t *testing.T) {
+	start := testHash(100)
+	headers := makeTestHeaders(start, 1)
+	rng := HeaderRange{
+		ID:        1,
+		StartHash: start,
+		StopHash:  testHash(201),
+	}
+
+	err := ValidateHeaderRange(rng, headers)
+	require.True(t, errors.Is(err, ErrRangeStopMismatch))
+}
+
+func TestValidateAnchorResponse(t *testing.T) {
+	start := testHash(100)
+	headers := makeTestHeaders(start, 2)
+	request := AnchorRequest{
+		StartHeight: 10,
+		StartHash:   start,
+		StopHeight:  20,
+		StopHash:    testHash(200),
+	}
+
+	response, err := ValidateAnchorResponse(request, headers, 2000)
+	require.NoError(t, err)
+	require.Equal(t, uint32(12), response.Height)
+	require.Equal(t, headers[1].BlockHash(), response.Hash)
+	require.False(t, response.Trusted)
+	require.Equal(t, 2, response.HeaderCount)
+}
+
+func TestValidateAnchorResponseTrustsStopHash(t *testing.T) {
+	start := testHash(100)
+	headers := makeTestHeaders(start, 2)
+	request := AnchorRequest{
+		StartHeight: 10,
+		StartHash:   start,
+		StopHeight:  12,
+		StopHash:    headers[1].BlockHash(),
+	}
+
+	response, err := ValidateAnchorResponse(request, headers, 2000)
+	require.NoError(t, err)
+	require.True(t, response.Trusted)
+}
+
+func TestValidateAnchorResponseWithZeroStopHash(t *testing.T) {
+	start := testHash(100)
+	headers := makeTestHeaders(start, 2)
+	request := AnchorRequest{
+		StartHeight: 10,
+		StartHash:   start,
+		StopHeight:  12,
+	}
+
+	response, err := ValidateAnchorResponse(request, headers, 2000)
+	require.NoError(t, err)
+	require.EqualValues(t, 12, response.Height)
+	require.Equal(t, headers[1].BlockHash(), response.Hash)
+	require.False(t, response.Trusted)
+}
+
+func TestValidateAnchorResponseRejectsOvershoot(t *testing.T) {
+	start := testHash(100)
+	headers := makeTestHeaders(start, 3)
+	request := AnchorRequest{
+		StartHeight: 10,
+		StartHash:   start,
+		StopHeight:  12,
+		StopHash:    headers[1].BlockHash(),
+	}
+
+	_, err := ValidateAnchorResponse(request, headers, 2000)
+	require.True(t, errors.Is(err, ErrRangeOvershoot))
+}
+
+func TestValidateAnchorResponseRejectsTooManyHeaders(t *testing.T) {
+	start := testHash(100)
+	headers := makeTestHeaders(start, 2)
+	request := AnchorRequest{
+		StartHeight: 10,
+		StartHash:   start,
+		StopHeight:  12,
+		StopHash:    headers[1].BlockHash(),
+	}
+
+	_, err := ValidateAnchorResponse(request, headers, 1)
+	require.True(t, errors.Is(err, ErrTooManyHeaders))
+}
+
+func makeTestHeaders(start Hash, count int) []*wire.BlockHeader {
+	headers := make([]*wire.BlockHeader, 0, count)
+	prev := start
+	for i := 0; i < count; i++ {
+		header := &wire.BlockHeader{
+			Version:   int32(i + 1),
+			PrevBlock: prev,
+			Bits:      uint32(i + 1),
+			Nonce:     uint32(i + 1),
+		}
+		headers = append(headers, header)
+		prev = header.BlockHash()
+	}
+
+	return headers
+}

--- a/p-models/neutrinoheadersync/bridge/scenarios.json
+++ b/p-models/neutrinoheadersync/bridge/scenarios.json
@@ -122,47 +122,6 @@
       }
     },
     {
-      "name": "external_tip_advance_plans_gap_before_staged_frontier",
-      "committed_tip": 0,
-      "committed_hash": 100,
-      "anchors": [
-        {"height": 0, "hash": 100, "trusted": true},
-        {"height": 20, "hash": 120, "trusted": true},
-        {"height": 30, "hash": 130, "trusted": true}
-      ],
-      "peers": [
-        {"id": "peer", "state": "ready"}
-      ],
-      "steps": [
-        {"op": "plan", "range_id": 1, "start_height": 20, "stop_height": 30},
-        {"op": "assign"},
-        {"op": "start", "peer_id": "peer"},
-        {"op": "complete", "peer_id": "peer", "range_id": 1, "lease_epoch": 1, "valid": true, "at_unix": 100},
-        {"op": "commit"},
-        {"op": "advance_tip", "height": 10, "hash": 110},
-        {"op": "plan", "range_id": 2, "start_height": 10, "stop_height": 20},
-        {"op": "assign"},
-        {"op": "start", "peer_id": "peer"},
-        {"op": "complete", "peer_id": "peer", "range_id": 2, "lease_epoch": 1, "valid": true, "at_unix": 101},
-        {"op": "commit"}
-      ],
-      "expect": {
-        "committed_tip": 30,
-        "committed_hash": 130,
-        "commit_log": [2, 1],
-        "ranges": [
-          {"id": 2, "state": "committed", "owner_peer": "peer", "lease_epoch": 1, "valid": true},
-          {"id": 1, "state": "committed", "owner_peer": "peer", "lease_epoch": 1, "valid": true}
-        ],
-        "peers": [
-          {"id": "peer", "state": "ready"}
-        ],
-        "metrics": {
-          "ranges_committed": 2
-        }
-      }
-    },
-    {
       "name": "commit_prunes_obsolete_anchor_requests",
       "committed_tip": 0,
       "committed_hash": 100,

--- a/p-models/neutrinoheadersync/src/header_sync.p
+++ b/p-models/neutrinoheadersync/src/header_sync.p
@@ -10,9 +10,7 @@
 //   * stealing increments the epoch so old responses become stale;
 //   * peers may complete ranges out of order;
 //   * completed ranges are staged before commit;
-//   * commits advance only through the next contiguous staged range;
-//   * if a legacy/fallback writer already persisted headers, the model can
-//     reconcile the visible tip before planning more frontier work.
+//   * commits advance only through the next contiguous staged range.
 
 enum HeaderPeerState {
     HeaderPeerReady,
@@ -139,68 +137,6 @@ fun NewModel(committed_tip: int, committed_hash: int): HeaderSyncModel {
         peers = default(seq[HeaderPeer]),
         commit_log = default(seq[int])
     );
-}
-
-// AdvanceCommittedTip models the production reconciliation path between the
-// pure scheduler and the durable block-header store. Most progress should come
-// from CommitReadyRanges, but during migration the block manager can still
-// persist a short serial fallback span. Once storage says the tip is already
-// ahead, the scheduler must not keep planning from its stale in-memory tip or
-// it can skip the newly persisted boundary and strand staged frontier ranges.
-fun AdvanceCommittedTip(model: HeaderSyncModel, height: int,
-    hash: int): HeaderSyncModel {
-
-    var i: int;
-    var range: HeaderRange;
-
-    if (height < model.committed_tip) {
-        return model;
-    }
-
-    model.anchors = AddOrConfirmAnchor(model.anchors, height, hash, true);
-    if (height == model.committed_tip) {
-        model.committed_hash = hash;
-        return model;
-    }
-
-    model.committed_tip = height;
-    model.committed_hash = hash;
-
-    i = 0;
-    while (i < sizeof(model.ranges)) {
-        range = model.ranges[i];
-        if (range.stop_height <= height) {
-            range = (
-                id = range.id,
-                start_height = range.start_height,
-                start_hash = range.start_hash,
-                stop_height = range.stop_height,
-                stop_hash = range.stop_hash,
-                lease_epoch = range.lease_epoch,
-                owner_peer = NoPeer(),
-                range_state = RangeCommitted,
-                valid = true
-            );
-            model.ranges = ReplaceRange(model.ranges, range);
-        } else if (range.start_height < height) {
-            range = (
-                id = range.id,
-                start_height = range.start_height,
-                start_hash = range.start_hash,
-                stop_height = range.stop_height,
-                stop_hash = range.stop_hash,
-                lease_epoch = range.lease_epoch,
-                owner_peer = NoPeer(),
-                range_state = RangeStale,
-                valid = false
-            );
-            model.ranges = ReplaceRange(model.ranges, range);
-        }
-
-        i = i + 1;
-    }
-
-    return model;
 }
 
 // AddOrConfirmAnchor is the anchor-discovery rule. Trusted checkpoints are

--- a/p-models/neutrinoheadersync/test/header_sync_test.p
+++ b/p-models/neutrinoheadersync/test/header_sync_test.p
@@ -325,59 +325,6 @@ machine TestOutOfOrderCompletionStagesUntilGapFilled {
     state Done {}
 }
 
-machine TestExternalTipAdvancePlansGapBeforeStagedFrontier {
-    start state Init {
-        entry {
-            var model: HeaderSyncModel;
-            var gap: HeaderRange;
-            var staged: HeaderRange;
-            var ready: seq[int];
-
-            model = NewModel(0, 100);
-            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
-            model.anchors = AddOrConfirmAnchor(model.anchors, 20, 120, true);
-            model.anchors = AddOrConfirmAnchor(model.anchors, 30, 130, true);
-
-            // This is the failure mode seen in the live sqlite testnet3 run:
-            // later frontier discovery responses were already staged, but a
-            // short serial/fallback write had advanced the durable tip to a
-            // boundary the FSM had not yet made visible. Reconciliation must
-            // add that boundary before the manager keeps discovering farther
-            // ahead, otherwise the staged range after the gap can never commit.
-            model = StageDiscoveredRange(model, 1, 9, 20, 30);
-            model = AdvanceCommittedTip(model, 10, 110);
-            assert model.committed_tip == 10,
-                "external durable tip should become manager-visible";
-
-            model = PlanRange(model, 2, 10, 20);
-            gap = RangeByID(model.ranges, 2);
-            assert gap.range_state == RangeQueued,
-                "known missing frontier span should become fetchable work";
-
-            ready = ReadyRanges(model);
-            assert sizeof(ready) == 0,
-                "later staged frontier range must wait for the planned gap";
-
-            model = AddPeer(model, NewPeer(1, 0, 10, HeaderPeerReady));
-            model = AssignNextQueuedRange(model);
-            model = StartPeerRange(model, 1);
-            gap = RangeByID(model.ranges, 2);
-            model = CompleteRange(model, 1, 2, gap.lease_epoch, true);
-            model = CommitReadyRanges(model);
-
-            staged = RangeByID(model.ranges, 1);
-            assert staged.range_state == RangeCommitted,
-                "committing the gap should drain the already staged range";
-            assert model.committed_tip == 30,
-                "visible tip should advance through all contiguous work";
-
-            goto Done;
-        }
-    }
-
-    state Done {}
-}
-
 machine TestReadyRangesDoesNotAdvanceCommittedTip {
     start state Init {
         entry {


### PR DESCRIPTION
Stacked on #370.

This PR adds the standalone `headersync` package that will back production parallel block-header sync in the next integration slice. The package keeps header-range ownership explicit through manager and peer actor state, leases active work so slow or failed peers can lose ownership, stages out-of-order completions, and only commits the next contiguous frontier.

The new package includes:

- manager and peer actor/FSM state for header range dispatch;
- checkpoint/anchor-backed range planning;
- range validation and ordered commit helpers;
- lease-aware stealing and stale completion rejection;
- a small `headersync/querydispatch` adapter that can share querysync peer/work ownership signals where that abstraction fits;
- deterministic bridge fixtures that exercise the same model stories against the Go FSM.

The P header-sync model is also kept aligned with this package boundary. The old external-tip reconciliation fixture belonged to the temporary mixed fallback path where blockmanager could advance durable headers behind the scheduler's back. This slice models the dedicated scheduler package that blockmanager will call directly in the following PR.

Validation performed:

```sh
go test ./headersync ./headersync/querydispatch -count=1
SCHEDULES=10 ./p-models/scripts/check.sh
go test ./... -count=1
```

All passed locally.
