### PR TITLE
wasmtransport: add browser WebTransport support

### DIFF
--- a/headerfs/file.go
+++ b/headerfs/file.go
@@ -9,10 +9,21 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 )
 
-// ErrHeaderNotFound is returned when a target header on disk (flat file) can't
-// be found.
+// ErrHeaderNotFound is returned when a target header can't be found in a
+// header store.
 type ErrHeaderNotFound struct {
 	error
+}
+
+// NewErrHeaderNotFound returns an error indicating that a header could not be
+// read from a store.
+func NewErrHeaderNotFound(err error) *ErrHeaderNotFound {
+	return &ErrHeaderNotFound{error: err}
+}
+
+// Unwrap returns the underlying storage error.
+func (e *ErrHeaderNotFound) Unwrap() error {
+	return e.error
 }
 
 // appendRaw appends a new raw header to the end of the flat file.
@@ -64,7 +75,7 @@ func (h *headerStore) readRaw(seekDist uint64) ([]byte, error) {
 	// buffer.
 	rawHeader := make([]byte, headerSize)
 	if _, err := h.file.ReadAt(rawHeader, int64(seekDist)); err != nil {
-		return nil, &ErrHeaderNotFound{err}
+		return nil, NewErrHeaderNotFound(err)
 	}
 
 	return rawHeader, nil

--- a/internal/memstore/ban.go
+++ b/internal/memstore/ban.go
@@ -1,0 +1,102 @@
+package memstore
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/lightninglabs/neutrino/banman"
+)
+
+type banRecord struct {
+	reason     banman.Reason
+	expiration time.Time
+}
+
+// BanStore is an in-memory implementation of banman.Store.
+type BanStore struct {
+	mu      sync.Mutex
+	records map[string]banRecord
+}
+
+var _ banman.Store = (*BanStore)(nil)
+
+// NewBanStore returns an empty ban store.
+func NewBanStore() *BanStore {
+	return &BanStore{
+		records: make(map[string]banRecord),
+	}
+}
+
+func ipNetKey(ipNet *net.IPNet) (string, error) {
+	if ipNet == nil || ipNet.IP == nil {
+		return "", fmt.Errorf("IP network is required")
+	}
+	ones, bits := ipNet.Mask.Size()
+	if ones < 0 || bits == 0 {
+		return "", fmt.Errorf("invalid IP network mask")
+	}
+
+	return ipNet.String(), nil
+}
+
+// BanIPNet records a ban for an IP network.
+func (s *BanStore) BanIPNet(ipNet *net.IPNet, reason banman.Reason,
+	duration time.Duration) error {
+
+	key, err := ipNetKey(ipNet)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.records[key] = banRecord{
+		reason:     reason,
+		expiration: time.Now().Add(duration),
+	}
+	s.mu.Unlock()
+
+	return nil
+}
+
+// Status returns the current ban status for an IP network and removes expired
+// records.
+func (s *BanStore) Status(ipNet *net.IPNet) (banman.Status, error) {
+	key, err := ipNetKey(ipNet)
+	if err != nil {
+		return banman.Status{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.records[key]
+	if !ok {
+		return banman.Status{}, nil
+	}
+	if !time.Now().Before(record.expiration) {
+		delete(s.records, key)
+		return banman.Status{}, nil
+	}
+
+	return banman.Status{
+		Banned:     true,
+		Reason:     record.reason,
+		Expiration: record.expiration,
+	}, nil
+}
+
+// UnbanIPNet removes a ban for an IP network.
+func (s *BanStore) UnbanIPNet(ipNet *net.IPNet) error {
+	key, err := ipNetKey(ipNet)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	delete(s.records, key)
+	s.mu.Unlock()
+
+	return nil
+}

--- a/internal/memstore/filter.go
+++ b/internal/memstore/filter.go
@@ -1,0 +1,146 @@
+package memstore
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/btcsuite/btcd/btcutil/v2/gcs"
+	"github.com/btcsuite/btcd/btcutil/v2/gcs/builder"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/neutrino/filterdb"
+)
+
+type filterKey struct {
+	blockHash chainhash.Hash
+	typeID    filterdb.FilterType
+}
+
+// FilterStore is an in-memory implementation of filterdb.FilterDatabase.
+type FilterStore struct {
+	mu      sync.RWMutex
+	filters map[filterKey][]byte
+}
+
+var _ filterdb.FilterDatabase = (*FilterStore)(nil)
+
+// NewFilterStore returns a filter store initialized with the basic genesis
+// filter for the target chain.
+func NewFilterStore(params *chaincfg.Params) (*FilterStore, error) {
+	if params == nil {
+		return nil, fmt.Errorf("chain parameters are required")
+	}
+
+	genesisFilter, err := builder.BuildBasicFilter(
+		params.GenesisBlock, nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	genesisBytes, err := genesisFilter.NBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	store := &FilterStore{
+		filters: make(map[filterKey][]byte),
+	}
+	store.filters[filterKey{
+		blockHash: *params.GenesisHash,
+		typeID:    filterdb.RegularFilter,
+	}] = genesisBytes
+
+	return store, nil
+}
+
+// PutFilters stores a batch of compact filters atomically.
+func (s *FilterStore) PutFilters(filters ...*filterdb.FilterData) error {
+	type encodedFilter struct {
+		key   filterKey
+		bytes []byte
+	}
+
+	encoded := make([]encodedFilter, len(filters))
+	for i, filter := range filters {
+		if filter == nil || filter.BlockHash == nil {
+			return fmt.Errorf("filter and block hash are required")
+		}
+		if filter.Type != filterdb.RegularFilter {
+			return fmt.Errorf("unknown filter type: %v", filter.Type)
+		}
+
+		var filterBytes []byte
+		if filter.Filter != nil {
+			var err error
+			filterBytes, err = filter.Filter.NBytes()
+			if err != nil {
+				return err
+			}
+		}
+
+		encoded[i] = encodedFilter{
+			key: filterKey{
+				blockHash: *filter.BlockHash,
+				typeID:    filter.Type,
+			},
+			bytes: filterBytes,
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, filter := range encoded {
+		s.filters[filter.key] = filter.bytes
+	}
+
+	return nil
+}
+
+// FetchFilter returns the compact filter for a block hash and filter type.
+func (s *FilterStore) FetchFilter(blockHash *chainhash.Hash,
+	filterType filterdb.FilterType) (*gcs.Filter, error) {
+
+	if filterType != filterdb.RegularFilter {
+		return nil, fmt.Errorf("unknown filter type: %v", filterType)
+	}
+
+	s.mu.RLock()
+	filterBytes, ok := s.filters[filterKey{
+		blockHash: *blockHash,
+		typeID:    filterType,
+	}]
+	if ok {
+		filterBytes = append([]byte(nil), filterBytes...)
+	}
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, filterdb.ErrFilterNotFound
+	}
+	if len(filterBytes) == 0 {
+		return nil, nil
+	}
+
+	return gcs.FromNBytes(
+		builder.DefaultP, builder.DefaultM, filterBytes,
+	)
+}
+
+// PurgeFilters removes all filters of the requested type.
+func (s *FilterStore) PurgeFilters(filterType filterdb.FilterType) error {
+	if filterType != filterdb.RegularFilter {
+		return fmt.Errorf("unknown filter type: %v", filterType)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for key := range s.filters {
+		if key.typeID == filterType {
+			delete(s.filters, key)
+		}
+	}
+
+	return nil
+}

--- a/internal/memstore/header.go
+++ b/internal/memstore/header.go
@@ -1,0 +1,441 @@
+package memstore
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil/v2/gcs/builder"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/neutrino/headerfs"
+)
+
+// BlockHeaderStore is an in-memory implementation of
+// headerfs.BlockHeaderStore.
+type BlockHeaderStore struct {
+	mu      sync.RWMutex
+	headers []wire.BlockHeader
+	heights map[chainhash.Hash]uint32
+}
+
+var _ headerfs.BlockHeaderStore = (*BlockHeaderStore)(nil)
+
+// NewBlockHeaderStore returns a block header store initialized with the
+// target chain's genesis header.
+func NewBlockHeaderStore(params *chaincfg.Params) *BlockHeaderStore {
+	genesis := params.GenesisBlock.Header
+
+	return &BlockHeaderStore{
+		headers: []wire.BlockHeader{genesis},
+		heights: map[chainhash.Hash]uint32{
+			genesis.BlockHash(): 0,
+		},
+	}
+}
+
+// ChainTip returns the best known block header and height.
+func (s *BlockHeaderStore) ChainTip() (*wire.BlockHeader, uint32, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	height := uint32(len(s.headers) - 1)
+	header := s.headers[height]
+	return &header, height, nil
+}
+
+// LatestBlockLocator returns a locator rooted at the current chain tip.
+func (s *BlockHeaderStore) LatestBlockLocator() (blockchain.BlockLocator,
+	error) {
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	height := uint32(len(s.headers) - 1)
+	locator := make(blockchain.BlockLocator, 0, 12)
+	decrement := uint32(1)
+
+	for {
+		hash := s.headers[height].BlockHash()
+		locator = append(locator, &hash)
+		if height == 0 || len(locator) == wire.MaxBlockLocatorsPerMsg {
+			return locator, nil
+		}
+
+		if len(locator) > 10 {
+			decrement *= 2
+		}
+		if decrement > height {
+			height = 0
+		} else {
+			height -= decrement
+		}
+	}
+}
+
+// FetchHeaderByHeight returns the block header at the requested height.
+func (s *BlockHeaderStore) FetchHeaderByHeight(
+	height uint32) (*wire.BlockHeader, error) {
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if uint64(height) >= uint64(len(s.headers)) {
+		return nil, headerfs.NewErrHeaderNotFound(io.EOF)
+	}
+
+	header := s.headers[height]
+	return &header, nil
+}
+
+// FetchHeaderAncestors returns the requested inclusive header range ending at
+// stopHash.
+func (s *BlockHeaderStore) FetchHeaderAncestors(numHeaders uint32,
+	stopHash *chainhash.Hash) ([]wire.BlockHeader, uint32, error) {
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	endHeight, ok := s.heights[*stopHash]
+	if !ok {
+		return nil, 0, headerfs.ErrHashNotFound
+	}
+	if numHeaders > endHeight {
+		return nil, 0, headerfs.NewErrHeaderNotFound(io.EOF)
+	}
+	startHeight := endHeight - numHeaders
+
+	headers := append(
+		[]wire.BlockHeader(nil), s.headers[startHeight:endHeight+1]...,
+	)
+	return headers, startHeight, nil
+}
+
+// HeightFromHash returns the height of a block hash.
+func (s *BlockHeaderStore) HeightFromHash(
+	hash *chainhash.Hash) (uint32, error) {
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	height, ok := s.heights[*hash]
+	if !ok {
+		return 0, headerfs.ErrHashNotFound
+	}
+
+	return height, nil
+}
+
+// FetchHeader returns a block header and its height by block hash.
+func (s *BlockHeaderStore) FetchHeader(
+	hash *chainhash.Hash) (*wire.BlockHeader, uint32, error) {
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	height, ok := s.heights[*hash]
+	if !ok {
+		return nil, 0, headerfs.ErrHashNotFound
+	}
+
+	header := s.headers[height]
+	return &header, height, nil
+}
+
+// WriteHeaders appends a contiguous batch of block headers atomically.
+func (s *BlockHeaderStore) WriteHeaders(hdrs ...headerfs.BlockHeader) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	nextHeight := uint32(len(s.headers))
+	for i := range hdrs {
+		if hdrs[i].BlockHeader == nil {
+			return fmt.Errorf("block header is required")
+		}
+		if hdrs[i].Height != nextHeight+uint32(i) {
+			return fmt.Errorf("non-contiguous block header height %d, "+
+				"expected %d", hdrs[i].Height,
+				nextHeight+uint32(i))
+		}
+	}
+
+	newHeaders := make([]wire.BlockHeader, len(hdrs))
+	for i := range hdrs {
+		newHeaders[i] = *hdrs[i].BlockHeader
+	}
+
+	for i := range newHeaders {
+		height := nextHeight + uint32(i)
+		s.headers = append(s.headers, newHeaders[i])
+		s.heights[newHeaders[i].BlockHash()] = height
+	}
+
+	return nil
+}
+
+// RollbackBlockHeaders removes headers from the tip without removing genesis.
+func (s *BlockHeaderStore) RollbackBlockHeaders(
+	numHeaders uint32) (*headerfs.BlockStamp, error) {
+
+	if numHeaders == 0 {
+		return &headerfs.BlockStamp{}, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tipHeight := uint32(len(s.headers) - 1)
+	if numHeaders > tipHeight {
+		return nil, fmt.Errorf("cannot roll back %d headers when chain "+
+			"height is %d", numHeaders, tipHeight)
+	}
+
+	newHeight := tipHeight - numHeaders
+	for height := newHeight + 1; height <= tipHeight; height++ {
+		delete(s.heights, s.headers[height].BlockHash())
+	}
+	s.headers = s.headers[:newHeight+1]
+
+	newTip := s.headers[newHeight]
+	return &headerfs.BlockStamp{
+		Height:    int32(newHeight),
+		Hash:      newTip.BlockHash(),
+		Timestamp: newTip.Timestamp,
+	}, nil
+}
+
+// RollbackLastBlock removes the current block header tip.
+func (s *BlockHeaderStore) RollbackLastBlock() (*headerfs.BlockStamp, error) {
+	return s.RollbackBlockHeaders(1)
+}
+
+// FilterHeaderStore is an in-memory implementation of
+// headerfs.FilterHeaderStore.
+type FilterHeaderStore struct {
+	mu          sync.RWMutex
+	headers     []chainhash.Hash
+	blockHashes []chainhash.Hash
+	heights     map[chainhash.Hash]uint32
+	blockStore  headerfs.BlockHeaderStore
+}
+
+var _ headerfs.FilterHeaderStore = (*FilterHeaderStore)(nil)
+
+// NewFilterHeaderStore returns a filter header store initialized with the
+// target chain's genesis filter header.
+func NewFilterHeaderStore(
+	params *chaincfg.Params) (*FilterHeaderStore, error) {
+	return newFilterHeaderStore(params, nil)
+}
+
+func newFilterHeaderStore(params *chaincfg.Params,
+	blockStore headerfs.BlockHeaderStore) (*FilterHeaderStore, error) {
+
+	genesisFilter, err := builder.BuildBasicFilter(
+		params.GenesisBlock, nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	genesisHeader, err := builder.MakeHeaderForFilter(
+		genesisFilter, params.GenesisBlock.Header.PrevBlock,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FilterHeaderStore{
+		headers:     []chainhash.Hash{genesisHeader},
+		blockHashes: []chainhash.Hash{*params.GenesisHash},
+		heights: map[chainhash.Hash]uint32{
+			*params.GenesisHash: 0,
+		},
+		blockStore: blockStore,
+	}, nil
+}
+
+// ChainTip returns the current filter header and height.
+func (s *FilterHeaderStore) ChainTip() (*chainhash.Hash, uint32, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	height := uint32(len(s.headers) - 1)
+	header := s.headers[height]
+	return &header, height, nil
+}
+
+// FetchHeader returns the filter header associated with a block hash.
+func (s *FilterHeaderStore) FetchHeader(
+	blockHash *chainhash.Hash) (*chainhash.Hash, error) {
+
+	height, err := s.heightFromBlockHash(blockHash)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if uint64(height) >= uint64(len(s.headers)) {
+		return nil, headerfs.NewErrHeaderNotFound(io.EOF)
+	}
+
+	header := s.headers[height]
+	return &header, nil
+}
+
+// FetchHeaderAncestors returns the requested inclusive filter header range
+// ending at stopHash.
+func (s *FilterHeaderStore) FetchHeaderAncestors(numHeaders uint32,
+	stopHash *chainhash.Hash) ([]chainhash.Hash, uint32, error) {
+
+	endHeight, err := s.heightFromBlockHash(stopHash)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if numHeaders > endHeight ||
+		uint64(endHeight) >= uint64(len(s.headers)) {
+
+		return nil, 0, headerfs.NewErrHeaderNotFound(io.EOF)
+	}
+	startHeight := endHeight - numHeaders
+
+	headers := append(
+		[]chainhash.Hash(nil), s.headers[startHeight:endHeight+1]...,
+	)
+	return headers, startHeight, nil
+}
+
+// FetchHeaderByHeight returns the filter header at the requested height.
+func (s *FilterHeaderStore) FetchHeaderByHeight(
+	height uint32) (*chainhash.Hash, error) {
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if uint64(height) >= uint64(len(s.headers)) {
+		return nil, headerfs.NewErrHeaderNotFound(io.EOF)
+	}
+
+	header := s.headers[height]
+	return &header, nil
+}
+
+// WriteHeaders appends a contiguous batch of filter headers atomically.
+func (s *FilterHeaderStore) WriteHeaders(
+	hdrs ...headerfs.FilterHeader) error {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(hdrs) == 0 {
+		return nil
+	}
+
+	nextHeight := uint32(len(s.headers))
+	lastHeader := hdrs[len(hdrs)-1]
+	expectedTipHeight := nextHeight + uint32(len(hdrs)) - 1
+	if lastHeader.Height != expectedTipHeight {
+		return fmt.Errorf("filter header tip height %d, expected %d",
+			lastHeader.Height, expectedTipHeight)
+	}
+
+	if s.blockStore != nil {
+		tipHeight, err := s.blockStore.HeightFromHash(
+			&lastHeader.HeaderHash,
+		)
+		if err != nil {
+			return fmt.Errorf("filter header tip block hash: %w", err)
+		}
+		if tipHeight != expectedTipHeight {
+			return fmt.Errorf("filter header tip block height %d, "+
+				"expected %d", tipHeight, expectedTipHeight)
+		}
+	} else if lastHeader.HeaderHash == (chainhash.Hash{}) {
+		return fmt.Errorf("filter header tip block hash is required")
+	}
+
+	blockHashes := make([]chainhash.Hash, len(hdrs))
+	for i := range hdrs {
+		height := nextHeight + uint32(i)
+		blockHashes[i] = hdrs[i].HeaderHash
+		if s.blockStore != nil {
+			blockHeader, err := s.blockStore.FetchHeaderByHeight(height)
+			if err != nil {
+				return fmt.Errorf("filter header block at height %d: %w",
+					height, err)
+			}
+			blockHashes[i] = blockHeader.BlockHash()
+		}
+	}
+
+	for i := range hdrs {
+		height := nextHeight + uint32(i)
+		s.headers = append(s.headers, hdrs[i].FilterHash)
+		s.blockHashes = append(s.blockHashes, blockHashes[i])
+		if blockHashes[i] != (chainhash.Hash{}) {
+			s.heights[blockHashes[i]] = height
+		}
+	}
+
+	return nil
+}
+
+// RollbackLastBlock removes the current filter header tip.
+func (s *FilterHeaderStore) RollbackLastBlock(
+	newTip *chainhash.Hash) (*headerfs.BlockStamp, error) {
+
+	newTipHeight, err := s.heightFromBlockHash(newTip)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.headers) == 1 {
+		return nil, headerfs.NewErrHeaderNotFound(io.EOF)
+	}
+
+	newHeight := uint32(len(s.headers) - 2)
+	if newTipHeight != newHeight {
+		return nil, fmt.Errorf("filter header rollback tip mismatch")
+	}
+
+	oldHeight := newHeight + 1
+	delete(s.heights, s.blockHashes[oldHeight])
+	s.headers = s.headers[:oldHeight]
+	s.blockHashes = s.blockHashes[:oldHeight]
+
+	return &headerfs.BlockStamp{
+		Height: int32(newHeight),
+		Hash:   s.headers[newHeight],
+	}, nil
+}
+
+func (s *FilterHeaderStore) heightFromBlockHash(
+	blockHash *chainhash.Hash) (uint32, error) {
+
+	if blockHash == nil {
+		return 0, headerfs.ErrHashNotFound
+	}
+	if s.blockStore != nil {
+		return s.blockStore.HeightFromHash(blockHash)
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	height, ok := s.heights[*blockHash]
+	if !ok {
+		return 0, headerfs.ErrHashNotFound
+	}
+
+	return height, nil
+}

--- a/internal/memstore/store_test.go
+++ b/internal/memstore/store_test.go
@@ -1,0 +1,347 @@
+package memstore
+
+import (
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2/gcs/builder"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/neutrino/banman"
+	"github.com/lightninglabs/neutrino/filterdb"
+	"github.com/lightninglabs/neutrino/headerfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStoresInitializesGenesis(t *testing.T) {
+	t.Parallel()
+
+	stores, err := New(&chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	blockTip, blockHeight, err := stores.BlockHeaders.ChainTip()
+	require.NoError(t, err)
+	require.Zero(t, blockHeight)
+	require.Equal(t, chaincfg.SimNetParams.GenesisBlock.Header, *blockTip)
+
+	genesisFilter, err := builder.BuildBasicFilter(
+		chaincfg.SimNetParams.GenesisBlock, nil,
+	)
+	require.NoError(t, err)
+	storedFilter, err := stores.FilterDB.FetchFilter(
+		chaincfg.SimNetParams.GenesisHash, filterdb.RegularFilter,
+	)
+	require.NoError(t, err)
+	require.Equal(t, genesisFilter, storedFilter)
+
+	expectedFilterHeader, err := builder.MakeHeaderForFilter(
+		genesisFilter,
+		chaincfg.SimNetParams.GenesisBlock.Header.PrevBlock,
+	)
+	require.NoError(t, err)
+	filterTip, filterHeight, err := stores.RegFilterHeaders.ChainTip()
+	require.NoError(t, err)
+	require.Zero(t, filterHeight)
+	require.Equal(t, expectedFilterHeader, *filterTip)
+}
+
+func TestNewStoresRequiresParams(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(nil)
+	require.EqualError(t, err, "chain parameters are required")
+}
+
+func testBlockHeaders(count uint32) []headerfs.BlockHeader {
+	headers := make([]headerfs.BlockHeader, count)
+	prevHash := *chaincfg.SimNetParams.GenesisHash
+
+	for i := uint32(0); i < count; i++ {
+		header := chaincfg.SimNetParams.GenesisBlock.Header
+		header.PrevBlock = prevHash
+		header.Timestamp = header.Timestamp.Add(
+			time.Duration(i+1) * time.Minute,
+		)
+		header.Nonce += i + 1
+		headers[i] = headerfs.BlockHeader{
+			BlockHeader: &header,
+			Height:      i + 1,
+		}
+		prevHash = header.BlockHash()
+	}
+
+	return headers
+}
+
+func TestBlockHeaderStoreOperations(t *testing.T) {
+	t.Parallel()
+
+	store := NewBlockHeaderStore(&chaincfg.SimNetParams)
+	headers := testBlockHeaders(20)
+	require.NoError(t, store.WriteHeaders(headers...))
+
+	tip, height, err := store.ChainTip()
+	require.NoError(t, err)
+	require.EqualValues(t, 20, height)
+	require.Equal(t, *headers[19].BlockHeader, *tip)
+
+	tipHash := tip.BlockHash()
+	fetched, fetchedHeight, err := store.FetchHeader(&tipHash)
+	require.NoError(t, err)
+	require.Equal(t, tip, fetched)
+	require.Equal(t, height, fetchedHeight)
+
+	ancestors, startHeight, err := store.FetchHeaderAncestors(3, &tipHash)
+	require.NoError(t, err)
+	require.EqualValues(t, 17, startHeight)
+	require.Len(t, ancestors, 4)
+	require.Equal(t, *headers[16].BlockHeader, ancestors[0])
+
+	locator, err := store.LatestBlockLocator()
+	require.NoError(t, err)
+	require.Equal(t, tipHash, *locator[0])
+	require.Equal(t, *chaincfg.SimNetParams.GenesisHash,
+		*locator[len(locator)-1])
+
+	missing := chainhash.HashH([]byte("missing"))
+	_, err = store.FetchHeaderByHeight(21)
+	var headerNotFound *headerfs.ErrHeaderNotFound
+	require.ErrorAs(t, err, &headerNotFound)
+	require.ErrorIs(t, err, io.EOF)
+	_, err = store.HeightFromHash(&missing)
+	require.ErrorIs(t, err, headerfs.ErrHashNotFound)
+
+	stamp, err := store.RollbackBlockHeaders(2)
+	require.NoError(t, err)
+	require.EqualValues(t, 18, stamp.Height)
+	_, _, err = store.FetchHeader(&tipHash)
+	require.ErrorIs(t, err, headerfs.ErrHashNotFound)
+
+	_, err = store.RollbackBlockHeaders(19)
+	require.EqualError(t, err,
+		"cannot roll back 19 headers when chain height is 18")
+}
+
+func TestBlockHeaderStoreRejectsNonContiguousBatch(t *testing.T) {
+	t.Parallel()
+
+	store := NewBlockHeaderStore(&chaincfg.SimNetParams)
+	headers := testBlockHeaders(2)
+	headers[1].Height = 3
+
+	err := store.WriteHeaders(headers...)
+	require.EqualError(t, err,
+		"non-contiguous block header height 3, expected 2")
+	_, height, err := store.ChainTip()
+	require.NoError(t, err)
+	require.Zero(t, height)
+}
+
+func TestFilterHeaderStoreOperations(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewFilterHeaderStore(&chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	blockHash1 := chainhash.HashH([]byte("block-1"))
+	blockHash2 := chainhash.HashH([]byte("block-2"))
+	filterHash1 := chainhash.HashH([]byte("filter-1"))
+	filterHash2 := chainhash.HashH([]byte("filter-2"))
+	require.NoError(t, store.WriteHeaders(
+		headerfs.FilterHeader{
+			HeaderHash: blockHash1,
+			FilterHash: filterHash1,
+			Height:     1,
+		},
+		headerfs.FilterHeader{
+			HeaderHash: blockHash2,
+			FilterHash: filterHash2,
+			Height:     2,
+		},
+	))
+
+	tip, height, err := store.ChainTip()
+	require.NoError(t, err)
+	require.EqualValues(t, 2, height)
+	require.Equal(t, filterHash2, *tip)
+
+	ancestors, startHeight, err := store.FetchHeaderAncestors(
+		1, &blockHash2,
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, startHeight)
+	require.Equal(t, []chainhash.Hash{filterHash1, filterHash2},
+		ancestors)
+
+	stamp, err := store.RollbackLastBlock(&blockHash1)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, stamp.Height)
+	require.Equal(t, filterHash1, stamp.Hash)
+	_, err = store.FetchHeader(&blockHash2)
+	require.ErrorIs(t, err, headerfs.ErrHashNotFound)
+}
+
+func TestFilterHeaderStoreSparseBatchMetadata(t *testing.T) {
+	t.Parallel()
+
+	stores, err := New(&chaincfg.SimNetParams)
+	require.NoError(t, err)
+	blockHeaders := testBlockHeaders(2)
+	require.NoError(t, stores.BlockHeaders.WriteHeaders(blockHeaders...))
+
+	blockHash1 := blockHeaders[0].BlockHash()
+	blockHash2 := blockHeaders[1].BlockHash()
+	filterHash1 := chainhash.HashH([]byte("filter-1"))
+	filterHash2 := chainhash.HashH([]byte("filter-2"))
+	wrongTip := chainhash.HashH([]byte("wrong-tip"))
+	err = stores.RegFilterHeaders.WriteHeaders(
+		headerfs.FilterHeader{
+			FilterHash: filterHash1,
+		},
+		headerfs.FilterHeader{
+			HeaderHash: wrongTip,
+			FilterHash: filterHash2,
+			Height:     2,
+		},
+	)
+	require.ErrorContains(t, err, "filter header tip block hash")
+	_, height, err := stores.RegFilterHeaders.ChainTip()
+	require.NoError(t, err)
+	require.Zero(t, height)
+
+	require.NoError(t, stores.RegFilterHeaders.WriteHeaders(
+		headerfs.FilterHeader{
+			FilterHash: filterHash1,
+		},
+		headerfs.FilterHeader{
+			HeaderHash: blockHash2,
+			FilterHash: filterHash2,
+			Height:     2,
+		},
+	))
+
+	stored, err := stores.RegFilterHeaders.FetchHeader(&blockHash1)
+	require.NoError(t, err)
+	require.Equal(t, filterHash1, *stored)
+	stored, err = stores.RegFilterHeaders.FetchHeader(&blockHash2)
+	require.NoError(t, err)
+	require.Equal(t, filterHash2, *stored)
+
+	ancestors, startHeight, err :=
+		stores.RegFilterHeaders.FetchHeaderAncestors(1, &blockHash2)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, startHeight)
+	require.Equal(t, []chainhash.Hash{filterHash1, filterHash2},
+		ancestors)
+
+	_, err = stores.BlockHeaders.RollbackLastBlock()
+	require.NoError(t, err)
+	stamp, err := stores.RegFilterHeaders.RollbackLastBlock(&blockHash1)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, stamp.Height)
+	require.Equal(t, filterHash1, stamp.Hash)
+}
+
+func TestFilterStoreOperations(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewFilterStore(&chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	blockHash := chainhash.HashH([]byte("block"))
+	filter, err := builder.BuildBasicFilter(
+		chaincfg.SimNetParams.GenesisBlock, nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.PutFilters(&filterdb.FilterData{
+		Filter:    filter,
+		BlockHash: &blockHash,
+		Type:      filterdb.RegularFilter,
+	}))
+
+	storedFilter, err := store.FetchFilter(
+		&blockHash, filterdb.RegularFilter,
+	)
+	require.NoError(t, err)
+	require.Equal(t, filter, storedFilter)
+
+	require.NoError(t, store.PurgeFilters(filterdb.RegularFilter))
+	_, err = store.FetchFilter(&blockHash, filterdb.RegularFilter)
+	require.ErrorIs(t, err, filterdb.ErrFilterNotFound)
+}
+
+func TestBanStoreOperations(t *testing.T) {
+	t.Parallel()
+
+	store := NewBanStore()
+	ipNet := &net.IPNet{
+		IP:   net.ParseIP("192.0.2.1"),
+		Mask: net.CIDRMask(32, 32),
+	}
+	require.NoError(t, store.BanIPNet(
+		ipNet, banman.NoCompactFilters, time.Hour,
+	))
+
+	status, err := store.Status(ipNet)
+	require.NoError(t, err)
+	require.True(t, status.Banned)
+	require.Equal(t, banman.NoCompactFilters, status.Reason)
+
+	require.NoError(t, store.UnbanIPNet(ipNet))
+	status, err = store.Status(ipNet)
+	require.NoError(t, err)
+	require.False(t, status.Banned)
+
+	require.NoError(t, store.BanIPNet(
+		ipNet, banman.NoCompactFilters, -time.Second,
+	))
+	status, err = store.Status(ipNet)
+	require.NoError(t, err)
+	require.False(t, status.Banned)
+}
+
+func TestStoresConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	stores, err := New(&chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 100)
+	for i := 0; i < 20; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			_, _, err := stores.BlockHeaders.ChainTip()
+			errs <- err
+			_, _, err = stores.RegFilterHeaders.ChainTip()
+			errs <- err
+			_, err = stores.FilterDB.FetchFilter(
+				chaincfg.SimNetParams.GenesisHash,
+				filterdb.RegularFilter,
+			)
+			errs <- err
+
+			blockHash := chainhash.HashH([]byte{byte(i)})
+			errs <- stores.FilterDB.PutFilters(&filterdb.FilterData{
+				BlockHash: &blockHash,
+				Type:      filterdb.RegularFilter,
+			})
+			_, err = stores.FilterDB.FetchFilter(
+				&blockHash, filterdb.RegularFilter,
+			)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}

--- a/internal/memstore/stores.go
+++ b/internal/memstore/stores.go
@@ -1,0 +1,42 @@
+// Package memstore provides volatile, concurrency-safe ChainService storage
+// backends for tests and integration fixtures.
+package memstore
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+)
+
+// Stores groups a complete set of in-memory ChainService storage backends.
+type Stores struct {
+	FilterDB         *FilterStore
+	BlockHeaders     *BlockHeaderStore
+	RegFilterHeaders *FilterHeaderStore
+	BanStore         *BanStore
+}
+
+// New returns a complete set of stores initialized for the target chain.
+func New(params *chaincfg.Params) (*Stores, error) {
+	if params == nil {
+		return nil, fmt.Errorf("chain parameters are required")
+	}
+
+	filterDB, err := NewFilterStore(params)
+	if err != nil {
+		return nil, err
+	}
+
+	blockHeaders := NewBlockHeaderStore(params)
+	filterHeaders, err := newFilterHeaderStore(params, blockHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Stores{
+		FilterDB:         filterDB,
+		BlockHeaders:     blockHeaders,
+		RegFilterHeaders: filterHeaders,
+		BanStore:         NewBanStore(),
+	}, nil
+}

--- a/itest/webtransport/README.md
+++ b/itest/webtransport/README.md
@@ -1,0 +1,19 @@
+# Browser WebTransport integration test
+
+This opt-in test runs a complete Neutrino `ChainService` as Go WASM in a real
+Chrome browser. It connects to a native simnet btcd process over WebTransport,
+synchronizes block and regular filter headers, and then proves that both tips
+advance after btcd mines more blocks. At each tip, it also fetches a compact
+filter through Neutrino and compares its bytes with btcd's RPC result.
+
+Build the paired btcd WebTransport branch, then run:
+
+```bash
+BTCD_WEBTRANSPORT_BIN=/absolute/path/to/btcd \
+  go test -tags=rpctest ./itest/webtransport -run TestWebTransportBrowserChainServiceSync -v
+```
+
+The test searches common Chrome and Chromium locations. Set `BTCD_CHROME_BIN`
+to an absolute browser executable path when automatic discovery is unsuitable.
+The WebTransport connection authenticates its short-lived test certificate by
+SHA-256 hash; the test does not disable TLS verification.

--- a/itest/webtransport/client/index.html
+++ b/itest/webtransport/client/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Neutrino WebTransport ChainService integration test</title>
+</head>
+<body>
+  <pre id="status">starting</pre>
+  <script src="/wasm_exec.js"></script>
+  <script>
+    const go = new Go();
+    WebAssembly.instantiateStreaming(fetch("/client.wasm"), go.importObject)
+      .then(({instance}) => go.run(instance))
+      .catch(async error => {
+        const result = {
+          status: "error",
+          phase: "bootstrap",
+          error: String(error),
+        };
+        document.getElementById("status").textContent = JSON.stringify(result);
+        await fetch("/result", {
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify(result),
+        });
+      });
+  </script>
+</body>
+</html>

--- a/itest/webtransport/client/main_js.go
+++ b/itest/webtransport/client/main_js.go
@@ -1,0 +1,383 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"syscall/js"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/neutrino"
+	"github.com/lightninglabs/neutrino/internal/memstore"
+	"github.com/lightninglabs/neutrino/wasmtransport"
+)
+
+const (
+	operationTimeout = 60 * time.Second
+	pollInterval     = 100 * time.Millisecond
+)
+
+type syncTarget struct {
+	Height           int32  `json:"height"`
+	BlockHash        string `json:"block_hash"`
+	FilterHeaderHash string `json:"filter_header_hash"`
+	FilterData       string `json:"filter_data"`
+}
+
+type browserSyncResult struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+	Phase  string `json:"phase,omitempty"`
+
+	PeerCount          int    `json:"peer_count,omitempty"`
+	BlockHeaderHeight  uint32 `json:"block_header_height,omitempty"`
+	BlockHeaderHash    string `json:"block_header_hash,omitempty"`
+	FilterHeaderHeight uint32 `json:"filter_header_height,omitempty"`
+	FilterHeaderHash   string `json:"filter_header_hash,omitempty"`
+	FilterData         string `json:"filter_data,omitempty"`
+	BestBlockHeight    int32  `json:"best_block_height,omitempty"`
+	BestBlockHash      string `json:"best_block_hash,omitempty"`
+}
+
+type promiseResult struct {
+	value js.Value
+	err   error
+}
+
+func main() {
+	if err := run(); err != nil {
+		result := browserSyncResult{
+			Status: "error",
+			Phase:  "runtime",
+			Error:  err.Error(),
+		}
+		if reportErr := report(result); reportErr != nil {
+			js.Global().Get("console").Call(
+				"error", err.Error()+"; report result: "+
+					reportErr.Error(),
+			)
+		}
+	}
+}
+
+func run() error {
+	query := js.Global().Get("URLSearchParams").New(
+		js.Global().Get("location").Get("search"),
+	)
+	endpoint, err := requiredQuery(query, "endpoint")
+	if err != nil {
+		return err
+	}
+	certificateHashHex, err := requiredQuery(query, "cert_hash")
+	if err != nil {
+		return err
+	}
+	peerAddress, err := requiredQuery(query, "peer_address")
+	if err != nil {
+		return err
+	}
+	certificateHash, err := hex.DecodeString(certificateHashHex)
+	if err != nil {
+		return fmt.Errorf("decode certificate hash: %w", err)
+	}
+
+	remote, err := net.ResolveTCPAddr("tcp", peerAddress)
+	if err != nil {
+		return fmt.Errorf("resolve configured Bitcoin peer: %w", err)
+	}
+	endpoints := wasmtransport.EndpointMap{
+		remote.String(): {
+			URL:                     endpoint,
+			ServerCertificateHashes: [][]byte{certificateHash},
+		},
+	}
+	dialer, err := wasmtransport.NewDialer(wasmtransport.DialerConfig{
+		ResolveEndpoint:  endpoints.Resolve,
+		HandshakeTimeout: 15 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("create WebTransport dialer: %w", err)
+	}
+
+	params := chaincfg.SimNetParams
+	memoryStores, err := memstore.New(&params)
+	if err != nil {
+		return fmt.Errorf("create in-memory ChainService stores: %w", err)
+	}
+
+	neutrino.UserAgentName = "neutrino-wasm-itest"
+	neutrino.UserAgentVersion = "0.0.1"
+	neutrino.MaxPeers = 1
+	neutrino.TargetOutbound = 1
+	service, err := neutrino.NewChainService(neutrino.Config{
+		ChainParams:  params,
+		ConnectPeers: []string{remote.String()},
+		Dialer:       dialer,
+		Stores: &neutrino.ChainServiceStores{
+			FilterDB:         memoryStores.FilterDB,
+			BlockHeaders:     memoryStores.BlockHeaders,
+			RegFilterHeaders: memoryStores.RegFilterHeaders,
+			BanStore:         memoryStores.BanStore,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("create ChainService: %w", err)
+	}
+	if err := service.Start(context.Background()); err != nil {
+		return fmt.Errorf("start ChainService: %w", err)
+	}
+	defer service.Stop()
+
+	initialTarget, err := fetchTarget()
+	if err != nil {
+		return fmt.Errorf("fetch initial btcd target: %w", err)
+	}
+	initialResult, err := waitForSync(
+		service, initialTarget, operationTimeout,
+	)
+	if err != nil {
+		return fmt.Errorf("initial sync: %w", err)
+	}
+	initialResult.Status = "ok"
+	initialResult.Phase = "initial"
+	if err := report(initialResult); err != nil {
+		return fmt.Errorf("report initial sync: %w", err)
+	}
+
+	advancedTarget, err := waitForHigherTarget(
+		initialTarget.Height, operationTimeout,
+	)
+	if err != nil {
+		return err
+	}
+	advancedResult, err := waitForSync(
+		service, advancedTarget, operationTimeout,
+	)
+	if err != nil {
+		return fmt.Errorf("advanced sync: %w", err)
+	}
+	advancedResult.Status = "ok"
+	advancedResult.Phase = "advanced"
+	if err := report(advancedResult); err != nil {
+		return fmt.Errorf("report advanced sync: %w", err)
+	}
+
+	return nil
+}
+
+func requiredQuery(query js.Value, key string) (string, error) {
+	value := query.Call("get", key)
+	if value.IsNull() || value.String() == "" {
+		return "", fmt.Errorf("missing %s query parameter", key)
+	}
+
+	return value.String(), nil
+}
+
+func waitForHigherTarget(currentHeight int32,
+	timeout time.Duration) (syncTarget, error) {
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		target, err := fetchTarget()
+		if err != nil {
+			return syncTarget{}, fmt.Errorf("fetch advanced btcd target: %w", err)
+		}
+		if target.Height > currentHeight {
+			return target, nil
+		}
+		time.Sleep(pollInterval)
+	}
+
+	return syncTarget{}, fmt.Errorf(
+		"timed out waiting for btcd target above height %d", currentHeight,
+	)
+}
+
+func waitForSync(service *neutrino.ChainService, target syncTarget,
+	timeout time.Duration) (browserSyncResult, error) {
+
+	deadline := time.Now().Add(timeout)
+	var last browserSyncResult
+	for time.Now().Before(deadline) {
+		blockHeader, blockHeight, err := service.BlockHeaders.ChainTip()
+		if err != nil {
+			return browserSyncResult{}, fmt.Errorf(
+				"read block-header tip: %w", err,
+			)
+		}
+		filterHeader, filterHeight, err :=
+			service.RegFilterHeaders.ChainTip()
+		if err != nil {
+			return browserSyncResult{}, fmt.Errorf(
+				"read filter-header tip: %w", err,
+			)
+		}
+		bestBlock, err := service.BestBlock()
+		if err != nil {
+			return browserSyncResult{}, fmt.Errorf("read BestBlock: %w", err)
+		}
+
+		last = browserSyncResult{
+			PeerCount:          len(service.Peers()),
+			BlockHeaderHeight:  blockHeight,
+			BlockHeaderHash:    blockHeader.BlockHash().String(),
+			FilterHeaderHeight: filterHeight,
+			FilterHeaderHash:   filterHeader.String(),
+			BestBlockHeight:    bestBlock.Height,
+			BestBlockHash:      bestBlock.Hash.String(),
+		}
+		if last.PeerCount > 0 &&
+			last.BlockHeaderHeight == uint32(target.Height) &&
+			last.FilterHeaderHeight == uint32(target.Height) &&
+			last.BestBlockHeight == target.Height &&
+			last.BlockHeaderHash == target.BlockHash &&
+			last.BestBlockHash == target.BlockHash &&
+			last.FilterHeaderHash == target.FilterHeaderHash {
+
+			blockHash, err := chainhash.NewHashFromStr(target.BlockHash)
+			if err != nil {
+				return browserSyncResult{}, fmt.Errorf(
+					"parse target block hash: %w", err,
+				)
+			}
+			filter, err := service.GetCFilter(
+				*blockHash, wire.GCSFilterRegular,
+			)
+			if err != nil {
+				return browserSyncResult{}, fmt.Errorf(
+					"fetch target compact filter: %w", err,
+				)
+			}
+			filterData, err := filter.NBytes()
+			if err != nil {
+				return browserSyncResult{}, fmt.Errorf(
+					"encode target compact filter: %w", err,
+				)
+			}
+			last.FilterData = hex.EncodeToString(filterData)
+			if last.FilterData != target.FilterData {
+				return browserSyncResult{}, fmt.Errorf(
+					"compact filter mismatch for %s", target.BlockHash,
+				)
+			}
+
+			return last, nil
+		}
+
+		time.Sleep(pollInterval)
+	}
+
+	return browserSyncResult{}, fmt.Errorf(
+		"timed out waiting for height=%d block=%s filter=%s; "+
+			"last snapshot: peers=%d block=%d/%s filter=%d/%s best=%d/%s",
+		target.Height, target.BlockHash, target.FilterHeaderHash,
+		last.PeerCount, last.BlockHeaderHeight, last.BlockHeaderHash,
+		last.FilterHeaderHeight, last.FilterHeaderHash,
+		last.BestBlockHeight, last.BestBlockHash,
+	)
+}
+
+func fetchTarget() (syncTarget, error) {
+	options := js.Global().Get("Object").New()
+	options.Set("cache", "no-store")
+	response, err := await(
+		js.Global().Call("fetch", "/target", options),
+		10*time.Second,
+	)
+	if err != nil {
+		return syncTarget{}, err
+	}
+	if !response.Get("ok").Bool() {
+		return syncTarget{}, fmt.Errorf(
+			"target request returned HTTP %d", response.Get("status").Int(),
+		)
+	}
+	value, err := await(response.Call("json"), 10*time.Second)
+	if err != nil {
+		return syncTarget{}, err
+	}
+
+	return syncTarget{
+		Height:           int32(value.Get("height").Int()),
+		BlockHash:        value.Get("block_hash").String(),
+		FilterHeaderHash: value.Get("filter_header_hash").String(),
+		FilterData:       value.Get("filter_data").String(),
+	}, nil
+}
+
+func report(result browserSyncResult) error {
+	body, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	status := js.Global().Get("document").Call("getElementById", "status")
+	status.Set("textContent", string(body))
+
+	headers := js.Global().Get("Object").New()
+	headers.Set("Content-Type", "application/json")
+	options := js.Global().Get("Object").New()
+	options.Set("method", "POST")
+	options.Set("headers", headers)
+	options.Set("body", string(body))
+	response, err := await(
+		js.Global().Call("fetch", "/result", options), 10*time.Second,
+	)
+	if err != nil {
+		return err
+	}
+	if !response.Get("ok").Bool() {
+		return fmt.Errorf(
+			"result request returned HTTP %d", response.Get("status").Int(),
+		)
+	}
+
+	return nil
+}
+
+func await(promise js.Value, timeout time.Duration) (js.Value, error) {
+	results := make(chan promiseResult, 1)
+	var resolve, reject js.Func
+	resolve = js.FuncOf(func(_ js.Value, args []js.Value) any {
+		value := js.Undefined()
+		if len(args) > 0 {
+			value = args[0]
+		}
+		results <- promiseResult{value: value}
+		resolve.Release()
+		reject.Release()
+		return nil
+	})
+	reject = js.FuncOf(func(_ js.Value, args []js.Value) any {
+		message := "JavaScript promise rejected"
+		if len(args) > 0 {
+			value := args[0]
+			if value.Type() == js.TypeObject &&
+				value.Get("message").Type() == js.TypeString {
+
+				message = value.Get("message").String()
+			}
+		}
+		results <- promiseResult{err: fmt.Errorf("%s", message)}
+		resolve.Release()
+		reject.Release()
+		return nil
+	})
+	promise.Call("then", resolve, reject)
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case result := <-results:
+		return result.value, result.err
+	case <-timer.C:
+		return js.Undefined(), fmt.Errorf("JavaScript promise timed out")
+	}
+}

--- a/itest/webtransport/webtransport_test.go
+++ b/itest/webtransport/webtransport_test.go
@@ -1,0 +1,596 @@
+//go:build rpctest
+
+package webtransport_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/integration/rpctest"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	webTransportPath = "/v1/btc-p2p"
+	wasmPeerAddress  = "127.0.0.1:18555"
+
+	initialBlockCount = 12
+	additionalBlocks  = 3
+)
+
+const wasmUserAgent = wire.DefaultUserAgent +
+	"neutrino-wasm-itest:0.0.1/"
+
+type syncTarget struct {
+	Height           int32  `json:"height"`
+	BlockHash        string `json:"block_hash"`
+	FilterHeaderHash string `json:"filter_header_hash"`
+	FilterData       string `json:"filter_data"`
+}
+
+type browserSyncResult struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+	Phase  string `json:"phase,omitempty"`
+
+	PeerCount          int    `json:"peer_count,omitempty"`
+	BlockHeaderHeight  uint32 `json:"block_header_height,omitempty"`
+	BlockHeaderHash    string `json:"block_header_hash,omitempty"`
+	FilterHeaderHeight uint32 `json:"filter_header_height,omitempty"`
+	FilterHeaderHash   string `json:"filter_header_hash,omitempty"`
+	FilterData         string `json:"filter_data,omitempty"`
+	BestBlockHeight    int32  `json:"best_block_height,omitempty"`
+	BestBlockHash      string `json:"best_block_hash,omitempty"`
+}
+
+type targetState struct {
+	mu     sync.RWMutex
+	target syncTarget
+}
+
+func (s *targetState) set(target syncTarget) {
+	s.mu.Lock()
+	s.target = target
+	s.mu.Unlock()
+}
+
+func (s *targetState) get() syncTarget {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.target
+}
+
+type chromeProcess struct {
+	cancel  context.CancelFunc
+	done    chan struct{}
+	logPath string
+	errMu   sync.Mutex
+	err     error
+	once    sync.Once
+}
+
+// TestWebTransportBrowserChainServiceSync proves that a complete Neutrino
+// ChainService running as Go WASM in Chrome can synchronize block headers and
+// regular filter headers from a full btcd node over WebTransport. The test is
+// deliberately opt-in because it requires a btcd binary containing the paired
+// WebTransport server change and a locally installed Chrome or Chromium.
+func TestWebTransportBrowserChainServiceSync(t *testing.T) {
+	btcdPath := requireBTCDWebTransportBinary(t)
+	chromePath := findChrome(t)
+	if chromePath == "" {
+		t.Skip("Chrome or Chromium not found; set BTCD_CHROME_BIN to run " +
+			"the WebTransport browser integration test")
+	}
+
+	repoRoot, fixtureDir := fixturePaths(t)
+	testDir := t.TempDir()
+	wasmPath := filepath.Join(testDir, "client.wasm")
+	buildWASMFixture(t, repoRoot, wasmPath)
+	wasmExec := readWASMExec(t)
+	indexHTML, err := os.ReadFile(filepath.Join(fixtureDir, "index.html"))
+	require.NoError(t, err)
+	wasmBinary, err := os.ReadFile(wasmPath)
+	require.NoError(t, err)
+
+	browserListener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	browserOrigin := "http://" + browserListener.Addr().String()
+
+	webTransportAddress := availableUDPAddress(t)
+	certificatePath := filepath.Join(testDir, "webtransport.cert")
+	keyPath := filepath.Join(testDir, "webtransport.key")
+	certificateHash := writeWebTransportCertificate(
+		t, certificatePath, keyPath,
+	)
+
+	harness, err := rpctest.New(
+		&chaincfg.SimNetParams, nil, []string{
+			"--webtransportlisten=" + webTransportAddress,
+			"--webtransportcert=" + certificatePath,
+			"--webtransportkey=" + keyPath,
+			"--webtransportpath=" + webTransportPath,
+			"--webtransportorigin=" + browserOrigin,
+		}, btcdPath,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := harness.TearDown(); err != nil {
+			t.Errorf("tear down btcd harness: %v", err)
+		}
+	})
+	require.NoError(t, harness.SetUp(false, 0))
+
+	_, err = harness.Client.Generate(initialBlockCount)
+	require.NoError(t, err)
+	initialTarget := currentTarget(t, harness)
+	targets := &targetState{target: initialTarget}
+
+	results := make(chan browserSyncResult, 4)
+	browserServer := newBrowserServer(
+		indexHTML, wasmExec, wasmBinary, targets, results,
+	)
+	serveError := make(chan error, 1)
+	go func() {
+		serveError <- browserServer.Serve(browserListener)
+	}()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+		if err := browserServer.Shutdown(ctx); err != nil {
+			t.Errorf("shut down browser asset server: %v", err)
+		}
+		select {
+		case err := <-serveError:
+			if err != nil && err != http.ErrServerClosed {
+				t.Errorf("browser asset server: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("browser asset server did not stop")
+		}
+	})
+
+	endpoint := "https://" + webTransportAddress + webTransportPath
+	query := make(url.Values)
+	query.Set("endpoint", endpoint)
+	query.Set("cert_hash", fmt.Sprintf("%x", certificateHash[:]))
+	query.Set("peer_address", wasmPeerAddress)
+	pageURL := browserOrigin + "/?" + query.Encode()
+
+	version, err := exec.Command(chromePath, "--version").CombinedOutput()
+	if err != nil {
+		t.Logf("unable to read Chrome version: %v", err)
+	} else {
+		t.Logf("browser: %s", strings.TrimSpace(string(version)))
+	}
+
+	chrome := startChrome(t, chromePath, pageURL, testDir)
+	t.Cleanup(chrome.stop)
+
+	initialResult := waitForBrowserResult(
+		t, chrome, results, "initial", 90*time.Second,
+	)
+	assertSyncResult(t, initialResult, initialTarget)
+	assertWebTransportRPCPeer(t, harness, webTransportAddress)
+
+	_, err = harness.Client.Generate(additionalBlocks)
+	require.NoError(t, err)
+	advancedTarget := currentTarget(t, harness)
+	require.Greater(t, advancedTarget.Height, initialTarget.Height)
+	targets.set(advancedTarget)
+
+	advancedResult := waitForBrowserResult(
+		t, chrome, results, "advanced", 60*time.Second,
+	)
+	assertSyncResult(t, advancedResult, advancedTarget)
+	assertWebTransportRPCPeer(t, harness, webTransportAddress)
+
+	t.Logf("browser ChainService synchronized block and regular filter "+
+		"headers and fetched matching compact filters over WebTransport "+
+		"from height %d to %d",
+		initialTarget.Height, advancedTarget.Height)
+}
+
+func currentTarget(t *testing.T, harness *rpctest.Harness) syncTarget {
+	t.Helper()
+
+	bestHash, bestHeight, err := harness.Client.GetBestBlock()
+	require.NoError(t, err)
+	filterHeader, err := harness.Client.GetCFilterHeader(
+		bestHash, wire.GCSFilterRegular,
+	)
+	require.NoError(t, err)
+	filter, err := harness.Client.GetCFilter(
+		bestHash, wire.GCSFilterRegular,
+	)
+	require.NoError(t, err)
+
+	return syncTarget{
+		Height:           bestHeight,
+		BlockHash:        bestHash.String(),
+		FilterHeaderHash: filterHeader.PrevFilterHeader.String(),
+		FilterData:       hex.EncodeToString(filter.Data),
+	}
+}
+
+func waitForBrowserResult(t *testing.T, chrome *chromeProcess,
+	results <-chan browserSyncResult, phase string,
+	timeout time.Duration) browserSyncResult {
+
+	t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case result := <-results:
+		if result.Status != "ok" {
+			chrome.stop()
+			t.Fatalf("browser ChainService failed during %s: %s\n%s",
+				result.Phase, result.Error, chrome.logOutput())
+		}
+		require.Equal(t, phase, result.Phase)
+		return result
+
+	case <-chrome.done:
+		t.Fatalf("Chrome exited before reporting %s sync: %v\n%s",
+			phase, chrome.exitError(), chrome.logOutput())
+
+	case <-timer.C:
+		chrome.stop()
+		t.Fatalf("timed out waiting for browser %s sync\n%s",
+			phase, chrome.logOutput())
+	}
+
+	return browserSyncResult{}
+}
+
+func assertSyncResult(t *testing.T, result browserSyncResult,
+	target syncTarget) {
+
+	t.Helper()
+	require.Positive(t, result.PeerCount)
+	require.EqualValues(t, target.Height, result.BlockHeaderHeight)
+	require.EqualValues(t, target.Height, result.FilterHeaderHeight)
+	require.Equal(t, target.Height, result.BestBlockHeight)
+	require.Equal(t, target.BlockHash, result.BlockHeaderHash)
+	require.Equal(t, target.BlockHash, result.BestBlockHash)
+	require.Equal(t, target.FilterHeaderHash, result.FilterHeaderHash)
+	require.Equal(t, target.FilterData, result.FilterData)
+}
+
+func assertWebTransportRPCPeer(t *testing.T, harness *rpctest.Harness,
+	webTransportAddress string) {
+
+	t.Helper()
+	require.Eventually(t, func() bool {
+		peers, err := harness.Client.GetPeerInfo()
+		if err != nil {
+			return false
+		}
+		for _, peer := range peers {
+			if peer.SubVer != wasmUserAgent {
+				continue
+			}
+
+			return peer.Inbound && peer.AddrLocal == webTransportAddress &&
+				peer.BytesRecv > 0 && peer.BytesSent > 0
+		}
+
+		return false
+	}, 10*time.Second, 50*time.Millisecond)
+}
+
+func requireBTCDWebTransportBinary(t *testing.T) string {
+	t.Helper()
+
+	path := os.Getenv("BTCD_WEBTRANSPORT_BIN")
+	if path == "" {
+		t.Skip("BTCD_WEBTRANSPORT_BIN is not set; point it at a btcd " +
+			"binary containing the WebTransport server change")
+	}
+	path, err := filepath.Abs(path)
+	require.NoError(t, err)
+	info, err := os.Stat(path)
+	require.NoErrorf(t, err, "stat BTCD_WEBTRANSPORT_BIN %q", path)
+	require.Falsef(t, info.IsDir(), "BTCD_WEBTRANSPORT_BIN %q is a directory", path)
+
+	return path
+}
+
+func fixturePaths(t *testing.T) (string, string) {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	itestDir := filepath.Dir(file)
+	repoRoot := filepath.Dir(filepath.Dir(itestDir))
+
+	return repoRoot, filepath.Join(itestDir, "client")
+}
+
+func buildWASMFixture(t *testing.T, repoRoot, outputPath string) {
+	t.Helper()
+
+	cmd := exec.Command(
+		"go", "build", "-trimpath", "-o", outputPath,
+		"./itest/webtransport/client",
+	)
+	cmd.Dir = repoRoot
+	cmd.Env = append(
+		os.Environ(), "GOOS=js", "GOARCH=wasm", "CGO_ENABLED=0",
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "build Go WASM fixture:\n%s", output)
+}
+
+func readWASMExec(t *testing.T) []byte {
+	t.Helper()
+
+	paths := []string{
+		filepath.Join(runtime.GOROOT(), "lib", "wasm", "wasm_exec.js"),
+		filepath.Join(runtime.GOROOT(), "misc", "wasm", "wasm_exec.js"),
+	}
+	for _, path := range paths {
+		contents, err := os.ReadFile(path)
+		if err == nil {
+			return contents
+		}
+	}
+
+	t.Fatalf("wasm_exec.js not found below %s", runtime.GOROOT())
+	return nil
+}
+
+func newBrowserServer(indexHTML, wasmExec, wasmBinary []byte,
+	targets *targetState,
+	results chan<- browserSyncResult) *http.Server {
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/" {
+			http.NotFound(w, request)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write(indexHTML)
+	})
+	mux.HandleFunc("/wasm_exec.js", func(w http.ResponseWriter,
+		_ *http.Request) {
+
+		w.Header().Set("Content-Type", "text/javascript; charset=utf-8")
+		_, _ = w.Write(wasmExec)
+	})
+	mux.HandleFunc("/client.wasm", func(w http.ResponseWriter,
+		_ *http.Request) {
+
+		w.Header().Set("Content-Type", "application/wasm")
+		_, _ = w.Write(wasmBinary)
+	})
+	mux.HandleFunc("/target", func(w http.ResponseWriter,
+		request *http.Request) {
+
+		if request.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "GET required", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(targets.get()); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+	mux.HandleFunc("/result", func(w http.ResponseWriter,
+		request *http.Request) {
+
+		if request.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, "POST required", http.StatusMethodNotAllowed)
+			return
+		}
+		defer request.Body.Close()
+		decoder := json.NewDecoder(io.LimitReader(request.Body, 1<<20))
+		var result browserSyncResult
+		if err := decoder.Decode(&result); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		select {
+		case results <- result:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "result queue is full", http.StatusConflict)
+		}
+	})
+
+	return &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+}
+
+func availableUDPAddress(t *testing.T) string {
+	t.Helper()
+
+	packetConn, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	address := packetConn.LocalAddr().String()
+	require.NoError(t, packetConn.Close())
+
+	return address
+}
+
+func writeWebTransportCertificate(t *testing.T, certPath,
+	keyPath string) [sha256.Size]byte {
+
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "btcd WebTransport test"},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+	der, err := x509.CreateCertificate(
+		rand.Reader, template, template, &privateKey.PublicKey, privateKey,
+	)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(privateKey)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE", Bytes: der,
+	})
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "EC PRIVATE KEY", Bytes: keyDER,
+	})
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0600))
+
+	return sha256.Sum256(der)
+}
+
+func findChrome(t *testing.T) string {
+	t.Helper()
+
+	if configured := os.Getenv("BTCD_CHROME_BIN"); configured != "" {
+		info, err := os.Stat(configured)
+		require.NoErrorf(t, err, "stat BTCD_CHROME_BIN %q", configured)
+		require.Falsef(t, info.IsDir(), "BTCD_CHROME_BIN %q is a directory", configured)
+		return configured
+	}
+
+	for _, name := range []string{
+		"google-chrome", "google-chrome-stable", "chromium",
+		"chromium-browser", "chrome",
+	} {
+		if path, err := exec.LookPath(name); err == nil {
+			return path
+		}
+	}
+	for _, path := range []string{
+		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+		"/Applications/Chromium.app/Contents/MacOS/Chromium",
+		`C:\Program Files\Google\Chrome\Application\chrome.exe`,
+		`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`,
+	} {
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return path
+		}
+	}
+
+	return ""
+}
+
+func startChrome(t *testing.T, chromePath, pageURL,
+	testDir string) *chromeProcess {
+
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	args := []string{
+		"--headless=new",
+		"--disable-background-networking",
+		"--disable-component-update",
+		"--disable-default-apps",
+		"--disable-dev-shm-usage",
+		"--disable-gpu",
+		"--disable-sync",
+		"--metrics-recording-only",
+		"--no-default-browser-check",
+		"--no-first-run",
+		"--user-data-dir=" + filepath.Join(testDir, "chrome-profile"),
+	}
+	if runtime.GOOS == "linux" {
+		args = append(args, "--no-sandbox")
+	}
+	args = append(args, pageURL)
+
+	logPath := filepath.Join(testDir, "chrome.log")
+	logFile, err := os.Create(logPath)
+	require.NoError(t, err)
+	cmd := exec.CommandContext(ctx, chromePath, args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	require.NoError(t, cmd.Start())
+
+	process := &chromeProcess{
+		cancel:  cancel,
+		done:    make(chan struct{}),
+		logPath: logPath,
+	}
+	go func() {
+		err := cmd.Wait()
+		_ = logFile.Close()
+		process.errMu.Lock()
+		process.err = err
+		process.errMu.Unlock()
+		close(process.done)
+	}()
+
+	return process
+}
+
+func (p *chromeProcess) stop() {
+	if p == nil {
+		return
+	}
+	p.once.Do(func() {
+		p.cancel()
+		select {
+		case <-p.done:
+		case <-time.After(10 * time.Second):
+		}
+	})
+}
+
+func (p *chromeProcess) logOutput() string {
+	contents, err := os.ReadFile(p.logPath)
+	if err != nil {
+		return fmt.Sprintf("read Chrome log: %v", err)
+	}
+	const maxLogBytes = 16 << 10
+	if len(contents) > maxLogBytes {
+		contents = contents[len(contents)-maxLogBytes:]
+	}
+
+	return string(contents)
+}
+
+func (p *chromeProcess) exitError() error {
+	p.errMu.Lock()
+	defer p.errMu.Unlock()
+
+	return p.err
+}

--- a/neutrino.go
+++ b/neutrino.go
@@ -549,15 +549,51 @@ func (sp *ServerPeer) OnWrite(_ *peer.Peer, bytesWritten int, msg wire.Message, 
 	sp.server.AddBytesSent(uint64(bytesWritten))
 }
 
+// ChainServiceStores contains the storage backends used by a ChainService.
+// All fields must be set when custom stores are supplied through Config.
+type ChainServiceStores struct {
+	FilterDB         filterdb.FilterDatabase
+	BlockHeaders     headerfs.BlockHeaderStore
+	RegFilterHeaders headerfs.FilterHeaderStore
+	BanStore         banman.Store
+}
+
+// validate checks that a complete set of custom stores was provided.
+func (s *ChainServiceStores) validate() error {
+	switch {
+	case s.FilterDB == nil:
+		return fmt.Errorf("custom filter database is required")
+
+	case s.BlockHeaders == nil:
+		return fmt.Errorf("custom block header store is required")
+
+	case s.RegFilterHeaders == nil:
+		return fmt.Errorf("custom filter header store is required")
+
+	case s.BanStore == nil:
+		return fmt.Errorf("custom ban store is required")
+
+	default:
+		return nil
+	}
+}
+
 // Config is a struct detailing the configuration of the chain service.
 type Config struct {
 	// DataDir is the directory that neutrino will store all header
 	// information within.
 	DataDir string
 
-	// Database is an *open* database instance that we'll use to storm
-	// indexes of the chain.
+	// Database is an *open* database instance that we'll use to store
+	// indexes of the chain. It may be nil when Stores is set.
 	Database walletdb.DB
+
+	// Stores optionally supplies all storage backends used by the chain
+	// service. If set, all stores must be non-nil, and Database won't be
+	// accessed to initialize the filter, header, or ban stores. Custom stores
+	// are responsible for their own state validation, so AssertFilterHeader
+	// must be nil.
+	Stores *ChainServiceStores
 
 	// ChainParams is the chain that we're running on.
 	ChainParams chaincfg.Params
@@ -729,6 +765,16 @@ type ChainService struct { // nolint:maligned
 // bitcoin network type specified by chainParams.  Use start to begin syncing
 // with peers.
 func NewChainService(cfg Config) (*ChainService, error) {
+	if cfg.Stores != nil {
+		if err := cfg.Stores.validate(); err != nil {
+			return nil, err
+		}
+		if cfg.AssertFilterHeader != nil {
+			return nil, fmt.Errorf("filter header assertions are not " +
+				"supported with custom stores")
+		}
+	}
+
 	// Use the default broadcast timeout if one isn't provided.
 	if cfg.BroadcastTimeout == 0 {
 		cfg.BroadcastTimeout = pushtx.DefaultBroadcastTimeout
@@ -791,9 +837,13 @@ func NewChainService(cfg Config) (*ChainService, error) {
 	})
 
 	var err error
-	s.FilterDB, err = filterdb.New(cfg.Database, cfg.ChainParams)
-	if err != nil {
-		return nil, err
+	if cfg.Stores != nil {
+		s.FilterDB = cfg.Stores.FilterDB
+	} else {
+		s.FilterDB, err = filterdb.New(cfg.Database, cfg.ChainParams)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if s.persistToDisk {
@@ -831,18 +881,23 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		)
 	}
 
-	s.BlockHeaders, err = headerfs.NewBlockHeaderStore(
-		cfg.DataDir, cfg.Database, &cfg.ChainParams,
-	)
-	if err != nil {
-		return nil, err
-	}
-	s.RegFilterHeaders, err = headerfs.NewFilterHeaderStore(
-		cfg.DataDir, cfg.Database, headerfs.RegularFilter,
-		&cfg.ChainParams, cfg.AssertFilterHeader,
-	)
-	if err != nil {
-		return nil, err
+	if cfg.Stores != nil {
+		s.BlockHeaders = cfg.Stores.BlockHeaders
+		s.RegFilterHeaders = cfg.Stores.RegFilterHeaders
+	} else {
+		s.BlockHeaders, err = headerfs.NewBlockHeaderStore(
+			cfg.DataDir, cfg.Database, &cfg.ChainParams,
+		)
+		if err != nil {
+			return nil, err
+		}
+		s.RegFilterHeaders, err = headerfs.NewFilterHeaderStore(
+			cfg.DataDir, cfg.Database, headerfs.RegularFilter,
+			&cfg.ChainParams, cfg.AssertFilterHeader,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	bm, err := newBlockManager(&blockManagerCfg{
@@ -987,9 +1042,14 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		RebroadcastInterval: pushtx.DefaultRebroadcastInterval,
 	})
 
-	s.banStore, err = banman.NewStore(cfg.Database)
-	if err != nil {
-		return nil, fmt.Errorf("unable to initialize ban store: %v", err)
+	if cfg.Stores != nil {
+		s.banStore = cfg.Stores.BanStore
+	} else {
+		s.banStore, err = banman.NewStore(cfg.Database)
+		if err != nil {
+			return nil, fmt.Errorf("unable to initialize ban store: %v",
+				err)
+		}
 	}
 
 	// Start up persistent peers.

--- a/stores_test.go
+++ b/stores_test.go
@@ -1,0 +1,114 @@
+package neutrino
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/lightninglabs/neutrino/headerfs"
+	"github.com/lightninglabs/neutrino/internal/memstore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChainServiceCustomStores(t *testing.T) {
+	t.Parallel()
+
+	stores, err := memstore.New(&chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	service, err := NewChainService(Config{
+		ChainParams: chaincfg.SimNetParams,
+		Stores: &ChainServiceStores{
+			FilterDB:         stores.FilterDB,
+			BlockHeaders:     stores.BlockHeaders,
+			RegFilterHeaders: stores.RegFilterHeaders,
+			BanStore:         stores.BanStore,
+		},
+	})
+	require.NoError(t, err)
+	require.Same(t, stores.FilterDB, service.FilterDB)
+	require.Same(t, stores.BlockHeaders, service.BlockHeaders)
+	require.Same(t, stores.RegFilterHeaders, service.RegFilterHeaders)
+	require.Same(t, stores.BanStore, service.banStore)
+}
+
+func TestChainServiceCustomStoresRequireCompleteSet(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		clear   func(*ChainServiceStores)
+		errText string
+	}{
+		{
+			name: "filter database",
+			clear: func(stores *ChainServiceStores) {
+				stores.FilterDB = nil
+			},
+			errText: "custom filter database is required",
+		},
+		{
+			name: "block headers",
+			clear: func(stores *ChainServiceStores) {
+				stores.BlockHeaders = nil
+			},
+			errText: "custom block header store is required",
+		},
+		{
+			name: "filter headers",
+			clear: func(stores *ChainServiceStores) {
+				stores.RegFilterHeaders = nil
+			},
+			errText: "custom filter header store is required",
+		},
+		{
+			name: "ban store",
+			clear: func(stores *ChainServiceStores) {
+				stores.BanStore = nil
+			},
+			errText: "custom ban store is required",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			memoryStores, err := memstore.New(&chaincfg.SimNetParams)
+			require.NoError(t, err)
+
+			stores := &ChainServiceStores{
+				FilterDB:         memoryStores.FilterDB,
+				BlockHeaders:     memoryStores.BlockHeaders,
+				RegFilterHeaders: memoryStores.RegFilterHeaders,
+				BanStore:         memoryStores.BanStore,
+			}
+			testCase.clear(stores)
+
+			_, err = NewChainService(Config{
+				ChainParams: chaincfg.SimNetParams,
+				Stores:      stores,
+			})
+			require.EqualError(t, err, testCase.errText)
+		})
+	}
+}
+
+func TestChainServiceCustomStoresRejectFilterHeaderAssertion(t *testing.T) {
+	t.Parallel()
+
+	memoryStores, err := memstore.New(&chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	_, err = NewChainService(Config{
+		ChainParams: chaincfg.SimNetParams,
+		Stores: &ChainServiceStores{
+			FilterDB:         memoryStores.FilterDB,
+			BlockHeaders:     memoryStores.BlockHeaders,
+			RegFilterHeaders: memoryStores.RegFilterHeaders,
+			BanStore:         memoryStores.BanStore,
+		},
+		AssertFilterHeader: &headerfs.FilterHeader{},
+	})
+	require.EqualError(t, err,
+		"filter header assertions are not supported with custom stores")
+}

--- a/wasmtransport/dial_js.go
+++ b/wasmtransport/dial_js.go
@@ -1,0 +1,561 @@
+//go:build js && wasm
+
+package wasmtransport
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"syscall/js"
+	"time"
+)
+
+const readQueueSize = 32
+
+type promiseResult struct {
+	value js.Value
+	err   error
+}
+
+type deadline struct {
+	mu      sync.Mutex
+	when    time.Time
+	changed chan struct{}
+}
+
+func newDeadline() *deadline {
+	return &deadline{changed: make(chan struct{})}
+}
+
+func (d *deadline) set(when time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.when = when
+	close(d.changed)
+	d.changed = make(chan struct{})
+}
+
+func (d *deadline) snapshot() (time.Time, <-chan struct{}) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.when, d.changed
+}
+
+type conn struct {
+	transport js.Value
+	reader    js.Value
+	writer    js.Value
+
+	local  net.Addr
+	remote net.Addr
+
+	readMu  sync.Mutex
+	readBuf []byte
+	readCh  chan []byte
+
+	writeMu sync.Mutex
+
+	readDeadline  *deadline
+	writeDeadline *deadline
+
+	errMu sync.Mutex
+	err   error
+
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+func newDialer(cfg DialerConfig) func(net.Addr) (net.Conn, error) {
+	return func(remote net.Addr) (net.Conn, error) {
+		if remote == nil {
+			return nil, fmt.Errorf("WebTransport peer address is nil")
+		}
+		if isOnionAddr(remote) {
+			return nil, fmt.Errorf("onion peer %s is not reachable through browser WebTransport", remote)
+		}
+
+		endpoint, err := cfg.ResolveEndpoint(remote)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"resolve WebTransport endpoint for %s: %w", remote, err,
+			)
+		}
+		endpoint, err = validatePeerEndpoint(endpoint)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"invalid WebTransport endpoint for %s: %w", remote, err,
+			)
+		}
+
+		return dial(cfg, endpoint, remote)
+	}
+}
+
+func dial(cfg DialerConfig, endpoint PeerEndpoint,
+	remote net.Addr) (net.Conn, error) {
+
+	constructor := js.Global().Get("WebTransport")
+	if constructor.Type() != js.TypeFunction {
+		return nil, fmt.Errorf("browser WebTransport API unavailable")
+	}
+
+	options := js.Global().Get("Object").New()
+	if len(endpoint.ServerCertificateHashes) > 0 {
+		hashes := js.Global().Get("Array").New()
+		for _, hash := range endpoint.ServerCertificateHashes {
+			value := js.Global().Get("Uint8Array").New(len(hash))
+			js.CopyBytesToJS(value, hash)
+
+			entry := js.Global().Get("Object").New()
+			entry.Set("algorithm", "sha-256")
+			entry.Set("value", value)
+			hashes.Call("push", entry)
+		}
+		options.Set("serverCertificateHashes", hashes)
+	}
+
+	transport, err := safeNew(constructor, endpoint.URL, options)
+	if err != nil {
+		return nil, fmt.Errorf("create WebTransport session: %w", err)
+	}
+
+	handshakeDeadline := time.Now().Add(cfg.HandshakeTimeout)
+	if _, err := awaitUntil(
+		transport.Get("ready"), handshakeDeadline,
+	); err != nil {
+		closeWebTransport(transport)
+		return nil, fmt.Errorf("establish WebTransport session: %w", err)
+	}
+
+	streamPromise, err := safeCall(
+		transport, "createBidirectionalStream",
+	)
+	if err != nil {
+		closeWebTransport(transport)
+		return nil, fmt.Errorf("open WebTransport stream: %w", err)
+	}
+
+	stream, err := awaitUntil(streamPromise, handshakeDeadline)
+	if err != nil {
+		closeWebTransport(transport)
+		return nil, fmt.Errorf("open WebTransport stream: %w", err)
+	}
+
+	reader, err := safeCall(stream.Get("readable"), "getReader")
+	if err != nil {
+		closeWebTransport(transport)
+		return nil, fmt.Errorf("create WebTransport reader: %w", err)
+	}
+	writer, err := safeCall(stream.Get("writable"), "getWriter")
+	if err != nil {
+		closeWebTransport(transport)
+		return nil, fmt.Errorf("create WebTransport writer: %w", err)
+	}
+
+	c := &conn{
+		transport:     transport,
+		reader:        reader,
+		writer:        writer,
+		local:         endpointAddr("wasm"),
+		remote:        remote,
+		readCh:        make(chan []byte, readQueueSize),
+		readDeadline:  newDeadline(),
+		writeDeadline: newDeadline(),
+		closed:        make(chan struct{}),
+	}
+
+	go c.readPump()
+	go c.closedPump()
+
+	return c, nil
+}
+
+func (c *conn) readPump() {
+	defer close(c.readCh)
+
+	for {
+		select {
+		case <-c.closed:
+			return
+		default:
+		}
+
+		promise, err := safeCall(c.reader, "read")
+		if err != nil {
+			c.shutdown(err, true)
+			return
+		}
+
+		var result promiseResult
+		select {
+		case result = <-promiseResults(promise):
+		case <-c.closed:
+			return
+		}
+		if result.err != nil {
+			c.shutdown(result.err, true)
+			return
+		}
+
+		if result.value.Get("done").Bool() {
+			c.shutdown(nil, true)
+			return
+		}
+
+		value := result.value.Get("value")
+		if value.IsUndefined() || value.IsNull() {
+			continue
+		}
+
+		buf := make([]byte, value.Get("byteLength").Int())
+		js.CopyBytesToGo(buf, value)
+		if len(buf) == 0 {
+			continue
+		}
+
+		select {
+		case c.readCh <- buf:
+		case <-c.closed:
+			return
+		}
+	}
+}
+
+func (c *conn) closedPump() {
+	result := <-promiseResults(c.transport.Get("closed"))
+	c.shutdown(result.err, false)
+}
+
+func (c *conn) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
+
+	when, _ := c.readDeadline.snapshot()
+	if !when.IsZero() && time.Until(when) <= 0 {
+		return 0, os.ErrDeadlineExceeded
+	}
+
+	if len(c.readBuf) > 0 {
+		return c.copyReadBuffer(p), nil
+	}
+
+	for {
+		chunk, err := c.nextReadChunk()
+		if err != nil {
+			return 0, err
+		}
+		if len(chunk) == 0 {
+			continue
+		}
+
+		c.readBuf = chunk
+		return c.copyReadBuffer(p), nil
+	}
+}
+
+func (c *conn) copyReadBuffer(p []byte) int {
+	n := copy(p, c.readBuf)
+	c.readBuf = c.readBuf[n:]
+	return n
+}
+
+func (c *conn) nextReadChunk() ([]byte, error) {
+	for {
+		select {
+		case chunk, ok := <-c.readCh:
+			if !ok {
+				return nil, c.readError()
+			}
+
+			return chunk, nil
+		default:
+		}
+
+		when, changed := c.readDeadline.snapshot()
+		if when.IsZero() {
+			select {
+			case chunk, ok := <-c.readCh:
+				if !ok {
+					return nil, c.readError()
+				}
+
+				return chunk, nil
+			case <-changed:
+				continue
+			}
+		}
+
+		remaining := time.Until(when)
+		if remaining <= 0 {
+			return nil, os.ErrDeadlineExceeded
+		}
+
+		timer := time.NewTimer(remaining)
+		select {
+		case chunk, ok := <-c.readCh:
+			stopTimer(timer)
+			if !ok {
+				return nil, c.readError()
+			}
+
+			return chunk, nil
+		case <-changed:
+			stopTimer(timer)
+			continue
+		case <-timer.C:
+			return nil, os.ErrDeadlineExceeded
+		}
+	}
+}
+
+func (c *conn) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	select {
+	case <-c.closed:
+		return 0, io.ErrClosedPipe
+	default:
+	}
+	when, _ := c.writeDeadline.snapshot()
+	if !when.IsZero() && time.Until(when) <= 0 {
+		return 0, os.ErrDeadlineExceeded
+	}
+
+	value := js.Global().Get("Uint8Array").New(len(p))
+	js.CopyBytesToJS(value, p)
+
+	promise, err := safeCall(c.writer, "write", value)
+	if err != nil {
+		c.shutdown(err, true)
+		return 0, err
+	}
+
+	if err := c.waitForWrite(promiseResults(promise)); err != nil {
+		// Web Streams cannot cancel one writer.write call independently.
+		// Close the session on an in-flight write failure or timeout so a
+		// caller cannot retry bytes whose delivery is ambiguous.
+		c.shutdown(err, true)
+		return 0, err
+	}
+
+	return len(p), nil
+}
+
+func (c *conn) waitForWrite(results <-chan promiseResult) error {
+	for {
+		when, changed := c.writeDeadline.snapshot()
+		if when.IsZero() {
+			select {
+			case result := <-results:
+				return result.err
+			case <-c.closed:
+				return io.ErrClosedPipe
+			case <-changed:
+				continue
+			}
+		}
+
+		remaining := time.Until(when)
+		if remaining <= 0 {
+			return os.ErrDeadlineExceeded
+		}
+
+		timer := time.NewTimer(remaining)
+		select {
+		case result := <-results:
+			stopTimer(timer)
+			return result.err
+		case <-c.closed:
+			stopTimer(timer)
+			return io.ErrClosedPipe
+		case <-changed:
+			stopTimer(timer)
+			continue
+		case <-timer.C:
+			return os.ErrDeadlineExceeded
+		}
+	}
+}
+
+func (c *conn) Close() error {
+	c.shutdown(nil, true)
+	return nil
+}
+
+func (c *conn) LocalAddr() net.Addr {
+	return c.local
+}
+
+func (c *conn) RemoteAddr() net.Addr {
+	return c.remote
+}
+
+func (c *conn) SetDeadline(t time.Time) error {
+	c.readDeadline.set(t)
+	c.writeDeadline.set(t)
+	return nil
+}
+
+func (c *conn) SetReadDeadline(t time.Time) error {
+	c.readDeadline.set(t)
+	return nil
+}
+
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	c.writeDeadline.set(t)
+	return nil
+}
+
+func (c *conn) shutdown(err error, notifyBrowser bool) {
+	didClose := false
+	c.closeOnce.Do(func() {
+		didClose = true
+		if err != nil {
+			c.errMu.Lock()
+			c.err = err
+			c.errMu.Unlock()
+		}
+		close(c.closed)
+	})
+
+	if didClose && notifyBrowser {
+		closeWebTransport(c.transport)
+	}
+}
+
+func (c *conn) readError() error {
+	c.errMu.Lock()
+	defer c.errMu.Unlock()
+
+	if c.err != nil {
+		return c.err
+	}
+
+	return io.EOF
+}
+
+func awaitUntil(promise js.Value, deadline time.Time) (js.Value, error) {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return js.Undefined(), os.ErrDeadlineExceeded
+	}
+
+	results := promiseResults(promise)
+	timer := time.NewTimer(remaining)
+	defer stopTimer(timer)
+
+	select {
+	case result := <-results:
+		return result.value, result.err
+	case <-timer.C:
+		return js.Undefined(), os.ErrDeadlineExceeded
+	}
+}
+
+func promiseResults(promise js.Value) <-chan promiseResult {
+	results := make(chan promiseResult, 1)
+	var resolve, reject js.Func
+
+	resolve = js.FuncOf(func(_ js.Value, args []js.Value) any {
+		value := js.Undefined()
+		if len(args) > 0 {
+			value = args[0]
+		}
+		results <- promiseResult{value: value}
+		resolve.Release()
+		reject.Release()
+		return nil
+	})
+	reject = js.FuncOf(func(_ js.Value, args []js.Value) any {
+		value := js.Undefined()
+		if len(args) > 0 {
+			value = args[0]
+		}
+		results <- promiseResult{err: errorFromJS(value)}
+		resolve.Release()
+		reject.Release()
+		return nil
+	})
+
+	if _, err := safeCall(promise, "then", resolve, reject); err != nil {
+		resolve.Release()
+		reject.Release()
+		results <- promiseResult{err: err}
+	}
+
+	return results
+}
+
+func closeWebTransport(transport js.Value) {
+	if transport.IsUndefined() || transport.IsNull() {
+		return
+	}
+
+	info := js.Global().Get("Object").New()
+	info.Set("closeCode", 0)
+	info.Set("reason", "")
+	_, _ = safeCall(transport, "close", info)
+}
+
+func safeCall(receiver js.Value, method string, args ...any) (
+	value js.Value, err error) {
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("JavaScript %s call failed: %v", method, recovered)
+		}
+	}()
+
+	return receiver.Call(method, args...), nil
+}
+
+func safeNew(constructor js.Value, args ...any) (value js.Value, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("JavaScript constructor failed: %v", recovered)
+		}
+	}()
+
+	return constructor.New(args...), nil
+}
+
+func errorFromJS(value js.Value) error {
+	if value.IsUndefined() || value.IsNull() {
+		return fmt.Errorf("JavaScript promise rejected")
+	}
+	if value.Type() == js.TypeString {
+		return fmt.Errorf("%s", value.String())
+	}
+	if value.Type() == js.TypeObject {
+		message := value.Get("message")
+		if message.Type() == js.TypeString {
+			return fmt.Errorf("%s", message.String())
+		}
+	}
+
+	return fmt.Errorf("JavaScript promise rejected: %s", value.String())
+}
+
+func stopTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}
+
+var _ net.Conn = (*conn)(nil)

