### PR TITLE
github: pin gateway v0.6.0 (Opus 5, /gateway check)

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -3,7 +3,11 @@ name: gateway
 # Opt-in code-review bot. Triggered by a `/gateway <command>` comment on a PR
 # (e.g. `/gateway review`); review/approve commands are gated to maintainers.
 # Comment-commands only — no pull_request triggers — so fork PRs (which receive
-# no secrets) never spawn failing runs.
+# no secrets) never spawn failing runs. v0.5.0 adds the
+# pull_request_review_comment trigger: /gateway dismiss, promote, and explain
+# now also work as replies on a finding's inline thread (finding id inferred
+# from the thread when omitted). Also a comment event — same fork-PR safety
+# profile as issue_comment.
 #
 # Thin shim: the public lightninglabs/gateway-action mints an App token and
 # checks out the private gateway runtime at execution time. The runtime stays
@@ -11,6 +15,8 @@ name: gateway
 
 on:
   issue_comment:
+    types: [created]
+  pull_request_review_comment:
     types: [created]
 
 permissions:
@@ -24,25 +30,33 @@ jobs:
     # comments that look like a /gateway command so unrelated comments don't
     # spin up a no-op runner. `contains` (not `startsWith`) because the runtime
     # accepts the command at column 0 of any line, including multi-line bodies.
-    if: ${{ github.event.issue.pull_request != null && contains(github.event.comment.body, '/gateway') }}
+    if: >-
+      ${{
+        (github.event_name == 'issue_comment'
+          && github.event.issue.pull_request != null
+          && contains(github.event.comment.body, '/gateway')) ||
+        (github.event_name == 'pull_request_review_comment'
+          && contains(github.event.comment.body, '/gateway'))
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       GATEWAY_REVIEW_MODE: multi
     steps:
-      - uses: lightninglabs/gateway-action@fa29e3132c8af9cdabd9cedca3b1b6ece56d0982 # v0.4.3
+      - uses: lightninglabs/gateway-action@3a31b86adf442852801a04ddb9c6bc0f12d363da # v0.5.0
         with:
           # Pin the private runtime to an immutable commit (matches the action
           # SHA-pin above) so runtime upgrades go through a neutrino PR, not a
-          # moved tag. Without this, runtime_ref defaults to the v0.4.3 tag.
-          runtime_ref: bb11d9744cd6fe7fbeeb9de720fc8a74b5232a8e # v0.4.3
+          # moved tag. Without this, runtime_ref defaults to the v0.5.0 tag.
+          runtime_ref: b7490e68db31b391becfe9534e947b8004fc518b # v0.5.0
           event_name:      ${{ github.event_name }}
           event_action:    ${{ github.event.action }}
           repo:            ${{ github.repository }}
-          pr_number:       ${{ github.event.issue.number }}
+          pr_number:       ${{ github.event.issue.number || github.event.pull_request.number }}
           actor:           ${{ github.event.sender.login }}
           comment_body:    ${{ github.event.comment.body }}
           comment_id:      ${{ github.event.comment.id }}
+          comment_in_reply_to: ${{ github.event.comment.in_reply_to_id }}
           installation_id: 131566347
           app_id:                  ${{ secrets.GATEWAY_APP_ID }}
           private_key:             ${{ secrets.GATEWAY_PRIVATE_KEY }}

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -3,7 +3,7 @@ name: gateway
 # Opt-in code-review bot. Triggered by a `/gateway <command>` comment on a PR
 # (e.g. `/gateway review`); review/approve commands are gated to maintainers.
 # Comment-commands only — no pull_request triggers — so fork PRs (which receive
-# no secrets) never spawn failing runs. v0.5.0 adds the
+# no secrets) never spawn failing runs. v0.5.0 added the
 # pull_request_review_comment trigger: /gateway dismiss, promote, and explain
 # now also work as replies on a finding's inline thread (finding id inferred
 # from the thread when omitted). Also a comment event — same fork-PR safety
@@ -43,12 +43,12 @@ jobs:
     env:
       GATEWAY_REVIEW_MODE: multi
     steps:
-      - uses: lightninglabs/gateway-action@3a31b86adf442852801a04ddb9c6bc0f12d363da # v0.5.0
+      - uses: lightninglabs/gateway-action@334a8455ee316e40668ae3ac85249150c62704ec # v0.6.0
         with:
           # Pin the private runtime to an immutable commit (matches the action
           # SHA-pin above) so runtime upgrades go through a neutrino PR, not a
-          # moved tag. Without this, runtime_ref defaults to the v0.5.0 tag.
-          runtime_ref: b7490e68db31b391becfe9534e947b8004fc518b # v0.5.0
+          # moved tag. Without this, runtime_ref defaults to the v0.6.0 tag.
+          runtime_ref: 75f6e67deac362bdcfc10d10629ddcf69c0e2615 # v0.6.0
           event_name:      ${{ github.event_name }}
           event_action:    ${{ github.event.action }}
           repo:            ${{ github.repository }}


### PR DESCRIPTION
Pin the gateway shim to **v0.6.0**.

> **Retargeted.** This PR originally pinned v0.5.0. It now goes straight to v0.6.0 so neutrino lands on the current release in one step rather than merging an already-superseded version. The branch name still says `gateway-v0.5.0` — cosmetic only.

neutrino is currently on v0.4.3, so this jump also picks up everything in v0.4.4 and v0.5.0.

## Shim changes (from v0.5.0 — still required)

- `pull_request_review_comment` trigger — `/gateway dismiss`, `promote` and `explain` work as replies on a finding's inline thread, with the finding id inferred from the thread when omitted. Also a comment event, so the same fork-PR safety profile as `issue_comment`.
- Compound job guard — comment events only boot a runner when the comment actually contains `/gateway`, instead of on every comment.
- `pr_number` fallback and the `comment_in_reply_to:` input, both needed by the inline-thread path.

**v0.6.0 itself adds no trigger and no input** — its only edits here are the two SHA pins and the comment naming the default tag.

## Both pins move together

The `uses:` SHA and the `runtime_ref` SHA are bumped as a pair. `runtime_ref` is pinned deliberately rather than left to the action's default, so a runtime upgrade goes through a neutrino PR instead of a moved tag — swapping only `uses:` would leave the job running the v0.5.0 runtime while claiming v0.6.0.

## What the v0.6.0 runtime brings

- Reviews run on **Claude Opus 5**
- **`/gateway check`** — an advisory "have my fixes landed?" report. Evaluates open findings against the current diff and reports one line each (`addressed`, `partially addressed`, `unresolved`, `unclear`) with a pointer to the evidence. Bare `/gateway check` sweeps everything; `/gateway check F2 F5` narrows it. Open to PR authors, and it writes nothing — `/gateway re-review` remains the only thing that moves a finding's status.
- Inline finding headers carry **`path:line`**, so a finding copied out of GitHub keeps its location
- **`/gateway dismiss` and `/gateway promote` no longer delete the finding's comment thread** — they annotate in place and resolve it, so replies and any `/gateway explain` output survive
- The review marker records an accurate `skill_version`
