### PR TITLE
Add optional HTTP block source with peer fallback

### DIFF
--- a/block_http_source_test.go
+++ b/block_http_source_test.go
@@ -1,0 +1,265 @@
+package neutrino
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/neutrino/blockfetch"
+	"github.com/lightninglabs/neutrino/cache/lru"
+	"github.com/lightninglabs/neutrino/headerfs"
+	"github.com/lightninglabs/neutrino/query"
+	"github.com/stretchr/testify/require"
+)
+
+// blockServerMode controls how the test HTTP block server responds.
+type blockServerMode int
+
+const (
+	// serveValidBlocks serves the correct, wire-encoded block for the
+	// requested hash.
+	serveValidBlocks blockServerMode = iota
+
+	// serveError responds with an HTTP 500 for every request.
+	serveError
+
+	// serveGarbage responds with 200 but a body that isn't a valid block.
+	serveGarbage
+)
+
+// newTestBlockServer spins up an httptest.Server that mimics the block-dn
+// "/block/<hash>" endpoint for the given blocks, in the requested mode. It
+// returns the server (already registered for cleanup) and a counter of how
+// many block requests it received.
+func newTestBlockServer(t *testing.T, blocks []*btcutil.Block,
+	mode blockServerMode) (*httptest.Server, *int) {
+
+	t.Helper()
+
+	// Index the blocks by hash so we can serve them by the requested hash.
+	blockBytes := make(map[string][]byte, len(blocks))
+	for _, b := range blocks {
+		raw, err := b.Bytes()
+		require.NoError(t, err)
+		blockBytes[b.Hash().String()] = raw
+	}
+
+	var requests int
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		requests++
+
+		switch mode {
+		case serveError:
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+
+		case serveGarbage:
+			_, _ = w.Write([]byte("this is not a block"))
+			return
+		}
+
+		hash := strings.TrimPrefix(r.URL.Path, "/block/")
+		raw, ok := blockBytes[hash]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		_, _ = w.Write(raw)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	return server, &requests
+}
+
+// newBlockSourceChainService builds a minimal ChainService wired up with a
+// mock header store, an in-memory block cache, a mock work manager, and
+// (optionally) an HTTP block fetcher pointed at baseURL. The returned queries
+// channel receives the hash of every block requested from peers, so a test can
+// assert whether the P2P path was exercised.
+func newBlockSourceChainService(t *testing.T, blocks []*btcutil.Block,
+	baseURL string) (*ChainService, chan chainhash.Hash) {
+
+	t.Helper()
+
+	mBlockHeaderStore := &headerfs.MockBlockHeaderStore{}
+	for i, b := range blocks {
+		blkHeader := &b.MsgBlock().Header
+		mBlockHeaderStore.On("FetchHeader", b.Hash()).Return(
+			blkHeader, uint32(i), nil,
+		)
+	}
+
+	cs := &ChainService{
+		BlockCache: lru.NewCache[wire.InvVect, *CacheableBlock](
+			DefaultBlockCacheSize,
+		),
+		BlockHeaders: mBlockHeaderStore,
+		chainParams: chaincfg.Params{
+			PowLimit: maxPowLimit,
+		},
+		timeSource:  blockchain.NewMedianTime(),
+		workManager: &mockDispatcher{},
+		quit:        make(chan struct{}),
+	}
+
+	if baseURL != "" {
+		cs.blockFetcher = blockfetch.New(blockfetch.Config{
+			BaseURL:    baseURL,
+			NumRetries: 1,
+		})
+	}
+
+	// The mock work manager serves the requested block and notifies the
+	// test of the query over the queries channel.
+	queries := make(chan chainhash.Hash, 1)
+	cs.workManager.(*mockDispatcher).query = func(reqs []*query.Request,
+		opts ...query.QueryOption) chan error {
+
+		errChan := make(chan error, 1)
+		defer close(errChan)
+
+		require.Len(t, reqs, 1)
+		getData, ok := reqs[0].Req.(*wire.MsgGetData)
+		require.True(t, ok)
+		require.Len(t, getData.InvList, 1)
+
+		inv := getData.InvList[0]
+		for _, b := range blocks {
+			if *b.Hash() != inv.Hash {
+				continue
+			}
+
+			resp := &wire.MsgBlock{
+				Header:       b.MsgBlock().Header,
+				Transactions: b.MsgBlock().Transactions,
+			}
+			progress := reqs[0].HandleResp(getData, resp, "")
+			require.True(t, progress.Finished)
+
+			select {
+			case queries <- inv.Hash:
+			case <-time.After(time.Second):
+				require.Fail(t, "query was not handled")
+			}
+
+			return errChan
+		}
+
+		require.Failf(t, "unknown block", "queried for %v", inv.Hash)
+
+		return errChan
+	}
+
+	return cs, queries
+}
+
+// requirePeersQueried asserts that the peer path was used for the given hash.
+func requirePeersQueried(t *testing.T, queries chan chainhash.Hash,
+	hash chainhash.Hash) {
+
+	t.Helper()
+
+	select {
+	case q := <-queries:
+		require.Equal(t, hash, q)
+	case <-time.After(time.Second):
+		require.Fail(t, "expected block to be queried from peers")
+	}
+}
+
+// requirePeersNotQueried asserts that the peer path was not used.
+func requirePeersNotQueried(t *testing.T, queries chan chainhash.Hash) {
+	t.Helper()
+
+	select {
+	case q := <-queries:
+		require.Failf(t, "unexpected peer query", "for block %v", q)
+	default:
+	}
+}
+
+// TestGetBlockHTTPSource asserts that, when an HTTP block source is configured,
+// GetBlock fetches from it first, caches the result, and only falls back to the
+// P2P network when the HTTP fetch fails.
+func TestGetBlockHTTPSource(t *testing.T) {
+	t.Parallel()
+
+	blocks, err := loadBlocks(t, blockDataFile, blockDataNet)
+	require.NoError(t, err)
+
+	// We use a non-genesis block with transactions as the target.
+	target := blocks[1]
+	targetHash := *target.Hash()
+
+	t.Run("http first, no peer fallback", func(t *testing.T) {
+		server, reqs := newTestBlockServer(
+			t, blocks, serveValidBlocks,
+		)
+		cs, queries := newBlockSourceChainService(
+			t, blocks, server.URL,
+		)
+
+		// The block should be fetched over HTTP and returned.
+		got, err := cs.GetBlock(targetHash)
+		require.NoError(t, err)
+		require.Equal(t, targetHash, *got.Hash())
+		require.Equal(t, 1, *reqs)
+		requirePeersNotQueried(t, queries)
+
+		// It should now be in the cache, so a second call neither hits
+		// HTTP nor the peers.
+		got, err = cs.GetBlock(targetHash)
+		require.NoError(t, err)
+		require.Equal(t, targetHash, *got.Hash())
+		require.Equal(t, 1, *reqs)
+		requirePeersNotQueried(t, queries)
+	})
+
+	t.Run("fallback to peers on http error", func(t *testing.T) {
+		server, reqs := newTestBlockServer(t, blocks, serveError)
+		cs, queries := newBlockSourceChainService(
+			t, blocks, server.URL,
+		)
+
+		got, err := cs.GetBlock(targetHash)
+		require.NoError(t, err)
+		require.Equal(t, targetHash, *got.Hash())
+
+		// The fetcher attempted the configured single request, then we
+		// fell back to the peers.
+		require.Equal(t, 1, *reqs)
+		requirePeersQueried(t, queries, targetHash)
+	})
+
+	t.Run("fallback to peers on garbage block", func(t *testing.T) {
+		server, reqs := newTestBlockServer(t, blocks, serveGarbage)
+		cs, queries := newBlockSourceChainService(
+			t, blocks, server.URL,
+		)
+
+		got, err := cs.GetBlock(targetHash)
+		require.NoError(t, err)
+		require.Equal(t, targetHash, *got.Hash())
+		require.Equal(t, 1, *reqs)
+		requirePeersQueried(t, queries, targetHash)
+	})
+
+	t.Run("no source configured queries peers", func(t *testing.T) {
+		cs, queries := newBlockSourceChainService(t, blocks, "")
+
+		got, err := cs.GetBlock(targetHash)
+		require.NoError(t, err)
+		require.Equal(t, targetHash, *got.Hash())
+		requirePeersQueried(t, queries, targetHash)
+	})
+}

