### PR TITLE
github: refresh gateway workflow

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -1,28 +1,45 @@
 name: gateway
 
+# Opt-in code-review bot. Triggered by a `/gateway <command>` comment on a PR
+# (e.g. `/gateway review`); review/approve commands are gated to maintainers.
+# Comment-commands only — no pull_request triggers — so fork PRs (which receive
+# no secrets) never spawn failing runs.
+#
+# Thin shim: the public lightninglabs/gateway-action mints an App token and
+# checks out the private gateway runtime at execution time. The runtime stays
+# private; only this entry point is public.
+
 on:
   issue_comment:
     types: [created]
-  pull_request:
-    types: [review_requested, closed]
 
 permissions:
+  # The action mints an App installation token internally; the GITHUB_TOKEN
+  # handed to this shim is unused, so we minimise it.
   contents: read
 
 jobs:
   review:
-    if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request != null }}
+    # issue_comment fires for all issues and every PR comment. Filter to PR
+    # comments that look like a /gateway command so unrelated comments don't
+    # spin up a no-op runner. `contains` (not `startsWith`) because the runtime
+    # accepts the command at column 0 of any line, including multi-line bodies.
+    if: ${{ github.event.issue.pull_request != null && contains(github.event.comment.body, '/gateway') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       GATEWAY_REVIEW_MODE: multi
     steps:
-      - uses: lightninglabs/gateway-action@v0.4.2
+      - uses: lightninglabs/gateway-action@fa29e3132c8af9cdabd9cedca3b1b6ece56d0982 # v0.4.3
         with:
+          # Pin the private runtime to an immutable commit (matches the action
+          # SHA-pin above) so runtime upgrades go through a neutrino PR, not a
+          # moved tag. Without this, runtime_ref defaults to the v0.4.3 tag.
+          runtime_ref: bb11d9744cd6fe7fbeeb9de720fc8a74b5232a8e # v0.4.3
           event_name:      ${{ github.event_name }}
           event_action:    ${{ github.event.action }}
           repo:            ${{ github.repository }}
-          pr_number:       ${{ github.event.issue.number || github.event.pull_request.number }}
+          pr_number:       ${{ github.event.issue.number }}
           actor:           ${{ github.event.sender.login }}
           comment_body:    ${{ github.event.comment.body }}
           comment_id:      ${{ github.event.comment.id }}


### PR DESCRIPTION
Refreshes the gateway workflow with three changes.

## 1. Stop no-op runs on every comment

The job fired on every PR comment, so automation posts (e.g. `lightninglabs-deploy`) spun up ~15s no-op runners. Now gated on the comment containing a `/gateway` command. Uses `contains()` rather than `startsWith()` — the runtime accepts the command at column 0 of any line, so `startsWith` would drop multi-line invocations.

## 2. Bump to gateway-action v0.4.3 + dual SHA-pin

- `uses:` and `runtime_ref` both pinned to commit SHAs, so a runtime upgrade requires a neutrino PR rather than a moved tag. (A SHA-pinned action alone still resolves the runtime at a movable tag default.)
- v0.4.3 also carries the fork-PR prompt-injection hardening (token stripped from the model's env + shell/network tools denied).

## 3. Comment-commands only

Drops the `pull_request` triggers (`review_requested`, `closed`) so fork PRs — which get no secrets — never spawn failing runs. Trade-off: loses the Re-request-review button flow and on-close label cleanup; `/gateway` comments still work everywhere.

No behavior change to the review itself.