--- a/wasmtransport/dial_js_test.go
+++ b/wasmtransport/dial_js_test.go
@@ -1,0 +1,249 @@
+//go:build js && wasm
+
+package wasmtransport
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"os"
+	"syscall/js"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const fakeWebTransport = `
+globalThis.__wasmTransportReadyDelay = 0;
+globalThis.__wasmTransportStreamDelay = 0;
+globalThis.__wasmTransportPendingWrite = false;
+globalThis.__wasmTransportAbortOnClose = false;
+
+globalThis.WebTransport = class {
+  constructor(url, options) {
+    globalThis.__wasmTransportURL = url;
+    globalThis.__wasmTransportOptions = options;
+    globalThis.__wasmTransportInstance = this;
+    this.ready = new Promise((resolve) => {
+      setTimeout(resolve, globalThis.__wasmTransportReadyDelay);
+    });
+    this.closed = new Promise((resolve) => {
+      this.resolveClosed = resolve;
+    });
+  }
+
+  async createBidirectionalStream() {
+    await new Promise((resolve) => {
+      setTimeout(resolve, globalThis.__wasmTransportStreamDelay);
+    });
+
+    let controller;
+    const readable = new ReadableStream({
+      start(value) {
+        controller = value;
+      },
+    });
+    this.controller = controller;
+
+    const writable = new WritableStream({
+      write(chunk) {
+        if (globalThis.__wasmTransportPendingWrite) {
+          return new Promise(() => {});
+        }
+
+        controller.enqueue(new Uint8Array(chunk));
+      },
+    });
+
+    return {readable, writable};
+  }
+
+  close(info) {
+    if (this.controller) {
+      try {
+        if (globalThis.__wasmTransportAbortOnClose) {
+          this.controller.error(new Error("AbortError"));
+        } else {
+          this.controller.close();
+        }
+      } catch (_) {}
+    }
+    this.resolveClosed(info);
+  }
+};
+`
+
+func installFakeWebTransport(t *testing.T) {
+	t.Helper()
+
+	js.Global().Call("eval", fakeWebTransport)
+	t.Cleanup(func() {
+		js.Global().Call("eval", `
+delete globalThis.WebTransport;
+delete globalThis.__wasmTransportInstance;
+delete globalThis.__wasmTransportURL;
+delete globalThis.__wasmTransportOptions;
+`)
+	})
+}
+
+func newTestDialer(t *testing.T, timeout time.Duration) (
+	func(net.Addr) (net.Conn, error), net.Addr) {
+
+	t.Helper()
+
+	remote := &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 8333}
+	hash := bytes.Repeat([]byte{1}, certificateHashLength)
+	endpoints := EndpointMap{
+		remote.String(): {
+			URL:                     "https://peer.example/v1/btc-p2p",
+			ServerCertificateHashes: [][]byte{hash},
+		},
+	}
+	dialer, err := NewDialer(DialerConfig{
+		ResolveEndpoint:  endpoints.Resolve,
+		HandshakeTimeout: timeout,
+	})
+	require.NoError(t, err)
+
+	return dialer, remote
+}
+
+func TestBrowserWebTransportConn(t *testing.T) {
+	installFakeWebTransport(t)
+	dialer, remote := newTestDialer(t, 0)
+
+	connection, err := dialer(remote)
+	require.NoError(t, err)
+	require.Same(t, remote, connection.RemoteAddr())
+	require.Equal(t, "webtransport", connection.LocalAddr().Network())
+	require.Equal(t, "wasm", connection.LocalAddr().String())
+	require.Equal(
+		t, "https://peer.example/v1/btc-p2p",
+		js.Global().Get("__wasmTransportURL").String(),
+	)
+
+	hashes := js.Global().Get("__wasmTransportOptions").Get(
+		"serverCertificateHashes",
+	)
+	require.Equal(t, 1, hashes.Get("length").Int())
+	require.Equal(t, certificateHashLength,
+		hashes.Index(0).Get("value").Get("byteLength").Int())
+
+	want := []byte("bitcoin-p2p")
+	n, err := connection.Write(want)
+	require.NoError(t, err)
+	require.Equal(t, len(want), n)
+
+	first := make([]byte, 3)
+	n, err = connection.Read(first)
+	require.NoError(t, err)
+	require.Equal(t, want[:3], first[:n])
+
+	rest := make([]byte, len(want))
+	n, err = connection.Read(rest)
+	require.NoError(t, err)
+	require.Equal(t, want[3:], rest[:n])
+
+	require.NoError(t, connection.Close())
+	require.NoError(t, connection.Close())
+	_, err = connection.Read(make([]byte, 1))
+	require.ErrorIs(t, err, io.EOF)
+	_, err = connection.Write([]byte{1})
+	require.ErrorIs(t, err, io.ErrClosedPipe)
+}
+
+func TestBrowserWebTransportDrainsFinalChunkBeforeEOF(t *testing.T) {
+	installFakeWebTransport(t)
+	dialer, remote := newTestDialer(t, 0)
+	connection, err := dialer(remote)
+	require.NoError(t, err)
+
+	want := []byte("final-chunk")
+	_, err = connection.Write(want)
+	require.NoError(t, err)
+	js.Global().Get("__wasmTransportInstance").Get("controller").Call(
+		"close",
+	)
+
+	got := make([]byte, len(want))
+	n, err := io.ReadFull(connection, got)
+	require.NoError(t, err)
+	require.Equal(t, len(want), n)
+	require.Equal(t, want, got)
+
+	_, err = connection.Read(make([]byte, 1))
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestBrowserWebTransportExpiredReadDeadlineWins(t *testing.T) {
+	installFakeWebTransport(t)
+	dialer, remote := newTestDialer(t, 0)
+	connection, err := dialer(remote)
+	require.NoError(t, err)
+	defer connection.Close()
+
+	_, err = connection.Write([]byte("buffered"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return len(connection.(*conn).readCh) > 0
+	}, time.Second, time.Millisecond)
+
+	require.NoError(
+		t, connection.SetReadDeadline(time.Now().Add(-time.Second)),
+	)
+	_, err = connection.Read(make([]byte, 8))
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+}
+
+func TestBrowserWebTransportWriteTimeoutClosesConnection(t *testing.T) {
+	installFakeWebTransport(t)
+	js.Global().Set("__wasmTransportPendingWrite", true)
+	dialer, remote := newTestDialer(t, 0)
+	connection, err := dialer(remote)
+	require.NoError(t, err)
+
+	require.NoError(
+		t, connection.SetWriteDeadline(time.Now().Add(10*time.Millisecond)),
+	)
+	_, err = connection.Write([]byte("ambiguous"))
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+
+	_, err = connection.Write([]byte("must-not-retry"))
+	require.ErrorIs(t, err, io.ErrClosedPipe)
+}
+
+func TestBrowserWebTransportLocalCloseWinsAbortError(t *testing.T) {
+	installFakeWebTransport(t)
+	js.Global().Set("__wasmTransportAbortOnClose", true)
+	dialer, remote := newTestDialer(t, 0)
+	connection, err := dialer(remote)
+	require.NoError(t, err)
+
+	require.NoError(t, connection.Close())
+	_, err = connection.Read(make([]byte, 1))
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestBrowserWebTransportUsesOneHandshakeBudget(t *testing.T) {
+	installFakeWebTransport(t)
+	js.Global().Set("__wasmTransportReadyDelay", 30)
+	js.Global().Set("__wasmTransportStreamDelay", 30)
+	dialer, remote := newTestDialer(t, 45*time.Millisecond)
+
+	_, err := dialer(remote)
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+}
+
+func TestBrowserWebTransportRejectsUnmappedPeer(t *testing.T) {
+	installFakeWebTransport(t)
+	dialer, _ := newTestDialer(t, 0)
+	unknown := &net.TCPAddr{IP: net.ParseIP("192.0.2.2"), Port: 8333}
+
+	_, err := dialer(unknown)
+	require.ErrorContains(t, err, "no WebTransport endpoint configured")
+	require.True(
+		t, js.Global().Get("__wasmTransportInstance").IsUndefined(),
+	)
+}

--- a/wasmtransport/dial_stub.go
+++ b/wasmtransport/dial_stub.go
@@ -1,0 +1,14 @@
+//go:build !js || !wasm
+
+package wasmtransport
+
+import (
+	"fmt"
+	"net"
+)
+
+func newDialer(DialerConfig) func(net.Addr) (net.Conn, error) {
+	return func(net.Addr) (net.Conn, error) {
+		return nil, fmt.Errorf("browser WebTransport dialer requires js/wasm")
+	}
+}

--- a/wasmtransport/dial_stub_test.go
+++ b/wasmtransport/dial_stub_test.go
@@ -1,0 +1,31 @@
+//go:build !js || !wasm
+
+package wasmtransport
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNativeDialerFailsClearly(t *testing.T) {
+	t.Parallel()
+
+	remote := &net.TCPAddr{
+		IP:   net.ParseIP("192.0.2.1"),
+		Port: 8333,
+	}
+	endpoints := EndpointMap{
+		remote.String(): {
+			URL: "https://peer.example/v1/btc-p2p",
+		},
+	}
+	dialer, err := NewDialer(DialerConfig{
+		ResolveEndpoint: endpoints.Resolve,
+	})
+	require.NoError(t, err)
+
+	_, err = dialer(remote)
+	require.ErrorContains(t, err, "requires js/wasm")
+}

--- a/wasmtransport/dialer.go
+++ b/wasmtransport/dialer.go
@@ -1,0 +1,156 @@
+package wasmtransport
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultHandshakeTimeout is the maximum time a browser dial waits for
+	// the WebTransport session and its bidirectional stream to become ready.
+	DefaultHandshakeTimeout = 30 * time.Second
+
+	certificateHashLength = 32
+)
+
+// PeerEndpoint describes the WebTransport endpoint for one Bitcoin peer.
+type PeerEndpoint struct {
+	// URL is the HTTPS WebTransport URL exposed by the peer.
+	URL string
+
+	// ServerCertificateHashes contains optional SHA-256 hashes of acceptable
+	// leaf certificates. Browser WebTransport applies additional validity and
+	// key restrictions to certificates authenticated this way.
+	ServerCertificateHashes [][]byte
+}
+
+// EndpointResolver maps a Bitcoin peer address to its WebTransport endpoint.
+// A resolver must reject peers it doesn't recognize. Bitcoin DNS seeds and
+// addr messages don't advertise WebTransport endpoints or TLS identities, so
+// silently using one fixed endpoint for every peer would misattribute the
+// connection to the address neutrino asked to dial.
+type EndpointResolver func(net.Addr) (PeerEndpoint, error)
+
+// EndpointMap is an exact peer-address-to-WebTransport-endpoint mapping. Keys
+// are net.Addr.String values, such as "192.0.2.1:8333".
+type EndpointMap map[string]PeerEndpoint
+
+// Resolve returns the configured endpoint for peer.
+func (m EndpointMap) Resolve(peer net.Addr) (PeerEndpoint, error) {
+	if peer == nil {
+		return PeerEndpoint{}, fmt.Errorf("WebTransport peer address is nil")
+	}
+
+	endpoint, ok := m[peer.String()]
+	if !ok {
+		return PeerEndpoint{}, fmt.Errorf(
+			"no WebTransport endpoint configured for peer %s", peer,
+		)
+	}
+
+	return endpoint, nil
+}
+
+// DialerConfig configures a browser WebTransport dialer. Each dial creates one
+// WebTransport session and one bidirectional stream. The stream is exposed as
+// a net.Conn carrying the Bitcoin P2P byte stream without additional framing.
+type DialerConfig struct {
+	// ResolveEndpoint returns the endpoint for the exact peer being dialed.
+	ResolveEndpoint EndpointResolver
+
+	// HandshakeTimeout limits session and stream establishment. A zero value
+	// uses DefaultHandshakeTimeout.
+	HandshakeTimeout time.Duration
+}
+
+type endpointAddr string
+
+func (endpointAddr) Network() string {
+	return "webtransport"
+}
+
+func (a endpointAddr) String() string {
+	return string(a)
+}
+
+func isOnionAddr(addr net.Addr) bool {
+	if addr == nil {
+		return false
+	}
+	if addr.Network() == "onion" {
+		return true
+	}
+
+	host := addr.String()
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	}
+
+	return strings.HasSuffix(
+		strings.ToLower(strings.Trim(host, "[]")), ".onion",
+	)
+}
+
+// NewDialer returns a neutrino-compatible outbound connection dialer backed by
+// the browser WebTransport API.
+func NewDialer(cfg DialerConfig) (func(net.Addr) (net.Conn, error), error) {
+	validated, err := validateDialerConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return newDialer(validated), nil
+}
+
+func validateDialerConfig(cfg DialerConfig) (DialerConfig, error) {
+	if cfg.ResolveEndpoint == nil {
+		return DialerConfig{}, fmt.Errorf(
+			"WebTransport endpoint resolver is required",
+		)
+	}
+
+	if cfg.HandshakeTimeout < 0 {
+		return DialerConfig{}, fmt.Errorf("WebTransport handshake timeout cannot be negative")
+	}
+	if cfg.HandshakeTimeout == 0 {
+		cfg.HandshakeTimeout = DefaultHandshakeTimeout
+	}
+
+	return cfg, nil
+}
+
+func validatePeerEndpoint(cfg PeerEndpoint) (PeerEndpoint, error) {
+	endpoint, err := url.Parse(cfg.URL)
+	if err != nil {
+		return PeerEndpoint{}, fmt.Errorf("invalid WebTransport endpoint: %w", err)
+	}
+	if endpoint.Scheme != "https" {
+		return PeerEndpoint{}, fmt.Errorf("WebTransport endpoint must use https")
+	}
+	if endpoint.Host == "" {
+		return PeerEndpoint{}, fmt.Errorf("WebTransport endpoint must include a host")
+	}
+	if endpoint.User != nil {
+		return PeerEndpoint{}, fmt.Errorf("WebTransport endpoint must not include user info")
+	}
+	if endpoint.Fragment != "" {
+		return PeerEndpoint{}, fmt.Errorf("WebTransport endpoint must not include a fragment")
+	}
+
+	hashes := make([][]byte, len(cfg.ServerCertificateHashes))
+	for i, hash := range cfg.ServerCertificateHashes {
+		if len(hash) != certificateHashLength {
+			return PeerEndpoint{}, fmt.Errorf("server certificate hash %d must be %d bytes", i, certificateHashLength)
+		}
+
+		hashes[i] = append([]byte(nil), hash...)
+	}
+
+	cfg.URL = endpoint.String()
+	cfg.ServerCertificateHashes = hashes
+
+	return cfg, nil
+}