--- a/blockfetch/fetcher.go
+++ b/blockfetch/fetcher.go
@@ -1,0 +1,178 @@
+package blockfetch
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+)
+
+const (
+	// DefaultNumRetries is the number of times we'll try to fetch a block
+	// from the HTTP source before giving up and letting the caller fall
+	// back to the P2P network.
+	DefaultNumRetries = 3
+
+	// DefaultRetryDelay is the delay we wait between retry attempts.
+	DefaultRetryDelay = 500 * time.Millisecond
+
+	// DefaultRequestTimeout is the timeout applied to a single HTTP block
+	// request when the default client is used.
+	DefaultRequestTimeout = 30 * time.Second
+)
+
+// blockPathFormat is the path, relative to the configured base URL, where an
+// individual block can be downloaded by its hash. This matches the API served
+// by block-dn (https://block-dn.org), which returns the raw, witness-encoded
+// block in Bitcoin wire format.
+const blockPathFormat = "%s/block/%s"
+
+// ErrShuttingDown is returned when a fetch is aborted because the caller's quit
+// channel was closed.
+var ErrShuttingDown = errors.New("block fetcher shutting down")
+
+// HTTPClient is the subset of *http.Client that the block fetcher relies on.
+// It's deliberately narrow so tests can supply a fake implementation.
+type HTTPClient interface {
+	// Get issues a GET request to the given URL and returns the response.
+	Get(url string) (*http.Response, error)
+}
+
+// Config holds the configuration for a BlockFetcher.
+type Config struct {
+	// BaseURL is the base URL of the HTTP block source, e.g.
+	// "https://block-dn.org". Individual blocks are fetched from
+	// "<BaseURL>/block/<hash>".
+	BaseURL string
+
+	// Client is the HTTP client used to issue requests. If nil, a default
+	// client with a DefaultRequestTimeout timeout is used.
+	Client HTTPClient
+
+	// NumRetries is the number of attempts made to fetch a block before
+	// giving up. If zero or negative, DefaultNumRetries is used.
+	NumRetries int
+
+	// RetryDelay is the delay between retry attempts. If zero,
+	// DefaultRetryDelay is used.
+	RetryDelay time.Duration
+}
+
+// BlockFetcher downloads raw blocks from an HTTP block source such as
+// block-dn. It is safe for concurrent use as it holds no mutable state.
+type BlockFetcher struct {
+	baseURL    string
+	client     HTTPClient
+	numRetries int
+	retryDelay time.Duration
+}
+
+// New constructs a BlockFetcher from the given config, applying defaults for
+// any unset fields.
+func New(cfg Config) *BlockFetcher {
+	client := cfg.Client
+	if client == nil {
+		client = &http.Client{Timeout: DefaultRequestTimeout}
+	}
+
+	numRetries := cfg.NumRetries
+	if numRetries <= 0 {
+		numRetries = DefaultNumRetries
+	}
+
+	retryDelay := cfg.RetryDelay
+	if retryDelay == 0 {
+		retryDelay = DefaultRetryDelay
+	}
+
+	return &BlockFetcher{
+		baseURL:    strings.TrimRight(cfg.BaseURL, "/"),
+		client:     client,
+		numRetries: numRetries,
+		retryDelay: retryDelay,
+	}
+}
+
+// FetchBlock downloads the block with the given hash from the HTTP source. It
+// retries up to the configured number of attempts, waiting RetryDelay between
+// them, and aborts early if the quit channel is closed.
+//
+// The returned block is guaranteed to hash to the requested hash, but the more
+// expensive consensus validation (sanity checks, witness commitment) is left
+// to the caller, which has the chain context required to perform it.
+func (b *BlockFetcher) FetchBlock(quit <-chan struct{},
+	hash chainhash.Hash) (*wire.MsgBlock, error) {
+
+	url := fmt.Sprintf(blockPathFormat, b.baseURL, hash.String())
+
+	var lastErr error
+	for attempt := 1; attempt <= b.numRetries; attempt++ {
+		// Abort early if we're shutting down.
+		select {
+		case <-quit:
+			return nil, ErrShuttingDown
+		default:
+		}
+
+		block, err := b.fetchOnce(url, hash)
+		if err == nil {
+			return block, nil
+		}
+
+		lastErr = err
+		log.Debugf("Attempt %d/%d to fetch block %v from %s failed: %v",
+			attempt, b.numRetries, hash, url, err)
+
+		// There's no point waiting after the final attempt.
+		if attempt == b.numRetries {
+			break
+		}
+
+		select {
+		case <-time.After(b.retryDelay):
+		case <-quit:
+			return nil, ErrShuttingDown
+		}
+	}
+
+	return nil, fmt.Errorf("failed to fetch block %v from HTTP source "+
+		"after %d attempt(s): %w", hash, b.numRetries, lastErr)
+}
+
+// fetchOnce performs a single download attempt and verifies that the returned
+// block hashes to the requested hash.
+func (b *BlockFetcher) fetchOnce(url string,
+	hash chainhash.Hash) (*wire.MsgBlock, error) {
+
+	resp, err := b.client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d",
+			resp.StatusCode)
+	}
+
+	// The block is served as a raw, witness-encoded block in Bitcoin wire
+	// format, so we can deserialize it straight from the response body.
+	var msgBlock wire.MsgBlock
+	if err := msgBlock.Deserialize(resp.Body); err != nil {
+		return nil, fmt.Errorf("failed to deserialize block: %w", err)
+	}
+
+	// Make sure the source actually returned the block we asked for. This
+	// is a cheap integrity check on the transport; it doesn't replace the
+	// consensus validation the caller still has to perform.
+	if gotHash := msgBlock.BlockHash(); gotHash != hash {
+		return nil, fmt.Errorf("block source returned block %v for "+
+			"requested block %v", gotHash, hash)
+	}
+
+	return &msgBlock, nil
+}

