### PR TITLE
blockmanager: scale checkpointed cfheader timeout

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -83,6 +83,22 @@ const (
 	// the filter header path from fragmenting initial sync into thousands
 	// of tiny batches.
 	checkpointedCFHeaderSyncWindow = 64 * wire.CFCheckptInterval
+
+	// checkpointedCFHeadersMinBatchTimeout is the minimum total timeout for
+	// checkpointed cfheader batch queries. The legacy default of 30s is too
+	// short for large initial-sync batches because it cancels all remaining
+	// 2,000-header range requests after one slow segment.
+	checkpointedCFHeadersMinBatchTimeout = 2 * time.Minute
+
+	// checkpointedCFHeadersPerQueryTimeout scales the total batch timeout
+	// with the number of range requests. This is an upper bound only; fast
+	// batches still finish as soon as all requests return.
+	checkpointedCFHeadersPerQueryTimeout = 250 * time.Millisecond
+
+	// checkpointedCFHeadersMaxBatchTimeout keeps a pathological peer mix
+	// from pinning cfheader sync forever while still allowing testnet3-size
+	// batches enough room to retry and steal work.
+	checkpointedCFHeadersMaxBatchTimeout = 15 * time.Minute
 )
 
 // zeroHash is the zero value hash (all zeros).  It is defined as a convenience.
@@ -1393,6 +1409,7 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 	// responses as they come back.
 	errChan := b.cfg.QueryDispatcher.Query(
 		q.requests(), query.Cancel(b.quit), query.NoRetryMax(),
+		query.Timeout(checkpointedCFHeadersBatchTimeout(batchesCount)),
 	)
 
 	// Keep waiting for more headers as long as we haven't received an
@@ -1513,6 +1530,18 @@ func (b *blockManager) getCheckpointedCFHeaders(checkpoints []*chainhash.Hash,
 			break
 		}
 	}
+}
+
+func checkpointedCFHeadersBatchTimeout(batches int) time.Duration {
+	timeout := time.Duration(batches) * checkpointedCFHeadersPerQueryTimeout
+	if timeout < checkpointedCFHeadersMinBatchTimeout {
+		timeout = checkpointedCFHeadersMinBatchTimeout
+	}
+	if timeout > checkpointedCFHeadersMaxBatchTimeout {
+		timeout = checkpointedCFHeadersMaxBatchTimeout
+	}
+
+	return timeout
 }
 
 // writeCFHeadersMsg writes a cfheaders message to the specified store. It

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -211,6 +211,34 @@ func TestSyncPeerCandidateOrdering(t *testing.T) {
 	require.True(t, syncPeerOrdersBefore(addrA, addrB))
 }
 
+func TestCheckpointedCFHeadersBatchTimeoutScales(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t, checkpointedCFHeadersMinBatchTimeout,
+		checkpointedCFHeadersBatchTimeout(1),
+	)
+
+	scaledQueries := int(
+		(checkpointedCFHeadersMinBatchTimeout /
+			checkpointedCFHeadersPerQueryTimeout) + 1,
+	)
+	require.Equal(
+		t, time.Duration(scaledQueries)*
+			checkpointedCFHeadersPerQueryTimeout,
+		checkpointedCFHeadersBatchTimeout(scaledQueries),
+	)
+
+	hugeQueries := int(
+		(checkpointedCFHeadersMaxBatchTimeout /
+			checkpointedCFHeadersPerQueryTimeout) + 1,
+	)
+	require.Equal(
+		t, checkpointedCFHeadersMaxBatchTimeout,
+		checkpointedCFHeadersBatchTimeout(hugeQueries),
+	)
+}
+
 func newTestServerPeer(t *testing.T, addr string,
 	lastBlock int32) *ServerPeer {
 


### PR DESCRIPTION
In this PR, we scale the timeout used for checkpointed cfheader batch queries with the number of 2,000-header range requests in the batch. The old fixed timeout was too small for large historical sync batches: one slow segment could cause the dispatcher to cancel the rest of the batch even though other requests were still making progress.

We keep this slice narrow. The timeout has a floor for small batches and a cap for bad peer mixes, while the normal fast path still returns as soon as all requests finish. This gives querysync enough room to retry and steal work during large testnet3-style cfheader syncs without changing the all-peer cfheader query semantics used by peer sanity checks.

## Tests

```
go test . -run 'TestCheckpointedCFHeadersBatchTimeoutScales|TestNeutrinoSyncWithoutHeadersImport' -count=1
go test . -count=1
go test ./... -count=1
```
