### PR TITLE
headersync: reconcile durable header tip

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2625,54 +2625,80 @@ func (b *blockManager) armHeaderSyncAnchorTimeout(peer *ServerPeer,
 }
 
 func (b *blockManager) planHeaderSyncRanges(bestHeight uint32) (int, error) {
-	if b.headerSync.Controller() == nil || b.nextCheckpoint == nil {
+	if b.headerSync.Controller() == nil {
 		return 0, nil
 	}
 
-	_, height, err := b.cfg.BlockHeaders.ChainTip()
+	header, height, err := b.cfg.BlockHeaders.ChainTip()
 	if err != nil {
 		return 0, err
 	}
-
-	stopHeight := uint32(b.nextCheckpoint.Height)
-	if height >= stopHeight || bestHeight < stopHeight {
-		return 0, nil
+	tip := headersync.ChainPoint{
+		Height: height,
+		Hash:   header.BlockHash(),
 	}
 
+	var (
+		ranges []headersync.HeaderRange
+		span   uint32
+		max    uint32
+		wait   bool
+	)
 	ctx, cancel := b.headerSyncOpCtx()
 	defer cancel()
 
-	plan, err := b.headerSync.Controller().PlanCheckpointRanges(
-		ctx,
-		headersync.ChainPoint{
-			Height: height,
-			Hash:   b.headerTipHash,
-		},
-		headersync.ChainPoint{
-			Height: stopHeight,
-			Hash:   *b.nextCheckpoint.Hash,
-		},
-		bestHeight,
-	)
-	if err != nil {
-		return 0, err
+	if b.nextCheckpoint == nil {
+		if height >= bestHeight {
+			return 0, nil
+		}
+
+		plan, err := b.headerSync.Controller().PlanFrontierRanges(
+			ctx, tip, bestHeight,
+		)
+		if err != nil {
+			return 0, err
+		}
+		ranges = plan.Ranges
+	} else {
+		stopHeight := uint32(b.nextCheckpoint.Height)
+		if height >= stopHeight || bestHeight < stopHeight {
+			return 0, nil
+		}
+
+		plan, err := b.headerSync.Controller().PlanCheckpointRanges(
+			ctx, tip,
+			headersync.ChainPoint{
+				Height: stopHeight,
+				Hash:   *b.nextCheckpoint.Hash,
+			},
+			bestHeight,
+		)
+		if err != nil {
+			return 0, err
+		}
+
+		ranges = plan.Ranges
+		span = plan.Span
+		max = plan.MaxRangeHeaders
+		wait = plan.WaitingForAnchors
 	}
-	if len(plan.Ranges) == 0 {
-		if plan.WaitingForAnchors {
+
+	if len(ranges) == 0 {
+		if wait {
 			log.Debugf("headersync waiting for confirmed anchors "+
 				"height=%d checkpoint=%d span=%d max_headers=%d",
-				height, stopHeight, plan.Span, plan.MaxRangeHeaders)
+				height, b.nextCheckpoint.Height, span, max)
 		}
 		return 0, nil
 	}
 
-	for _, rng := range plan.Ranges {
+	for _, rng := range ranges {
 		log.Infof("headersync range_planned range_id=%d start_height=%d "+
 			"stop_height=%d stop_hash=%s", rng.ID, rng.StartHeight,
 			rng.StopHeight, rng.StopHash)
 	}
 
-	return len(plan.Ranges), nil
+	return len(ranges), nil
 }
 
 func (b *blockManager) dispatchHeaderSyncWork(peers *list.List) bool {
@@ -2806,7 +2832,7 @@ func (b *blockManager) startHeaderFrontierDiscovery(peers *list.List,
 	}
 	b.recoverHeaderSyncPeers(peers)
 
-	_, height, err := b.cfg.BlockHeaders.ChainTip()
+	header, height, err := b.cfg.BlockHeaders.ChainTip()
 	if err != nil {
 		log.Warnf("headersync unable to get chain tip for frontier "+
 			"discovery: %v", err)
@@ -2820,7 +2846,7 @@ func (b *blockManager) startHeaderFrontierDiscovery(peers *list.List,
 		ctx,
 		headersync.ChainPoint{
 			Height: height,
-			Hash:   b.headerTipHash,
+			Hash:   header.BlockHash(),
 		},
 		bestHeight,
 	)
@@ -3885,6 +3911,7 @@ func (b *blockManager) commitReadyHeaderSyncRanges(ctx context.Context) error {
 		return nil
 	}
 
+	commitRanges := make([]headerSyncRangeCommit, 0, len(ready))
 	for _, rangeID := range ready {
 		staged, ok := b.headerSync.Session().StagedRange(rangeID)
 		if !ok {
@@ -3901,14 +3928,25 @@ func (b *blockManager) commitReadyHeaderSyncRanges(ctx context.Context) error {
 				rangeID)
 		}
 
-		if err := b.commitHeaderSyncRangeHeaders(
-			rng, staged.Headers, staged.PeerID,
-		); err != nil {
-			return err
-		}
+		commitRanges = append(commitRanges, headerSyncRangeCommit{
+			Range:  rng,
+			Staged: staged,
+		})
 	}
 
-	commitResult, err := b.headerSync.Controller().CommitReadyRanges(ctx)
+	if _, err := b.commitHeaderSyncRangeHeaders(commitRanges); err != nil {
+		return err
+	}
+
+	// Persistence and header validation can legitimately consume the short
+	// actor-operation deadline under heavy sqlite write pressure. Once the
+	// headers are durably written and the visible tip has advanced, use a
+	// fresh actor context so the FSM cannot lag behind the block manager
+	// just because the pre-write context expired.
+	commitCtx, commitCancel := b.headerSyncOpCtx()
+	defer commitCancel()
+
+	commitResult, err := b.headerSync.Controller().CommitReadyRanges(commitCtx)
 	if err != nil {
 		return err
 	}
@@ -3927,57 +3965,215 @@ func (b *blockManager) commitReadyHeaderSyncRanges(ctx context.Context) error {
 	return nil
 }
 
-func (b *blockManager) commitHeaderSyncRangeHeaders(rng headersync.HeaderRange,
-	headers []*wire.BlockHeader, peerID string) error {
+type headerSyncRangeCommit struct {
+	Range  headersync.HeaderRange
+	Staged headersync.StagedRange
+}
 
-	if len(headers) == 0 {
-		return headersync.ErrNoHeaders
+type headerSyncVerifiedCheckpoint struct {
+	Height  int32
+	Hash    chainhash.Hash
+	PeerID  string
+	RangeID headersync.RangeID
+}
+
+type headerSyncPreparedCommit struct {
+	Headers             []headerfs.BlockHeader
+	Nodes               []headerlist.Node
+	VerifiedCheckpoints []headerSyncVerifiedCheckpoint
+	FinalHeight         int32
+	FinalHash           chainhash.Hash
+	NextCheckpoint      *chaincfg.Checkpoint
+}
+
+// headerSyncValidationChain overlays headers prepared in the current commit
+// batch on top of the long-lived header cache. Contextual validation can then
+// see freshly prepared parents without losing access to older cached ancestors.
+type headerSyncValidationChain struct {
+	base    headerlist.Chain
+	pending *headerlist.BoundedMemoryChain
+}
+
+func newHeaderSyncValidationChain(base headerlist.Chain,
+	seed headerlist.Node) *headerSyncValidationChain {
+
+	pending := headerlist.NewBoundedMemoryChain(numMaxMemHeaders)
+	pending.ResetHeaderState(seed)
+
+	return &headerSyncValidationChain{
+		base:    base,
+		pending: pending,
+	}
+}
+
+func (h *headerSyncValidationChain) ResetHeaderState(n headerlist.Node) {
+	h.pending.ResetHeaderState(n)
+}
+
+func (h *headerSyncValidationChain) Back() *headerlist.Node {
+	if back := h.pending.Back(); back != nil {
+		return back
 	}
 
-	headerWriteBatch := make([]headerfs.BlockHeader, 0, len(headers))
-	var (
-		finalHash   *chainhash.Hash
-		finalHeight int32
+	return h.base.Back()
+}
+
+func (h *headerSyncValidationChain) Front() *headerlist.Node {
+	return h.base.Front()
+}
+
+func (h *headerSyncValidationChain) PushBack(
+	n headerlist.Node) *headerlist.Node {
+
+	return h.pending.PushBack(n)
+}
+
+func (h *headerSyncValidationChain) AtHeight(
+	height int32) (*headerlist.Node, bool) {
+
+	if node, ok := h.pending.AtHeight(height); ok {
+		return node, true
+	}
+
+	return h.base.AtHeight(height)
+}
+
+func (b *blockManager) commitHeaderSyncRangeHeaders(
+	ranges []headerSyncRangeCommit) (headerSyncPreparedCommit, error) {
+
+	var prepared headerSyncPreparedCommit
+	if len(ranges) == 0 {
+		return prepared, nil
+	}
+
+	totalHeaders := 0
+	for _, commitRange := range ranges {
+		totalHeaders += len(commitRange.Staged.Headers)
+	}
+	if totalHeaders == 0 {
+		return prepared, headersync.ErrNoHeaders
+	}
+
+	prepared.Headers = make([]headerfs.BlockHeader, 0, totalHeaders)
+	prepared.Nodes = make([]headerlist.Node, 0, totalHeaders)
+	prepared.NextCheckpoint = b.nextCheckpoint
+
+	prevNodeEl := b.headerList.Back()
+	if prevNodeEl == nil {
+		return prepared, fmt.Errorf("header list missing previous element")
+	}
+
+	prevHash := prevNodeEl.Header.BlockHash()
+	prevHeight := prevNodeEl.Height
+	prevHeader := prevNodeEl.Header
+
+	validationList := newHeaderSyncValidationChain(
+		b.headerList, *prevNodeEl,
 	)
 
-	for _, blockHeader := range headers {
-		blockHash := blockHeader.BlockHash()
-		finalHash = &blockHash
+	for _, commitRange := range ranges {
+		rng := commitRange.Range
+		headers := commitRange.Staged.Headers
+		peerID := commitRange.Staged.PeerID
 
-		prevNodeEl := b.headerList.Back()
-		if prevNodeEl == nil {
-			return fmt.Errorf("header list missing previous element")
+		if len(headers) == 0 {
+			return prepared, headersync.ErrNoHeaders
 		}
 
-		prevHash := prevNodeEl.Header.BlockHash()
-		if !prevHash.IsEqual(&blockHeader.PrevBlock) {
-			return fmt.Errorf("headersync staged range_id=%d does not "+
-				"connect to current tip hash=%s prev=%s",
-				rng.ID, prevHash, blockHeader.PrevBlock)
+		var rangeFinalHeight int32
+		for _, blockHeader := range headers {
+			blockHash := blockHeader.BlockHash()
+			if !prevHash.IsEqual(&blockHeader.PrevBlock) {
+				return prepared, fmt.Errorf("headersync staged "+
+					"range_id=%d does not connect to current "+
+					"tip hash=%s prev=%s", rng.ID, prevHash,
+					blockHeader.PrevBlock)
+			}
+
+			if err := b.checkHeaderSanity(
+				blockHeader, false, prevHeight, &prevHeader,
+				validationList,
+			); err != nil {
+				return prepared, fmt.Errorf("headersync "+
+					"range_id=%d header sanity failed: %w",
+					rng.ID, err)
+			}
+
+			node := headerlist.Node{
+				Header: *blockHeader,
+				Height: prevHeight + 1,
+			}
+			rangeFinalHeight = node.Height
+
+			prepared.Headers = append(prepared.Headers,
+				headerfs.BlockHeader{
+					BlockHeader: blockHeader,
+					Height:      uint32(node.Height),
+				},
+			)
+			prepared.Nodes = append(prepared.Nodes, node)
+			validationList.PushBack(node)
+
+			if prepared.NextCheckpoint != nil &&
+				node.Height == prepared.NextCheckpoint.Height {
+
+				if !blockHash.IsEqual(prepared.NextCheckpoint.Hash) {
+					return prepared, fmt.Errorf("headersync "+
+						"checkpoint mismatch height=%d "+
+						"got=%s want=%s peer=%s",
+						node.Height, blockHash,
+						prepared.NextCheckpoint.Hash,
+						peerID)
+				}
+
+				prepared.VerifiedCheckpoints = append(
+					prepared.VerifiedCheckpoints,
+					headerSyncVerifiedCheckpoint{
+						Height:  node.Height,
+						Hash:    blockHash,
+						PeerID:  peerID,
+						RangeID: rng.ID,
+					},
+				)
+				prepared.NextCheckpoint = b.findNextHeaderCheckpoint(
+					node.Height,
+				)
+			}
+
+			prepared.FinalHash = blockHash
+			prepared.FinalHeight = node.Height
+			prevHash = blockHash
+			prevHeight = node.Height
+			prevHeader = node.Header
 		}
 
-		prevNodeHeight := prevNodeEl.Height
-		prevNodeHeader := prevNodeEl.Header
-		if err := b.checkHeaderSanity(
-			blockHeader, false, prevNodeHeight, &prevNodeHeader,
-		); err != nil {
-			return fmt.Errorf("headersync range_id=%d header sanity "+
-				"failed: %w", rng.ID, err)
+		if rangeFinalHeight != int32(rng.StopHeight) {
+			return prepared, fmt.Errorf("headersync range_id=%d "+
+				"final_height=%d stop_height=%d", rng.ID,
+				rangeFinalHeight, rng.StopHeight)
 		}
+	}
 
-		node := headerlist.Node{
-			Header: *blockHeader,
-			Height: prevNodeEl.Height + 1,
-		}
-		finalHeight = node.Height
+	log.Tracef("headersync writing range_batch=%d header_count=%d",
+		len(ranges), len(prepared.Headers))
+	writeStart := time.Now()
+	if err := b.cfg.BlockHeaders.WriteHeaders(prepared.Headers...); err != nil {
+		return prepared, fmt.Errorf("unable to write headersync "+
+			"range_batch=%d: %w", len(ranges), err)
+	}
+	writeElapsed := time.Since(writeStart)
 
-		headerWriteBatch = append(headerWriteBatch, headerfs.BlockHeader{
-			BlockHeader: blockHeader,
-			Height:      uint32(node.Height),
-		})
+	verifiedByHeight := make(
+		map[int32]headerSyncVerifiedCheckpoint,
+		len(prepared.VerifiedCheckpoints),
+	)
+	for _, checkpoint := range prepared.VerifiedCheckpoints {
+		verifiedByHeight[checkpoint.Height] = checkpoint
+	}
 
+	for _, node := range prepared.Nodes {
 		b.blkHeaderProgressLogger.LogBlockHeight(
-			blockHeader.Timestamp, node.Height,
+			node.Header.Timestamp, node.Height,
 		)
 
 		e := b.headerList.PushBack(node)
@@ -3985,43 +4181,28 @@ func (b *blockManager) commitHeaderSyncRangeHeaders(rng headersync.HeaderRange,
 			b.startHeader = e
 		}
 
-		if b.nextCheckpoint != nil &&
-			node.Height == b.nextCheckpoint.Height {
-
-			nodeHash := node.Header.BlockHash()
-			if !nodeHash.IsEqual(b.nextCheckpoint.Hash) {
-				return fmt.Errorf("headersync checkpoint mismatch "+
-					"height=%d got=%s want=%s peer=%s",
-					node.Height, nodeHash,
-					b.nextCheckpoint.Hash, peerID)
-			}
-
+		if checkpoint, ok := verifiedByHeight[node.Height]; ok {
 			log.Infof("headersync verified checkpoint height=%d "+
-				"hash=%s peer=%s range_id=%d", node.Height,
-				nodeHash, peerID, rng.ID)
-			b.nextCheckpoint = b.findNextHeaderCheckpoint(node.Height)
+				"hash=%s peer=%s range_id=%d", checkpoint.Height,
+				checkpoint.Hash, checkpoint.PeerID,
+				checkpoint.RangeID)
 		}
 	}
 
-	if finalHeight != int32(rng.StopHeight) {
-		return fmt.Errorf("headersync range_id=%d final_height=%d "+
-			"stop_height=%d", rng.ID, finalHeight, rng.StopHeight)
-	}
-
-	log.Tracef("headersync writing range_id=%d header_count=%d",
-		rng.ID, len(headerWriteBatch))
-	if err := b.cfg.BlockHeaders.WriteHeaders(headerWriteBatch...); err != nil {
-		return fmt.Errorf("unable to write headersync range_id=%d: %w",
-			rng.ID, err)
-	}
+	b.nextCheckpoint = prepared.NextCheckpoint
 
 	b.newHeadersMtx.Lock()
-	b.headerTip = uint32(finalHeight)
-	b.headerTipHash = *finalHash
+	b.headerTip = uint32(prepared.FinalHeight)
+	b.headerTipHash = prepared.FinalHash
 	b.newHeadersMtx.Unlock()
 	b.newHeadersSignal.Broadcast()
 
-	return nil
+	log.Debugf("headersync range_commit_batch ranges=%d headers=%d "+
+		"tip_height=%d tip_hash=%s write_elapsed=%v", len(ranges),
+		len(prepared.Headers), prepared.FinalHeight, prepared.FinalHash,
+		writeElapsed)
+
+	return prepared, nil
 }
 
 // handleHeadersMsg handles headers messages from all peers.
@@ -4093,7 +4274,7 @@ func (b *blockManager) handleHeadersMsgWithPeers(peers *list.List,
 			prevNodeHeader := prevNode.Header
 			err := b.checkHeaderSanity(
 				blockHeader, false, prevNodeHeight,
-				&prevNodeHeader,
+				&prevNodeHeader, nil,
 			)
 			if err != nil {
 				log.Warnf("Header doesn't pass sanity check: "+
@@ -4223,7 +4404,7 @@ func (b *blockManager) handleHeadersMsgWithPeers(peers *list.List,
 
 				err = b.checkHeaderSanity(
 					reorgHeader, true,
-					int32(prevNodeHeight), prevNodeHeader,
+					int32(prevNodeHeight), prevNodeHeader, nil,
 				)
 				if err != nil {
 					log.Warnf("Header doesn't pass sanity"+
@@ -4445,12 +4626,15 @@ func areHeadersConnected(headers []*wire.BlockHeader) bool {
 // checks.
 func (b *blockManager) checkHeaderSanity(blockHeader *wire.BlockHeader,
 	reorgAttempt bool, prevNodeHeight int32,
-	prevNodeHeader *wire.BlockHeader) error {
+	prevNodeHeader *wire.BlockHeader, headerChain headerlist.Chain) error {
 
 	// Create the lightHeaderCtx for the blockHeader's parent.
 	hList := b.headerList
 	if reorgAttempt {
 		hList = b.reorgList
+	}
+	if headerChain != nil {
+		hList = headerChain
 	}
 
 	parentHeaderCtx := newLightHeaderCtx(

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightninglabs/neutrino/banman"
 	"github.com/lightninglabs/neutrino/blockntfns"
 	"github.com/lightninglabs/neutrino/headerfs"
+	"github.com/lightninglabs/neutrino/headerlist"
 	"github.com/lightninglabs/neutrino/query"
 	"github.com/stretchr/testify/require"
 )
@@ -73,6 +74,41 @@ func TestShouldStartCheckpointedCFHeaderSync(t *testing.T) {
 	require.True(t, shouldStartCheckpointedCFHeaderSync(
 		100, 100+window, false,
 	))
+}
+
+func TestHeaderSyncValidationChain(t *testing.T) {
+	t.Parallel()
+
+	base := headerlist.NewBoundedMemoryChain(4)
+	base.ResetHeaderState(headerlist.Node{
+		Height: 10,
+		Header: wire.BlockHeader{Nonce: 10},
+	})
+	baseTip := base.PushBack(headerlist.Node{
+		Height: 11,
+		Header: wire.BlockHeader{Nonce: 11},
+	})
+
+	validationChain := newHeaderSyncValidationChain(base, *baseTip)
+	pendingTip := validationChain.PushBack(headerlist.Node{
+		Height: 12,
+		Header: wire.BlockHeader{Nonce: 12},
+	})
+
+	require.Equal(t, int32(12), validationChain.Back().Height)
+	require.Equal(t, uint32(12), validationChain.Back().Header.Nonce)
+	require.Equal(t, pendingTip, validationChain.Back())
+
+	pending, ok := validationChain.AtHeight(12)
+	require.True(t, ok)
+	require.Equal(t, uint32(12), pending.Header.Nonce)
+
+	cached, ok := validationChain.AtHeight(10)
+	require.True(t, ok)
+	require.Equal(t, uint32(10), cached.Header.Nonce)
+
+	_, ok = validationChain.AtHeight(9)
+	require.False(t, ok)
 }
 
 // setupBlockManager initialises a blockManager to be used in tests.

--- a/headersync/actor.go
+++ b/headersync/actor.go
@@ -64,6 +64,22 @@ type AddAnchorResp struct {
 	OK     bool
 }
 
+// AdvanceCommittedTipMsg moves the manager-visible committed tip to a header
+// tip already persisted by the block manager.
+type AdvanceCommittedTipMsg struct {
+	managerMessage
+
+	Height uint32
+	Hash   Hash
+}
+
+// AdvanceCommittedTipResp reports whether the committed tip changed.
+type AdvanceCommittedTipResp struct {
+	managerResponse
+
+	Advanced bool
+}
+
 // AnchorsMsg asks the manager for the currently known anchor set.
 type AnchorsMsg struct {
 	managerMessage
@@ -351,6 +367,11 @@ func (managerState) ProcessEvent(ctx context.Context, msg ManagerMsg,
 		)
 
 		return respond(&AddAnchorResp{Anchor: anchor, OK: ok})
+
+	case *AdvanceCommittedTipMsg:
+		advanced := env.fsm.AdvanceCommittedTip(m.Height, m.Hash)
+
+		return respond(&AdvanceCommittedTipResp{Advanced: advanced})
 
 	case *AnchorsMsg:
 		return respond(&AnchorsResp{Anchors: env.fsm.Anchors()})
@@ -833,6 +854,27 @@ func (m *ManagerActor) AddAnchor(ctx context.Context, height uint32,
 	}
 
 	return anchorResp.Anchor, anchorResp.OK, nil
+}
+
+// AdvanceCommittedTip asks the manager to reconcile its committed tip with a
+// block-header tip that has already been persisted by the block manager.
+func (m *ManagerActor) AdvanceCommittedTip(ctx context.Context, height uint32,
+	hash Hash) (bool, error) {
+
+	resp, err := m.ask(ctx, &AdvanceCommittedTipMsg{
+		Height: height,
+		Hash:   hash,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	advanceResp, ok := resp.(*AdvanceCommittedTipResp)
+	if !ok {
+		return false, unexpectedManagerResp(resp)
+	}
+
+	return advanceResp.Advanced, nil
 }
 
 // Anchors asks the manager actor for the current known anchors.

--- a/headersync/bridge.go
+++ b/headersync/bridge.go
@@ -162,6 +162,9 @@ func runBridgeStep(fsm *HeaderSyncFSM, session *Session,
 			step.Height, hashFromBridge(step.Hash), step.Trusted,
 		)
 
+	case "advance_tip":
+		fsm.AdvanceCommittedTip(step.Height, hashFromBridge(step.Hash))
+
 	case "track_anchor":
 		session.TrackAnchor(step.PeerID, AnchorRequest{
 			StartHeight: step.StartHeight,

--- a/headersync/controller.go
+++ b/headersync/controller.go
@@ -119,12 +119,10 @@ func (c *Controller) PlanCheckpointRanges(ctx context.Context,
 		return CheckpointRangePlan{}, nil
 	}
 
-	if _, ok, err := c.manager.AddAnchor(ctx, tip.Height, tip.Hash,
-		true); err != nil {
-
+	if _, err := c.manager.AdvanceCommittedTip(
+		ctx, tip.Height, tip.Hash,
+	); err != nil {
 		return CheckpointRangePlan{}, err
-	} else if !ok {
-		return CheckpointRangePlan{}, nil
 	}
 
 	if _, ok, err := c.manager.AddAnchor(ctx, stop.Height, stop.Hash,
@@ -150,6 +148,37 @@ func (c *Controller) PlanCheckpointRanges(ctx context.Context,
 		Span:              span,
 		MaxRangeHeaders:   c.cfg.MaxRangeHeaders,
 	}, nil
+}
+
+// PlanFrontierRanges plans any already-known confirmed frontier spans after
+// the current persisted block-header tip. This is the recovery path for
+// discovery that learned anchors out of order: missing spans can be fetched as
+// normal range work while later staged ranges wait for ordered commit.
+func (c *Controller) PlanFrontierRanges(ctx context.Context,
+	tip ChainPoint, bestHeight uint32) (PlanRangesResult, error) {
+
+	if c == nil || c.manager == nil {
+		return PlanRangesResult{}, nil
+	}
+	if tip.Height >= bestHeight {
+		return PlanRangesResult{}, nil
+	}
+
+	if _, err := c.manager.AdvanceCommittedTip(
+		ctx, tip.Height, tip.Hash,
+	); err != nil {
+		return PlanRangesResult{}, err
+	}
+
+	result, err := c.manager.PlanConfirmedAnchorRanges(
+		ctx, c.session.NextRangeID(), tip.Height, bestHeight,
+	)
+	if err != nil {
+		return result, err
+	}
+	c.session.SetNextRangeID(result.NextID)
+
+	return result, nil
 }
 
 // AnchorDiscoverySpan returns the next span that needs anchor discovery before

--- a/headersync/controller_test.go
+++ b/headersync/controller_test.go
@@ -154,6 +154,40 @@ func TestControllerFrontierDiscoverySpan(t *testing.T) {
 	require.Equal(t, Hash{}, span.StopHash)
 }
 
+func TestControllerPlanFrontierRangesFillsGapBeforeStagedRanges(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	manager := NewManagerActor(newTestFSM(0, 100), 8)
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	addManagerAnchor(t, ctx, manager, 20, 120)
+	addManagerAnchor(t, ctx, manager, 30, 130)
+	_, ok, err := manager.StageDiscoveredRange(
+		ctx, 1, "peer-a", 20, 30, time.Now(),
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	session := NewSession()
+	session.SetNextRangeID(2)
+	controller := NewController(manager, session, DefaultConfig())
+	plan, err := controller.PlanFrontierRanges(
+		ctx, ChainPoint{Height: 10, Hash: testHash(110)}, 30,
+	)
+	require.NoError(t, err)
+	require.Len(t, plan.Ranges, 1)
+	require.EqualValues(t, 10, plan.Ranges[0].StartHeight)
+	require.EqualValues(t, 20, plan.Ranges[0].StopHeight)
+	require.EqualValues(t, 3, session.NextRangeID())
+
+	commit, err := manager.CommitReadyRanges(ctx)
+	require.NoError(t, err)
+	require.Empty(t, commit.Committed)
+	require.EqualValues(t, 10, commit.TipHeight)
+}
+
 func TestControllerFrontierLookaheadSpan(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.MaxRangeHeaders = 5

--- a/headersync/fsm.go
+++ b/headersync/fsm.go
@@ -48,6 +48,51 @@ func (h *HeaderSyncFSM) CommittedHash() Hash {
 	return h.committedHash
 }
 
+// AdvanceCommittedTip reconciles the FSM with a block-header tip that was
+// persisted outside the staged headersync commit path. Production can still
+// fall back to the legacy serial writer in a few edge cases; when that writer
+// advances the database tip, the scheduler must treat the new tip as committed
+// before planning additional frontier work.
+func (h *HeaderSyncFSM) AdvanceCommittedTip(height uint32,
+	hash Hash) bool {
+
+	if height < h.committedTip {
+		return false
+	}
+	if height == h.committedTip {
+		h.AddOrConfirmAnchor(height, hash, true)
+		h.committedHash = hash
+
+		return false
+	}
+
+	h.committedTip = height
+	h.committedHash = hash
+	h.AddOrConfirmAnchor(height, hash, true)
+
+	for id, rng := range h.ranges {
+		switch {
+		case rng.StopHeight <= height:
+			h.detachRangeFromPeers(id)
+			rng.OwnerPeer = NoPeer
+			rng.State = RangeCommitted
+			rng.Valid = true
+			rng.StagedAt = time.Time{}
+			h.ranges[id] = rng
+
+		case rng.StartHeight < height:
+			h.detachRangeFromPeers(id)
+			rng.OwnerPeer = NoPeer
+			rng.State = RangeStale
+			rng.Valid = false
+			rng.StagedAt = time.Time{}
+			h.ranges[id] = rng
+		}
+	}
+
+	return true
+}
+
 // Metrics returns the current counters.
 func (h *HeaderSyncFSM) Metrics() Metrics {
 	return h.metrics

--- a/headersync/fsm_test.go
+++ b/headersync/fsm_test.go
@@ -90,6 +90,34 @@ func TestReadyRangesDoesNotAdvanceCommittedTip(t *testing.T) {
 	require.EqualValues(t, 10, fsm.CommittedTip())
 }
 
+func TestAdvanceCommittedTipReconcilesExternalProgress(t *testing.T) {
+	fsm := newTestFSM(0, 100)
+	addTrustedAnchor(t, fsm, 0, 100)
+	addTrustedAnchor(t, fsm, 10, 110)
+	addTrustedAnchor(t, fsm, 20, 120)
+	addTrustedAnchor(t, fsm, 30, 130)
+	addPeer(t, fsm, "peer")
+	mustPlanRange(t, fsm, 1, 0, 10)
+	mustPlanRange(t, fsm, 2, 10, 20)
+	mustPlanRange(t, fsm, 3, 20, 30)
+	mustAssignRange(t, fsm)
+	started := mustStartRange(t, fsm, "peer")
+	require.EqualValues(t, 1, started.RangeID)
+
+	advanced := fsm.AdvanceCommittedTip(15, testHash(115))
+	require.True(t, advanced)
+	require.EqualValues(t, 15, fsm.CommittedTip())
+	require.Equal(t, testHash(115), fsm.CommittedHash())
+	require.False(t, fsm.rangeOverlaps(15, 20))
+
+	first, ok := fsm.ranges[1]
+	require.True(t, ok)
+	require.Equal(t, RangeCommitted, first.State)
+	second, ok := fsm.ranges[2]
+	require.True(t, ok)
+	require.Equal(t, RangeStale, second.State)
+}
+
 func TestStageDiscoveredRangeUsesConfirmedAnchors(t *testing.T) {
 	fsm := newTestFSM(0, 100)
 	fsm.SeedCommittedAnchor()

--- a/p-models/neutrinoheadersync/bridge/scenarios.json
+++ b/p-models/neutrinoheadersync/bridge/scenarios.json
@@ -122,6 +122,47 @@
       }
     },
     {
+      "name": "external_tip_advance_plans_gap_before_staged_frontier",
+      "committed_tip": 0,
+      "committed_hash": 100,
+      "anchors": [
+        {"height": 0, "hash": 100, "trusted": true},
+        {"height": 20, "hash": 120, "trusted": true},
+        {"height": 30, "hash": 130, "trusted": true}
+      ],
+      "peers": [
+        {"id": "peer", "state": "ready"}
+      ],
+      "steps": [
+        {"op": "plan", "range_id": 1, "start_height": 20, "stop_height": 30},
+        {"op": "assign"},
+        {"op": "start", "peer_id": "peer"},
+        {"op": "complete", "peer_id": "peer", "range_id": 1, "lease_epoch": 1, "valid": true, "at_unix": 100},
+        {"op": "commit"},
+        {"op": "advance_tip", "height": 10, "hash": 110},
+        {"op": "plan", "range_id": 2, "start_height": 10, "stop_height": 20},
+        {"op": "assign"},
+        {"op": "start", "peer_id": "peer"},
+        {"op": "complete", "peer_id": "peer", "range_id": 2, "lease_epoch": 1, "valid": true, "at_unix": 101},
+        {"op": "commit"}
+      ],
+      "expect": {
+        "committed_tip": 30,
+        "committed_hash": 130,
+        "commit_log": [2, 1],
+        "ranges": [
+          {"id": 2, "state": "committed", "owner_peer": "peer", "lease_epoch": 1, "valid": true},
+          {"id": 1, "state": "committed", "owner_peer": "peer", "lease_epoch": 1, "valid": true}
+        ],
+        "peers": [
+          {"id": "peer", "state": "ready"}
+        ],
+        "metrics": {
+          "ranges_committed": 2
+        }
+      }
+    },
+    {
       "name": "commit_prunes_obsolete_anchor_requests",
       "committed_tip": 0,
       "committed_hash": 100,

--- a/p-models/neutrinoheadersync/src/header_sync.p
+++ b/p-models/neutrinoheadersync/src/header_sync.p
@@ -10,7 +10,9 @@
 //   * stealing increments the epoch so old responses become stale;
 //   * peers may complete ranges out of order;
 //   * completed ranges are staged before commit;
-//   * commits advance only through the next contiguous staged range.
+//   * commits advance only through the next contiguous staged range;
+//   * if a legacy/fallback writer already persisted headers, the model can
+//     reconcile the visible tip before planning more frontier work.
 
 enum HeaderPeerState {
     HeaderPeerReady,
@@ -137,6 +139,68 @@ fun NewModel(committed_tip: int, committed_hash: int): HeaderSyncModel {
         peers = default(seq[HeaderPeer]),
         commit_log = default(seq[int])
     );
+}
+
+// AdvanceCommittedTip models the production reconciliation path between the
+// pure scheduler and the durable block-header store. Most progress should come
+// from CommitReadyRanges, but during migration the block manager can still
+// persist a short serial fallback span. Once storage says the tip is already
+// ahead, the scheduler must not keep planning from its stale in-memory tip or
+// it can skip the newly persisted boundary and strand staged frontier ranges.
+fun AdvanceCommittedTip(model: HeaderSyncModel, height: int,
+    hash: int): HeaderSyncModel {
+
+    var i: int;
+    var range: HeaderRange;
+
+    if (height < model.committed_tip) {
+        return model;
+    }
+
+    model.anchors = AddOrConfirmAnchor(model.anchors, height, hash, true);
+    if (height == model.committed_tip) {
+        model.committed_hash = hash;
+        return model;
+    }
+
+    model.committed_tip = height;
+    model.committed_hash = hash;
+
+    i = 0;
+    while (i < sizeof(model.ranges)) {
+        range = model.ranges[i];
+        if (range.stop_height <= height) {
+            range = (
+                id = range.id,
+                start_height = range.start_height,
+                start_hash = range.start_hash,
+                stop_height = range.stop_height,
+                stop_hash = range.stop_hash,
+                lease_epoch = range.lease_epoch,
+                owner_peer = NoPeer(),
+                range_state = RangeCommitted,
+                valid = true
+            );
+            model.ranges = ReplaceRange(model.ranges, range);
+        } else if (range.start_height < height) {
+            range = (
+                id = range.id,
+                start_height = range.start_height,
+                start_hash = range.start_hash,
+                stop_height = range.stop_height,
+                stop_hash = range.stop_hash,
+                lease_epoch = range.lease_epoch,
+                owner_peer = NoPeer(),
+                range_state = RangeStale,
+                valid = false
+            );
+            model.ranges = ReplaceRange(model.ranges, range);
+        }
+
+        i = i + 1;
+    }
+
+    return model;
 }
 
 // AddOrConfirmAnchor is the anchor-discovery rule. Trusted checkpoints are

--- a/p-models/neutrinoheadersync/test/header_sync_test.p
+++ b/p-models/neutrinoheadersync/test/header_sync_test.p
@@ -325,6 +325,59 @@ machine TestOutOfOrderCompletionStagesUntilGapFilled {
     state Done {}
 }
 
+machine TestExternalTipAdvancePlansGapBeforeStagedFrontier {
+    start state Init {
+        entry {
+            var model: HeaderSyncModel;
+            var gap: HeaderRange;
+            var staged: HeaderRange;
+            var ready: seq[int];
+
+            model = NewModel(0, 100);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 0, 100, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 20, 120, true);
+            model.anchors = AddOrConfirmAnchor(model.anchors, 30, 130, true);
+
+            // This is the failure mode seen in the live sqlite testnet3 run:
+            // later frontier discovery responses were already staged, but a
+            // short serial/fallback write had advanced the durable tip to a
+            // boundary the FSM had not yet made visible. Reconciliation must
+            // add that boundary before the manager keeps discovering farther
+            // ahead, otherwise the staged range after the gap can never commit.
+            model = StageDiscoveredRange(model, 1, 9, 20, 30);
+            model = AdvanceCommittedTip(model, 10, 110);
+            assert model.committed_tip == 10,
+                "external durable tip should become manager-visible";
+
+            model = PlanRange(model, 2, 10, 20);
+            gap = RangeByID(model.ranges, 2);
+            assert gap.range_state == RangeQueued,
+                "known missing frontier span should become fetchable work";
+
+            ready = ReadyRanges(model);
+            assert sizeof(ready) == 0,
+                "later staged frontier range must wait for the planned gap";
+
+            model = AddPeer(model, NewPeer(1, 0, 10, HeaderPeerReady));
+            model = AssignNextQueuedRange(model);
+            model = StartPeerRange(model, 1);
+            gap = RangeByID(model.ranges, 2);
+            model = CompleteRange(model, 1, 2, gap.lease_epoch, true);
+            model = CommitReadyRanges(model);
+
+            staged = RangeByID(model.ranges, 1);
+            assert staged.range_state == RangeCommitted,
+                "committing the gap should drain the already staged range";
+            assert model.committed_tip == 30,
+                "visible tip should advance through all contiguous work";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
 machine TestReadyRangesDoesNotAdvanceCommittedTip {
     start state Init {
         entry {


### PR DESCRIPTION
Stacked on #372.

In this PR, we add the missing reconciliation path between the headersync scheduler and the durable block-header store. Most progress should come through the staged range commit path, but while we're migrating away from the old serial loop there are still cases where blockmanager can persist headers outside of the scheduler's visible committed tip. If the scheduler doesn't learn that durable boundary, it can keep planning from a stale in-memory tip and strand later completed ranges behind a missing gap.

The new `AdvanceCommittedTip` event lets the manager treat the durable store tip as committed, mark fully covered ranges committed, mark overlapping old ranges stale, and seed the new tip as a trusted anchor. Blockmanager now reads the actual store tip hash when it plans checkpoint and frontier ranges, then asks the controller to plan confirmed frontier spans when there isn't a next checkpoint.

The P model and Go bridge now cover the failure mode directly: a later range completes first, an external durable tip advance exposes the missing gap, the gap becomes fetchable work, and once it commits the already staged later range drains in order.

Validation performed:

```sh
go test ./headersync -count=1
SCHEDULES=10 ./p-models/scripts/check.sh
go test . -count=1
go test ./... -count=1
```

All passed locally before the rebase. After rebasing on the updated #372 runtime shape, these passed again:

```sh
go test ./headersync -count=1
SCHEDULES=10 ./p-models/scripts/check.sh
go test . -count=1
```