--- a/blockfetch/fetcher_test.go
+++ b/blockfetch/fetcher_test.go
@@ -1,0 +1,220 @@
+package blockfetch
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeResp describes the outcome of a single mocked HTTP request.
+type fakeResp struct {
+	body   []byte
+	status int
+	err    error
+}
+
+// fakeHTTPClient is a programmable HTTPClient that returns a preconfigured
+// sequence of responses, one per call. Once the sequence is exhausted the last
+// entry is repeated, which lets tests describe "fail forever" behavior with a
+// single entry.
+type fakeHTTPClient struct {
+	responses []fakeResp
+	calls     int
+	lastURL   string
+}
+
+// Get returns the next preconfigured response.
+func (f *fakeHTTPClient) Get(url string) (*http.Response, error) {
+	f.lastURL = url
+
+	idx := f.calls
+	if idx >= len(f.responses) {
+		idx = len(f.responses) - 1
+	}
+	f.calls++
+
+	resp := f.responses[idx]
+	if resp.err != nil {
+		return nil, resp.err
+	}
+
+	return &http.Response{
+		StatusCode: resp.status,
+		Body:       io.NopCloser(bytes.NewReader(resp.body)),
+	}, nil
+}
+
+// genesisBytes returns the wire-encoded mainnet genesis block along with its
+// hash, used as realistic block payload in the tests.
+func genesisBytes(t *testing.T) (chainhash.Hash, []byte) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	require.NoError(t, chaincfg.MainNetParams.GenesisBlock.Serialize(&buf))
+
+	return *chaincfg.MainNetParams.GenesisHash, buf.Bytes()
+}
+
+// TestFetchBlockSuccess asserts that a single successful response yields the
+// expected block and only one request is made.
+func TestFetchBlockSuccess(t *testing.T) {
+	t.Parallel()
+
+	hash, raw := genesisBytes(t)
+	client := &fakeHTTPClient{responses: []fakeResp{
+		{body: raw, status: http.StatusOK},
+	}}
+
+	f := New(Config{BaseURL: "https://block-dn.org/", Client: client})
+
+	block, err := f.FetchBlock(nil, hash)
+	require.NoError(t, err)
+	require.Equal(t, hash, block.BlockHash())
+	require.Equal(t, 1, client.calls)
+
+	// The URL must follow the block-dn "/block/<hash>" scheme, with the
+	// trailing slash on the base URL stripped.
+	require.Equal(
+		t, "https://block-dn.org/block/"+hash.String(),
+		client.lastURL,
+	)
+}
+
+// TestFetchBlockRetryThenSuccess asserts that a transient failure is retried
+// and a later success is returned.
+func TestFetchBlockRetryThenSuccess(t *testing.T) {
+	t.Parallel()
+
+	hash, raw := genesisBytes(t)
+	client := &fakeHTTPClient{responses: []fakeResp{
+		{status: http.StatusInternalServerError},
+		{err: errors.New("connection reset")},
+		{body: raw, status: http.StatusOK},
+	}}
+
+	f := New(Config{
+		BaseURL:    "https://block-dn.org",
+		Client:     client,
+		NumRetries: 3,
+		RetryDelay: time.Millisecond,
+	})
+
+	block, err := f.FetchBlock(nil, hash)
+	require.NoError(t, err)
+	require.Equal(t, hash, block.BlockHash())
+	require.Equal(t, 3, client.calls)
+}
+
+// TestFetchBlockRetriesExhausted asserts that we give up after the configured
+// number of attempts and surface the last error.
+func TestFetchBlockRetriesExhausted(t *testing.T) {
+	t.Parallel()
+
+	hash, _ := genesisBytes(t)
+	client := &fakeHTTPClient{responses: []fakeResp{
+		{status: http.StatusInternalServerError},
+	}}
+
+	f := New(Config{
+		BaseURL:    "https://block-dn.org",
+		Client:     client,
+		NumRetries: 3,
+		RetryDelay: time.Millisecond,
+	})
+
+	_, err := f.FetchBlock(nil, hash)
+	require.ErrorContains(t, err, "after 3 attempt(s)")
+	require.ErrorContains(t, err, "status code 500")
+	require.Equal(t, 3, client.calls)
+}
+
+// TestFetchBlockBadBytes asserts that an undeserializable body is treated as a
+// failure and retried.
+func TestFetchBlockBadBytes(t *testing.T) {
+	t.Parallel()
+
+	hash, _ := genesisBytes(t)
+	client := &fakeHTTPClient{responses: []fakeResp{
+		{body: []byte("not a block"), status: http.StatusOK},
+	}}
+
+	f := New(Config{
+		BaseURL:    "https://block-dn.org",
+		Client:     client,
+		NumRetries: 2,
+		RetryDelay: time.Millisecond,
+	})
+
+	_, err := f.FetchBlock(nil, hash)
+	require.ErrorContains(t, err, "failed to deserialize block")
+	require.Equal(t, 2, client.calls)
+}
+
+// TestFetchBlockHashMismatch asserts that a well-formed block that doesn't
+// match the requested hash is rejected, guarding against a source serving the
+// wrong block.
+func TestFetchBlockHashMismatch(t *testing.T) {
+	t.Parallel()
+
+	_, raw := genesisBytes(t)
+
+	// Request a different block (testnet genesis) but have the source serve
+	// the mainnet genesis block.
+	wrongHash := *chaincfg.TestNet3Params.GenesisHash
+	client := &fakeHTTPClient{responses: []fakeResp{
+		{body: raw, status: http.StatusOK},
+	}}
+
+	f := New(Config{
+		BaseURL:    "https://block-dn.org",
+		Client:     client,
+		NumRetries: 1,
+	})
+
+	_, err := f.FetchBlock(nil, wrongHash)
+	require.ErrorContains(t, err, "returned block")
+	require.Equal(t, 1, client.calls)
+}
+
+// TestFetchBlockQuit asserts that closing the quit channel aborts the fetch
+// immediately with ErrShuttingDown.
+func TestFetchBlockQuit(t *testing.T) {
+	t.Parallel()
+
+	hash, _ := genesisBytes(t)
+	client := &fakeHTTPClient{responses: []fakeResp{
+		{status: http.StatusInternalServerError},
+	}}
+
+	quit := make(chan struct{})
+	close(quit)
+
+	f := New(Config{BaseURL: "https://block-dn.org", Client: client})
+
+	_, err := f.FetchBlock(quit, hash)
+	require.ErrorIs(t, err, ErrShuttingDown)
+	require.Equal(t, 0, client.calls)
+}
+
+// TestNewDefaults asserts that New fills in sane defaults for unset config
+// fields.
+func TestNewDefaults(t *testing.T) {
+	t.Parallel()
+
+	f := New(Config{BaseURL: "https://block-dn.org"})
+	require.Equal(t, DefaultNumRetries, f.numRetries)
+	require.Equal(t, DefaultRetryDelay, f.retryDelay)
+	require.Equal(t, "https://block-dn.org", f.baseURL)
+
+	// The default client must be a real *http.Client with a timeout set.
+	httpClient, ok := f.client.(*http.Client)
+	require.True(t, ok)
+	require.Equal(t, DefaultRequestTimeout, httpClient.Timeout)
+}

