### PR TITLE
query: announce transactions with a non-witness inv type

### DIFF
--- a/query.go
+++ b/query.go
@@ -958,20 +958,19 @@ func (s *ChainService) GetBlock(blockHash chainhash.Hash,
 // cannot be done at the moment due to circular dependencies.
 func (s *ChainService) sendTransaction(tx *wire.MsgTx, options ...QueryOption) error {
 	// Starting with the set of default options, we'll apply any specified
-	// functional options to the query so that we can check what inv type
-	// to use. Broadcast the inv to all peers, responding to any getdata
-	// messages for the transaction.
+	// functional options to the query so we know which encoding to serve
+	// the transaction with. We broadcast an inv to all peers and respond to
+	// any getdata messages for the transaction.
 	qo := defaultQueryOptions()
 	qo.applyQueryOptions(options...)
-	invType := wire.InvTypeWitnessTx
-	if qo.encoding == wire.BaseEncoding {
-		invType = wire.InvTypeTx
-	}
 
-	// Create an inv.
+	// Announce the transaction with a non-witness inv type. Per BIP-144 the
+	// witness inv types (MSG_WITNESS_TX) are only valid in getdata, not in
+	// inv; a peer that wants the witness serialization requests it via
+	// getdata, which we answer using qo.encoding below.
 	txHash := tx.TxHash()
 	inv := wire.NewMsgInv()
-	_ = inv.AddInvVect(wire.NewInvVect(invType, &txHash))
+	_ = inv.AddInvVect(wire.NewInvVect(wire.InvTypeTx, &txHash))
 
 	// We'll gather all the peers who replied to our query, along with
 	// the ones who rejected it and their reason for rejecting it. We'll use

--- a/query.go
+++ b/query.go
@@ -948,6 +948,18 @@ func (s *ChainService) GetBlock(blockHash chainhash.Hash,
 	return foundBlock, nil
 }
 
+// newTransactionInv creates the inventory used to announce a transaction.
+// BIP-144 reserves witness inventory types for getdata, where the requesting
+// peer selects the transaction encoding. The preceding inv therefore always
+// identifies the transaction by its txid using MSG_TX.
+func newTransactionInv(tx *wire.MsgTx) *wire.MsgInv {
+	txHash := tx.TxHash()
+	inv := wire.NewMsgInv()
+	_ = inv.AddInvVect(wire.NewInvVect(wire.InvTypeTx, &txHash))
+
+	return inv
+}
+
 // sendTransaction sends a transaction to all peers. It returns an error if any
 // peer rejects the transaction.
 //
@@ -964,13 +976,10 @@ func (s *ChainService) sendTransaction(tx *wire.MsgTx, options ...QueryOption) e
 	qo := defaultQueryOptions()
 	qo.applyQueryOptions(options...)
 
-	// Announce the transaction with a non-witness inv type. Per BIP-144 the
-	// witness inv types (MSG_WITNESS_TX) are only valid in getdata, not in
-	// inv; a peer that wants the witness serialization requests it via
-	// getdata, which we answer using qo.encoding below.
+	// Announce the transaction by txid. A peer can request its preferred
+	// serialization in getdata, which we answer using qo.encoding below.
 	txHash := tx.TxHash()
-	inv := wire.NewMsgInv()
-	_ = inv.AddInvVect(wire.NewInvVect(wire.InvTypeTx, &txHash))
+	inv := newTransactionInv(tx)
 
 	// We'll gather all the peers who replied to our query, along with
 	// the ones who rejected it and their reason for rejecting it. We'll use

--- a/query_test.go
+++ b/query_test.go
@@ -247,6 +247,21 @@ func TestBigFilterEvictsEverything(t *testing.T) {
 	assertEqual(t, getFilter(cs, b3, t), f3, "")
 }
 
+// TestTransactionInv ensures transaction announcements use the txid-based
+// inventory type. Witness serialization is negotiated later when a peer sends
+// getdata, so it must not change the preceding announcement.
+func TestTransactionInv(t *testing.T) {
+	t.Parallel()
+
+	tx := wire.NewMsgTx(2)
+	txHash := tx.TxHash()
+	inv := newTransactionInv(tx)
+
+	require.Len(t, inv.InvList, 1)
+	require.Equal(t, wire.InvTypeTx, inv.InvList[0].Type)
+	require.Equal(t, txHash, inv.InvList[0].Hash)
+}
+
 // TestBlockCache checks that blocks are inserted and fetched from the cache
 // before peers are queried.
 func TestBlockCache(t *testing.T) {


### PR DESCRIPTION
`sendTransaction` announces a broadcast as `InvTypeWitnessTx` when the query encoding is witness (`query.go:966`). Per BIP-144 the witness inv types (`MSG_WITNESS_TX`) are valid only in `getdata`, not in `inv`, which must use `MSG_TX`. A peer that wants the witness serialization requests it via `getdata`, and that reply still uses `qo.encoding` unchanged (`query.go:1010`), so the announcement type is all that changes here.

The block sibling at `query.go:816` builds a `getdata`, where the witness type is correct, so it is left as-is.

Fixes #384.