--- a/wasmtransport/dialer_test.go
+++ b/wasmtransport/dialer_test.go
@@ -1,0 +1,125 @@
+package wasmtransport
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func ExampleNewDialer() {
+	peerAddress := "192.0.2.1:8333"
+	endpoints := EndpointMap{
+		peerAddress: {
+			URL: "https://peer.example/v1/btc-p2p",
+		},
+	}
+
+	// Assign dialer to neutrino.Config.Dialer and include peerAddress in
+	// neutrino.Config.ConnectPeers.
+	dialer, err := NewDialer(DialerConfig{
+		ResolveEndpoint: endpoints.Resolve,
+	})
+	fmt.Println(dialer != nil, err)
+
+	// Output:
+	// true <nil>
+}
+
+func TestValidateDialerConfig(t *testing.T) {
+	t.Parallel()
+
+	resolver := EndpointMap{}.Resolve
+	cfg, err := validateDialerConfig(DialerConfig{
+		ResolveEndpoint: resolver,
+	})
+	require.NoError(t, err)
+	require.Equal(t, DefaultHandshakeTimeout, cfg.HandshakeTimeout)
+}
+
+func TestValidatePeerEndpoint(t *testing.T) {
+	t.Parallel()
+
+	hash := make([]byte, certificateHashLength)
+	cfg, err := validatePeerEndpoint(PeerEndpoint{
+		URL:                     "https://peer.example:443/v1/btc-p2p",
+		ServerCertificateHashes: [][]byte{hash},
+	})
+	require.NoError(t, err)
+	require.Equal(t, hash, cfg.ServerCertificateHashes[0])
+
+	hash[0] = 1
+	require.Zero(t, cfg.ServerCertificateHashes[0][0])
+}
+
+func TestValidateDialerConfigRejectsInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  DialerConfig
+	}{
+		{name: "missing resolver"},
+		{
+			name: "negative timeout",
+			cfg: DialerConfig{
+				ResolveEndpoint:  EndpointMap{}.Resolve,
+				HandshakeTimeout: -time.Second,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := validateDialerConfig(test.cfg)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestValidatePeerEndpointRejectsInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []PeerEndpoint{
+		{URL: "http://peer.example/v1/btc-p2p"},
+		{URL: "https:///v1/btc-p2p"},
+		{URL: "https://user@peer.example/v1/btc-p2p"},
+		{URL: "https://peer.example/v1/btc-p2p#fragment"},
+		{
+			URL:                     "https://peer.example/v1/btc-p2p",
+			ServerCertificateHashes: [][]byte{{1, 2, 3}},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.URL, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := validatePeerEndpoint(test)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestEndpointMapRejectsUnknownPeer(t *testing.T) {
+	t.Parallel()
+
+	known := &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 8333}
+	unknown := &net.TCPAddr{IP: net.ParseIP("192.0.2.2"), Port: 8333}
+	endpoints := EndpointMap{
+		known.String(): {URL: "https://peer.example/v1/btc-p2p"},
+	}
+
+	endpoint, err := endpoints.Resolve(known)
+	require.NoError(t, err)
+	require.Equal(t, "https://peer.example/v1/btc-p2p", endpoint.URL)
+
+	_, err = endpoints.Resolve(unknown)
+	require.ErrorContains(t, err, "no WebTransport endpoint configured")
+}

--- a/wasmtransport/doc.go
+++ b/wasmtransport/doc.go
@@ -1,0 +1,13 @@
+// Package wasmtransport adapts the browser WebTransport API to neutrino's
+// outbound net.Conn dialer.
+//
+// The transport uses one WebTransport session and one client-created
+// bidirectional stream for each Bitcoin peer. The stream carries the raw
+// Bitcoin P2P byte stream; it does not add a framing or proxy protocol.
+//
+// DialerConfig resolves each Bitcoin peer address to its WebTransport endpoint.
+// EndpointMap provides an exact mapping suitable for neutrino's ConnectPeers
+// mode. Regular Bitcoin DNS seeds and addr messages do not advertise
+// WebTransport URLs, TLS identities, or HTTP paths, so unconfigured addresses
+// are rejected instead of being routed to an unrelated server.
+package wasmtransport

--- a/wasmtransport/doh.go
+++ b/wasmtransport/doh.go
@@ -1,0 +1,148 @@
+package wasmtransport
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	// DefaultDoHEndpoint is a browser-compatible DNS-over-HTTPS JSON
+	// endpoint. Callers can provide a different endpoint when required.
+	DefaultDoHEndpoint = "https://cloudflare-dns.com/dns-query"
+
+	defaultDoHTimeout = 15 * time.Second
+)
+
+// DoHResolver resolves peer host names through DNS over HTTPS. It is useful in
+// browser WASM, where raw DNS lookups are unavailable.
+type DoHResolver struct {
+	Endpoint string
+	Client   *http.Client
+}
+
+// NewDoHNameResolver returns a neutrino-compatible name resolver backed by a
+// DNS-over-HTTPS JSON endpoint. An empty endpoint uses DefaultDoHEndpoint.
+func NewDoHNameResolver(endpoint string) func(string) ([]net.IP, error) {
+	resolver := &DoHResolver{
+		Endpoint: endpoint,
+		Client: &http.Client{
+			Timeout: defaultDoHTimeout,
+		},
+	}
+
+	return resolver.LookupIP
+}
+
+// LookupIP resolves host through A and AAAA DNS-over-HTTPS queries.
+func (r *DoHResolver) LookupIP(host string) ([]net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return []net.IP{ip}, nil
+	}
+
+	var (
+		result     []net.IP
+		lookupErrs []error
+	)
+	for _, recordType := range []string{"A", "AAAA"} {
+		ips, err := r.lookup(context.Background(), host, recordType)
+		if err != nil {
+			lookupErrs = append(lookupErrs, err)
+			continue
+		}
+
+		result = append(result, ips...)
+	}
+
+	if len(result) == 0 {
+		if len(lookupErrs) > 0 {
+			return nil, fmt.Errorf(
+				"DNS lookup failed for %s: %w", host,
+				errors.Join(lookupErrs...),
+			)
+		}
+
+		return nil, fmt.Errorf("no DNS answers for %s", host)
+	}
+
+	return result, nil
+}
+
+func (r *DoHResolver) lookup(ctx context.Context, host,
+	recordType string) ([]net.IP, error) {
+
+	endpoint := r.Endpoint
+	if endpoint == "" {
+		endpoint = DefaultDoHEndpoint
+	}
+	client := r.Client
+	if client == nil {
+		client = &http.Client{Timeout: defaultDoHTimeout}
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("parse DNS-over-HTTPS endpoint: %w", err)
+	}
+
+	query := u.Query()
+	query.Set("name", host)
+	query.Set("type", recordType)
+	u.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("accept", "application/dns-json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("DNS lookup %s %s failed: %s",
+			host, recordType, resp.Status)
+	}
+
+	var dnsResponse struct {
+		Status int `json:"Status"`
+		Answer []struct {
+			Type int    `json:"type"`
+			Data string `json:"data"`
+		} `json:"Answer"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&dnsResponse); err != nil {
+		return nil, err
+	}
+	if dnsResponse.Status != 0 {
+		return nil, fmt.Errorf("DNS lookup %s %s returned status %d",
+			host, recordType, dnsResponse.Status)
+	}
+
+	wantType := 1
+	if recordType == "AAAA" {
+		wantType = 28
+	}
+
+	var ips []net.IP
+	for _, answer := range dnsResponse.Answer {
+		if answer.Type != wantType {
+			continue
+		}
+
+		ip := net.ParseIP(answer.Data)
+		if ip != nil {
+			ips = append(ips, ip)
+		}
+	}
+
+	return ips, nil
+}

--- a/wasmtransport/doh_test.go
+++ b/wasmtransport/doh_test.go
@@ -1,0 +1,138 @@
+//go:build !js
+
+package wasmtransport
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoHResolverLookupIP(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu      sync.Mutex
+		queries []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+
+		if got := r.Header.Get("accept"); got != "application/dns-json" {
+			t.Errorf("unexpected accept header %q", got)
+		}
+		mu.Lock()
+		queries = append(queries, r.URL.Query().Get("type"))
+		mu.Unlock()
+
+		answers := []map[string]any{}
+		switch r.URL.Query().Get("type") {
+		case "A":
+			answers = append(answers, map[string]any{
+				"type": 1,
+				"data": "192.0.2.7",
+			})
+		case "AAAA":
+			answers = append(answers, map[string]any{
+				"type": 28,
+				"data": "2001:db8::7",
+			})
+		}
+
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"Status": 0,
+			"Answer": answers,
+		}); err != nil {
+			t.Errorf("encode DNS response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	resolver := &DoHResolver{
+		Endpoint: server.URL,
+		Client:   server.Client(),
+	}
+	ips, err := resolver.LookupIP("peer.example")
+	require.NoError(t, err)
+	require.Len(t, ips, 2)
+	require.True(t, ips[0].Equal(net.ParseIP("192.0.2.7")))
+	require.True(t, ips[1].Equal(net.ParseIP("2001:db8::7")))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.ElementsMatch(t, []string{"A", "AAAA"}, queries)
+}
+
+func TestDoHResolverLiteralIP(t *testing.T) {
+	t.Parallel()
+
+	resolver := &DoHResolver{}
+	ips, err := resolver.LookupIP("192.0.2.9")
+	require.NoError(t, err)
+	require.Len(t, ips, 1)
+	require.True(t, ips[0].Equal(net.ParseIP("192.0.2.9")))
+}
+
+func TestDoHResolverPartialFamilyFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		r *http.Request) {
+
+		if r.URL.Query().Get("type") == "AAAA" {
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"Status": 2,
+			}); err != nil {
+				t.Errorf("encode DNS response: %v", err)
+			}
+			return
+		}
+
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"Status": 0,
+			"Answer": []map[string]any{{
+				"type": 1,
+				"data": "192.0.2.7",
+			}},
+		}); err != nil {
+			t.Errorf("encode DNS response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	resolver := &DoHResolver{
+		Endpoint: server.URL,
+		Client:   server.Client(),
+	}
+	ips, err := resolver.LookupIP("peer.example")
+	require.NoError(t, err)
+	require.Len(t, ips, 1)
+	require.True(t, ips[0].Equal(net.ParseIP("192.0.2.7")))
+}
+
+func TestDoHResolverDNSFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+		_ *http.Request) {
+
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"Status": 3,
+		}); err != nil {
+			t.Errorf("encode DNS response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	resolver := &DoHResolver{
+		Endpoint: server.URL,
+		Client:   server.Client(),
+	}
+	_, err := resolver.LookupIP("missing.example")
+	require.ErrorContains(t, err, "returned status 3")
+}


### PR DESCRIPTION
## Summary

This change lets a Neutrino client running as Go/WebAssembly (WASM) connect to
Bitcoin peers through the browser's WebTransport API.

`wasmtransport.NewDialer` returns the same dial function accepted by
`neutrino.Config.Dialer`. It maps a Bitcoin peer address to an HTTPS
WebTransport endpoint, supports browser certificate-hash pinning, and exposes
the session's single bidirectional stream as a `net.Conn`. The package also
provides DNS-over-HTTPS helpers for browser runtimes that cannot use Go's
native DNS path.

The paired btcd server change is required for direct interoperability:
https://github.com/btcsuite/btcd/pull/2582

## ChainService integration

A transport-only handshake can miss failures in Neutrino's connection manager,
header synchronization, filter queries, or storage wiring. This PR therefore
adds an opt-in real-browser integration test that:

1. Starts a full native btcd simnet node with WebTransport enabled.
2. Runs an actual `neutrino.ChainService` as Go/WASM in stock Chrome.
3. Synchronizes the exact block-header and regular-filter-header hashes from
   genesis to height 12.
4. Fetches a compact filter through `ChainService.GetCFilter` and compares its
   bytes with btcd's RPC result.
5. Mines three more blocks and proves that both tips advance to height 15 over
   the existing WebTransport connection, then compares the new compact filter.
6. Confirms through btcd RPC that the browser client is an inbound peer on the
   WebTransport listener.

`ChainService` normally constructs walletdb and flat-file stores directly.
The test cannot use those stores in a stock browser, so `Config.Stores` allows
callers to inject the existing storage interfaces as one complete set. The
default walletdb/flat-file path is unchanged. The integration test uses
concurrency-safe stores under `internal/memstore`; those stores are volatile
test fixtures, not a production browser persistence backend.

## Review order

The commits separate the transport from its end-to-end proof:

1. Add the browser WebTransport dialer and DNS helpers.
2. Allow a complete set of custom `ChainService` stores.
3. Add volatile in-memory stores for tests.
4. Add the full Chrome-to-btcd synchronization test.

## Validation

```bash
go vet ./...
GOOS=js GOARCH=wasm CGO_ENABLED=0 go build ./...
go test -race ./internal/memstore
PATH=/path/to/btcd:$PATH go test ./...
```

With a btcd binary built from the paired PR:

```bash
BTCD_WEBTRANSPORT_BIN=/absolute/path/to/btcd \
  go test -v -tags=rpctest ./itest/webtransport \
  -run '^TestWebTransportBrowserChainServiceSync$' -count=1
```

The browser integration test passes repeatedly with Chrome 150. It uses
certificate-hash pinning and does not disable TLS verification.

## Scope

This PR proves an ephemeral browser `ChainService` can connect and synchronize
over WebTransport. Durable browser persistence and restart recovery still need
a browser-backed database such as SQLite on the Origin Private File System
(OPFS); the in-memory fixtures do not claim to solve that separate runtime
requirement.