--- a/blockfetch/log.go
+++ b/blockfetch/log.go
@@ -1,0 +1,25 @@
+package blockfetch
+
+import "github.com/btcsuite/btclog"
+
+// log is a logger that is initialized with no output filters. This means the
+// package will not perform any logging by default until the caller requests
+// it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	DisableLog()
+}
+
+// DisableLog disables all library log output. Logging output is disabled by
+// default until UseLogger is called.
+func DisableLog() {
+	log = btclog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info. This should
+// be used in preference to SetLogWriter if the caller is also using btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/log.go
+++ b/log.go
@@ -7,6 +7,7 @@ import (
 	"github.com/btcsuite/btcd/peer"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btclog"
+	"github.com/lightninglabs/neutrino/blockfetch"
 	"github.com/lightninglabs/neutrino/blockntfns"
 	"github.com/lightninglabs/neutrino/chainimport"
 	"github.com/lightninglabs/neutrino/chanutils"
@@ -47,4 +48,5 @@ func UseLogger(logger btclog.Logger) {
 	filterdb.UseLogger(logger)
 	chanutils.UseLogger(logger)
 	chainimport.UseLogger(logger)
+	blockfetch.UseLogger(logger)
 }

--- a/neutrino.go
+++ b/neutrino.go
@@ -24,6 +24,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightninglabs/neutrino/banman"
+	"github.com/lightninglabs/neutrino/blockfetch"
 	"github.com/lightninglabs/neutrino/blockntfns"
 	"github.com/lightninglabs/neutrino/cache/lru"
 	"github.com/lightninglabs/neutrino/chainimport"
@@ -610,6 +611,14 @@ type Config struct {
 	// synchronization.
 	HeadersImport *HeadersImportConfig
 
+	// BlockSource, when set, configures an HTTP(S) source from which full
+	// blocks are downloaded. When configured, GetBlock attempts to fetch a
+	// block from this source first and only falls back to the P2P network
+	// if the HTTP fetch fails. When nil, blocks are fetched exclusively
+	// from peers, as before. Block caching behaves identically regardless
+	// of where a block is ultimately fetched from.
+	BlockSource *BlockSourceConfig
+
 	// AssertFilterHeader is an optional field that allows the creator of
 	// the ChainService to ensure that if any chain data exists, it's
 	// compliant with the expected filter header state. If neutrino starts
@@ -663,6 +672,30 @@ type HeadersImportConfig struct {
 	ValidationFlags blockchain.BehaviorFlags
 }
 
+// BlockSourceConfig contains the configuration for downloading full blocks
+// from an HTTP(S) source (such as block-dn) before falling back to the P2P
+// network.
+type BlockSourceConfig struct {
+	// BaseURL is the base URL of the HTTP block source, e.g.
+	// "https://block-dn.org". Individual blocks are downloaded from
+	// "<BaseURL>/block/<hash>".
+	BaseURL string
+
+	// Client is an optional HTTP client used to issue requests. If nil, a
+	// default client is used. This can be set to route requests through a
+	// proxy, or to inject a custom client in tests.
+	Client blockfetch.HTTPClient
+
+	// NumRetries is the number of times an individual block download is
+	// attempted before falling back to the P2P network. If zero, a default
+	// is used.
+	NumRetries int
+
+	// RetryDelay is the delay between download attempts. If zero, a default
+	// is used.
+	RetryDelay time.Duration
+}
+
 // peerSubscription holds a peer subscription which we'll notify about any
 // connected peers.
 type peerSubscription struct {
@@ -685,6 +718,10 @@ type ChainService struct { // nolint:maligned
 	persistToDisk    bool
 
 	headersImport *HeadersImportConfig
+
+	// blockFetcher, when non-nil, downloads blocks from an HTTP block
+	// source. GetBlock tries it before falling back to the P2P network.
+	blockFetcher *blockfetch.BlockFetcher
 
 	FilterCache *lru.Cache[FilterCacheKey, *CacheableFilter]
 	BlockCache  *lru.Cache[wire.InvVect, *CacheableBlock]
@@ -829,6 +866,17 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		s.BlockCache = lru.NewCache[wire.InvVect, *CacheableBlock](
 			blockCacheSize,
 		)
+	}
+
+	// If an HTTP block source was configured, set up the fetcher that
+	// GetBlock will try before falling back to the P2P network.
+	if cfg.BlockSource != nil {
+		s.blockFetcher = blockfetch.New(blockfetch.Config{
+			BaseURL:    cfg.BlockSource.BaseURL,
+			Client:     cfg.BlockSource.Client,
+			NumRetries: cfg.BlockSource.NumRetries,
+			RetryDelay: cfg.BlockSource.RetryDelay,
+		})
 	}
 
 	s.BlockHeaders, err = headerfs.NewBlockHeaderStore(

--- a/query.go
+++ b/query.go
@@ -863,36 +863,16 @@ func (s *ChainService) GetBlock(blockHash chainhash.Hash,
 			block.SetHeight(int32(height))
 		}
 
-		// If this claims our block but doesn't pass the sanity check,
-		// the peer is trying to bamboozle us.
-		if err := blockchain.CheckBlockSanity(
-			block,
-			// We don't need to check PoW because by the time we get
-			// here, it's been checked during header synchronization
-			s.chainParams.PowLimit,
-			s.timeSource,
-		); err != nil {
-			log.Warnf("Invalid block for %s received from %s: %v",
-				blockHash, peer, err)
-
-			// Ban and disconnect the peer.
-			err = s.BanPeer(peer, banman.InvalidBlock)
-			if err != nil {
-				log.Errorf("Unable to ban peer %v: %v", peer,
-					err)
-			}
-
-			return noProgress
-		}
-
-		if err := blockchain.ValidateWitnessCommitment(
-			block,
-		); err != nil {
+		// If this claims our block but doesn't pass our validation
+		// checks, the peer is trying to bamboozle us.
+		if err := s.validateBlock(block); err != nil {
 			log.Warnf("Invalid block for %s received from %s: %v "+
 				"-- disconnecting peer", blockHash, peer, err)
 
-			err = s.BanPeer(peer, banman.InvalidBlock)
-			if err != nil {
+			// Ban and disconnect the peer.
+			if err := s.BanPeer(
+				peer, banman.InvalidBlock,
+			); err != nil {
 				log.Errorf("Unable to ban peer %v: %v", peer,
 					err)
 			}
@@ -940,12 +920,39 @@ func (s *ChainService) GetBlock(blockHash chainhash.Hash,
 	}
 
 	// Add block to the cache before returning it.
-	_, err = s.BlockCache.Put(*inv, &CacheableBlock{Block: foundBlock})
+	s.cacheBlock(*inv, foundBlock)
+
+	return foundBlock, nil
+}
+
+// validateBlock checks that the given block passes the consensus-level sanity
+// checks we require before accepting it for the given hash, regardless of the
+// source it was obtained from (a peer or an HTTP block source). It
+// deliberately has no side effects (such as peer banning) so that the caller
+// can decide how to react to an invalid block based on its origin.
+//
+// We don't need to check the proof of work because by the time we get here the
+// block's header has already been validated during header synchronization.
+func (s *ChainService) validateBlock(block *btcutil.Block) error {
+	if err := blockchain.CheckBlockSanity(
+		block, s.chainParams.PowLimit, s.timeSource,
+	); err != nil {
+		return err
+	}
+
+	return blockchain.ValidateWitnessCommitment(block)
+}
+
+// cacheBlock stores the given block in the block cache under the provided
+// inventory vector. A failure to cache is logged but not returned, since it
+// doesn't affect the validity of the block we're about to hand back to the
+// caller. This is shared by all block sources so caching behaves identically
+// no matter where a block came from.
+func (s *ChainService) cacheBlock(inv wire.InvVect, block *btcutil.Block) {
+	_, err := s.BlockCache.Put(inv, &CacheableBlock{Block: block})
 	if err != nil {
 		log.Warnf("couldn't write block to cache: %v", err)
 	}
-
-	return foundBlock, nil
 }
 
 // sendTransaction sends a transaction to all peers. It returns an error if any

--- a/query.go
+++ b/query.go
@@ -830,6 +830,23 @@ func (s *ChainService) GetBlock(blockHash chainhash.Hash,
 		return nil, err
 	}
 
+	// If an HTTP block source is configured, try to fetch the block from
+	// there first. We only fall back to the P2P network below if the HTTP
+	// fetch (including its own retries) fails or returns a block that
+	// doesn't pass our validation. Caching happens here exactly as it does
+	// for the peer path, so the cache behaves identically regardless of
+	// where the block ultimately comes from.
+	if s.blockFetcher != nil {
+		block, err := s.fetchBlockFromSource(blockHash, height)
+		if err == nil {
+			s.cacheBlock(*inv, block)
+			return block, nil
+		}
+
+		log.Warnf("Unable to fetch block %v from HTTP source, falling "+
+			"back to peers: %v", blockHash, err)
+	}
+
 	// Construct the appropriate getdata message to fetch the target block.
 	getData := wire.NewMsgGetData()
 	_ = getData.AddInvVect(inv)
@@ -953,6 +970,34 @@ func (s *ChainService) cacheBlock(inv wire.InvVect, block *btcutil.Block) {
 	if err != nil {
 		log.Warnf("couldn't write block to cache: %v", err)
 	}
+}
+
+// fetchBlockFromSource downloads the block with the given hash from the
+// configured HTTP block source and runs it through the same consensus
+// validation we apply to blocks received from peers. Unlike the peer path, an
+// invalid block here only results in an error (so GetBlock falls back to the
+// network), as there's no peer to ban.
+func (s *ChainService) fetchBlockFromSource(blockHash chainhash.Hash,
+	height uint32) (*btcutil.Block, error) {
+
+	msgBlock, err := s.blockFetcher.FetchBlock(s.quit, blockHash)
+	if err != nil {
+		return nil, err
+	}
+
+	block := btcutil.NewBlock(msgBlock)
+
+	// Only set height if btcutil hasn't automagically put one in.
+	if block.Height() == btcutil.BlockHeightUnknown {
+		block.SetHeight(int32(height))
+	}
+
+	if err := s.validateBlock(block); err != nil {
+		return nil, fmt.Errorf("block %v from HTTP source failed "+
+			"validation: %w", blockHash, err)
+	}
+
+	return block, nil
 }
 
 // sendTransaction sends a transaction to all peers. It returns an error if any


### PR DESCRIPTION
## Change Description

Neutrino currently fetches full blocks exclusively from P2P peers, routed
through the query work manager's scheduling/queue mechanism (`GetBlock` in
`query.go`). This PR adds an **optional** HTTP(S) block source: when configured,
`GetBlock` downloads a block from an HTTP server first and only falls back to
the P2P network if the HTTP fetch fails.

This complements the recently merged HTTP header side-load (`chainimport`): a
client can now side-load headers *and* pull full blocks from an HTTP source
such as [block-dn](https://block-dn.org), reaching a usable state much faster
and leaning on peers only as a fallback. Importantly, the block source is
**not** a trusted component for correctness — a downloaded block is fully
verified against the already-validated header chain (see
[Trust Assumptions](#trust-assumptions) below).

### Behavior

The block lookup order in `GetBlock` becomes:

1. **Block cache** — unchanged; checked first, so an in-memory block never
   triggers a network fetch.
2. **HTTP source** — only if `Config.BlockSource` is set. The fetcher retries a
   configurable number of times and aborts on shutdown.
3. **P2P peers** — the existing work-manager path, used unchanged whenever no
   HTTP source is configured or the HTTP fetch fails (transport error, non-200,
   undeserializable body, wrong block returned, or a block that fails our
   consensus validation).

Blocks obtained over HTTP are validated with the **same** consensus checks
(`CheckBlockSanity` + `ValidateWitnessCommitment`) applied to blocks received
from peers, and are written to the block cache in the **same** way. A block
that fails validation simply causes a fall-back to peers — there's no peer to
ban, unlike the P2P path. The fetcher additionally verifies that the bytes
returned by the server actually hash to the requested block hash, so a
misbehaving server can't substitute a different block.

The feature is **off by default** and fully backwards compatible: a nil
`Config.BlockSource` preserves the existing peer-only behavior exactly. No
RPC, wire, on-disk, or existing config surface changes.

### The block-dn contract

block-dn serves an individual block at `GET /block/<hash>` as a raw,
witness-encoded block in Bitcoin wire format (HTTP 200; 4xx/5xx on
error). The fetcher targets exactly this endpoint, building
`<BaseURL>/block/<hash>` and deserializing straight from the response body.
Unlike the header side-load — where the batched header files are large enough
to warrant downloading to a temp file first — a single block is small, so it's
deserialized directly with no temp-file indirection.

## Trust Assumptions

Downloading a *block* over HTTP requires **no additional trust** beyond what
Neutrino already establishes for the header chain. A block is self-certifying
against its header, so the HTTP server is untrusted for correctness:

- The block hash *is* the hash of its 80-byte header. We only ever request a
  block whose header we already hold, and the fetcher rejects any response
  whose bytes don't hash to that exact hash. A different or corrupt block (or
  an undeserializable body) is caught immediately.
- The header commits to the transaction set via its merkle root, which
  `CheckBlockSanity` recomputes from the downloaded transactions and compares
  against the header. Adding, removing, reordering, or tampering with any
  transaction is detected.
- `ValidateWitnessCommitment` verifies the segwit witness commitment, so
  witness data can't be forged either.
- The header chain that those hashes come from is itself validated by
  proof-of-work and, during P2P sync, cross-checked against multiple peers —
  exactly as today. **This PR does not change how headers are obtained or
  validated**, only where the block *bytes* come from.

So the strongest a malicious or buggy server can do on the correctness axis is
serve a wrong, corrupt, or otherwise-invalid block — all of which we detect and
reject, then fall back to the P2P network. It cannot make us accept a block
that doesn't match the header chain we already trust. This is the *same*
security property we get when a P2P peer serves us a block; in both cases the
block is trustless given a valid header.

What does change are the operational trade-offs:

**Pros**

- Faster, more reliable block retrieval (especially behind a CDN), and reduced
  load on the P2P block-serving network.
- No weakening of correctness or consensus guarantees: block validation is
  byte-for-byte identical to the peer path.
- Strictly additive and opt-in. Peer fallback means a slow, failing, or
  malicious server degrades to today's behavior rather than breaking sync.

**Cons / considerations**

- **Privacy** — the real trust consideration. A single HTTP endpoint sees your
  IP address together with exactly which blocks you request. For a wallet, the
  set of blocks fetched can leak which transactions/addresses you care about,
  and it is all observable by one party (plus any TLS-terminating CDN or
  middlebox in front of it). With P2P you can spread requests across peers and
  route over Tor; pointing at one block server concentrates that metadata.
  Operators who care about privacy should self-host the server, point at one
  they trust for privacy, and/or tunnel the requests.
- **Availability / DoS** — a server that's down, slow, or withholding blocks
  can only delay us: we retry, then fall back to peers. The retry count bounds
  the wasted effort per request. Note there's no peer-style "ban" for a server
  that keeps serving invalid blocks, so a persistently-bad endpoint is retried
  on every block until reconfigured (inefficiency, not a security issue).
- **Centralization** — relying on a single provider for blocks is a soft
  centralization pressure on an otherwise P2P system. Fallback keeps it from
  being a hard dependency, but a fleet of clients pointed at one server is a
  single point of observation (see privacy) and of failure.
- **Fallback requires peers** — the safety net is the P2P network. A client
  configured with an HTTP source *and no peers* loses no correctness, but does
  lose the availability fallback: it then depends on the server being
  reachable.
- **Transport trust only** — you rely on TLS/the CA system for transport
  integrity and on the server for availability, but never for correctness,
  since every block is verified against the header regardless of how it arrived.

### Configuration

A new optional field on `neutrino.Config`:

```go
type Config struct {
    // ...
    // BlockSource, when set, configures an HTTP(S) source from which full
    // blocks are downloaded before falling back to the P2P network.
    BlockSource *BlockSourceConfig
}

type BlockSourceConfig struct {
    // BaseURL is the base URL of the HTTP block source, e.g.
    // "https://block-dn.org". Blocks are fetched from "<BaseURL>/block/<hash>".
    BaseURL string

    // Client is an optional HTTP client (for a proxy or for tests). If nil, a
    // default client with a timeout is used.
    Client blockfetch.HTTPClient

    // NumRetries is the number of attempts before falling back to peers.
    // Defaults to 3 if zero.
    NumRetries int

    // RetryDelay is the delay between attempts. Defaults to 500ms if zero.
    RetryDelay time.Duration
}
```

The presence of `BlockSource` is the toggle; `BaseURL` is the server.
