### PR TITLE
chainimport: align imported header validation with p2p sync

### DIFF
--- a/chainimport/block_headers_validator.go
+++ b/chainimport/block_headers_validator.go
@@ -3,6 +3,7 @@ package chainimport
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
 
 	"github.com/btcsuite/btcd/blockchain"
@@ -61,6 +62,14 @@ func (v *blockHeadersImportSourceValidator) Validate(ctx context.Context,
 		lastHeader Header
 	)
 
+	if start > end {
+		return io.EOF
+	}
+
+	if err := v.validateBoundary(start); err != nil {
+		return fmt.Errorf("boundary validation failed: %w", err)
+	}
+
 	for batch, err := range it.BatchIterator(start, end, batchSize) {
 		if err != nil {
 			return fmt.Errorf("failed to get next batch for "+
@@ -94,6 +103,69 @@ func (v *blockHeadersImportSourceValidator) Validate(ctx context.Context,
 
 	log.Debugf("Successfully validated %d block headers", count)
 	return nil
+}
+
+// validateBoundary gives the first header the parent context that pair-wise
+// validation normally obtains from the preceding element. A subrange uses the
+// preceding source header, while the first source range connects to either the
+// network genesis or the existing target-store tip.
+func (v *blockHeadersImportSourceValidator) validateBoundary(
+	start uint32) error {
+
+	current, err := v.blockHeadersImportSource.GetHeader(start)
+	if err != nil {
+		return fmt.Errorf("failed to get first block header: %w", err)
+	}
+
+	if start > 0 {
+		previous, err := v.blockHeadersImportSource.GetHeader(start - 1)
+		if err != nil {
+			return fmt.Errorf("failed to get preceding block header: %w",
+				err)
+		}
+
+		return v.ValidatePair(previous, current)
+	}
+
+	metadata, err := v.blockHeadersImportSource.GetHeaderMetadata()
+	if err != nil {
+		return fmt.Errorf("failed to get block header metadata: %w", err)
+	}
+
+	if metadata.startHeight == 0 {
+		first, err := assertBlockHeader(current)
+		if err != nil {
+			return err
+		}
+
+		firstHash := first.BlockHash()
+		if !firstHash.IsEqual(v.targetChainParams.GenesisHash) {
+			return fmt.Errorf("block header at height 0 does not match "+
+				"network genesis: got %v, want %v", firstHash,
+				v.targetChainParams.GenesisHash)
+		}
+
+		return v.ValidateSingle(current)
+	}
+
+	// The target store owns history below the source range. Its tip gives
+	// the first imported header the same contextual checks as a header
+	// received from a peer.
+	previousHeight := metadata.startHeight - 1
+	previous, err := v.targetBlockHeaderStore.FetchHeaderByHeight(
+		previousHeight,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get target block header at height "+
+			"%d: %w", previousHeight, err)
+	}
+
+	return v.ValidatePair(&blockHeader{
+		BlockHeader: headerfs.BlockHeader{
+			BlockHeader: previous,
+			Height:      previousHeight,
+		},
+	}, current)
 }
 
 // ValidateSingle validates a single block header for basic sanity.
@@ -159,7 +231,7 @@ func (v *blockHeadersImportSourceValidator) ValidatePair(prev,
 	}
 
 	if err := blockchain.CheckBlockHeaderContext(
-		currBlockHeader.BlockHeader, parentCtx, v.flags, chainCtx, true,
+		currBlockHeader.BlockHeader, parentCtx, v.flags, chainCtx, false,
 	); err != nil {
 		return fmt.Errorf("block header contextual validation "+
 			"failed: %w", err)
@@ -176,8 +248,13 @@ func (v *blockHeadersImportSourceValidator) ValidatePair(prev,
 func (v *blockHeadersImportSourceValidator) ValidateBatch(
 	headers []Header) error {
 
-	if len(headers) == 1 {
-		return v.ValidateSingle(headers[0])
+	if len(headers) == 0 {
+		return nil
+	}
+
+	if err := v.ValidateSingle(headers[0]); err != nil {
+		return fmt.Errorf("validation failed at batch position 0: %w",
+			err)
 	}
 
 	for i := 1; i < len(headers); i++ {
@@ -227,15 +304,20 @@ func (l *lightHeaderCtx) RelativeAncestorCtx(
 
 	ancestorHeight := uint32(math.Max(0, float64(l.height-distance)))
 
-	// Lookup the ancestor in the target store.
+	// The target store owns history below an imported range. Source-only
+	// validation doesn't require one. Prefer the store when present, and
+	// otherwise use the import source for ancestors within the supplied
+	// range.
 	targetStore := l.validator.targetBlockHeaderStore
-	ancestor, err := targetStore.FetchHeaderByHeight(ancestorHeight)
-	if err == nil {
-		return &lightHeaderCtx{
-			height:    int32(ancestorHeight),
-			bits:      ancestor.Bits,
-			timestamp: ancestor.Timestamp.Unix(),
-			validator: l.validator,
+	if targetStore != nil {
+		ancestor, err := targetStore.FetchHeaderByHeight(ancestorHeight)
+		if err == nil {
+			return &lightHeaderCtx{
+				height:    int32(ancestorHeight),
+				bits:      ancestor.Bits,
+				timestamp: ancestor.Timestamp.Unix(),
+				validator: l.validator,
+			}
 		}
 	}
 
@@ -327,7 +409,16 @@ func (l *lightChainCtx) MaxRetargetTimespan() int64 {
 func (l *lightChainCtx) VerifyCheckpoint(height int32,
 	hash *chainhash.Hash) bool {
 
-	return false
+	for i := range l.params.Checkpoints {
+		checkpoint := &l.params.Checkpoints[i]
+		if checkpoint.Height != height {
+			continue
+		}
+
+		return hash.IsEqual(checkpoint.Hash)
+	}
+
+	return true
 }
 
 // FindPreviousCheckpoint returns the most recent checkpoint that we have

--- a/chainimport/block_headers_validator.go
+++ b/chainimport/block_headers_validator.go
@@ -120,8 +120,8 @@ func (v *blockHeadersImportSourceValidator) validateBoundary(
 	if start > 0 {
 		previous, err := v.blockHeadersImportSource.GetHeader(start - 1)
 		if err != nil {
-			return fmt.Errorf("failed to get preceding block header: %w",
-				err)
+			return fmt.Errorf("failed to get preceding block "+
+				"header: %w", err)
 		}
 
 		return v.ValidatePair(previous, current)
@@ -129,7 +129,8 @@ func (v *blockHeadersImportSourceValidator) validateBoundary(
 
 	metadata, err := v.blockHeadersImportSource.GetHeaderMetadata()
 	if err != nil {
-		return fmt.Errorf("failed to get block header metadata: %w", err)
+		return fmt.Errorf("failed to get block header metadata: %w",
+			err)
 	}
 
 	if metadata.startHeight == 0 {
@@ -140,9 +141,9 @@ func (v *blockHeadersImportSourceValidator) validateBoundary(
 
 		firstHash := first.BlockHash()
 		if !firstHash.IsEqual(v.targetChainParams.GenesisHash) {
-			return fmt.Errorf("block header at height 0 does not match "+
-				"network genesis: got %v, want %v", firstHash,
-				v.targetChainParams.GenesisHash)
+			return fmt.Errorf("block header at height 0 does not "+
+				"match network genesis: got %v, want %v",
+				firstHash, v.targetChainParams.GenesisHash)
 		}
 
 		return v.ValidateSingle(current)
@@ -156,8 +157,8 @@ func (v *blockHeadersImportSourceValidator) validateBoundary(
 		previousHeight,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to get target block header at height "+
-			"%d: %w", previousHeight, err)
+		return fmt.Errorf("failed to get target block header at "+
+			"height %d: %w", previousHeight, err)
 	}
 
 	return v.ValidatePair(&blockHeader{
@@ -231,7 +232,8 @@ func (v *blockHeadersImportSourceValidator) ValidatePair(prev,
 	}
 
 	if err := blockchain.CheckBlockHeaderContext(
-		currBlockHeader.BlockHeader, parentCtx, v.flags, chainCtx, false,
+		currBlockHeader.BlockHeader, parentCtx, v.flags, chainCtx,
+		false,
 	); err != nil {
 		return fmt.Errorf("block header contextual validation "+
 			"failed: %w", err)

--- a/chainimport/filter_headers_validator.go
+++ b/chainimport/filter_headers_validator.go
@@ -33,8 +33,9 @@ func newFilterHeadersImportSourceValidator(
 
 // Validate checks imported filter headers against hardcoded checkpoints. This
 // detects a known mismatch, but doesn't authenticate entries between
-// checkpoints. The importer therefore doesn't write these values to the filter
-// header store.
+// checkpoints. Importing filter headers therefore trusts the configured source
+// for those entries. Compact filters fetched later are still checked against
+// the imported filter-header commitments before use.
 //
 // The validation utilizes the existing checkpointing mechanism based on the
 // hardcoded filter headers at different checkpoints. Individual headers are

--- a/chainimport/filter_headers_validator.go
+++ b/chainimport/filter_headers_validator.go
@@ -31,8 +31,10 @@ func newFilterHeadersImportSourceValidator(
 	}
 }
 
-// Validate performs validation on a batch of filter headers using hardcoded
-// checkpoints.
+// Validate checks imported filter headers against hardcoded checkpoints. This
+// detects a known mismatch, but doesn't authenticate entries between
+// checkpoints. The importer therefore doesn't write these values to the filter
+// header store.
 //
 // The validation utilizes the existing checkpointing mechanism based on the
 // hardcoded filter headers at different checkpoints. Individual headers are
@@ -113,8 +115,7 @@ func (v *filterHeadersImportSourceValidator) ValidateSingle(h Header) error {
 	return nil
 }
 
-// ValidatePair checks if two consecutive filter headers maintain the correct
-// cryptographic relationship.
+// ValidatePair can't check the relationship between consecutive filter headers.
 //
 // In a full validation, we would verify that each filter header is correctly
 // derived by hashing the previous filter header with the current block's

--- a/chainimport/headers_import.go
+++ b/chainimport/headers_import.go
@@ -128,10 +128,10 @@ type headerRegion struct {
 	syncModes syncModes
 }
 
-// headersImport orchestrates the import of blockchain headers from external
-// sources into local header stores. It handles validation, processing, and
-// atomic writes of both block headers and filter headers while maintaining
-// chain integrity and consistency between stores.
+// headersImport validates block headers from external sources and writes them
+// to the local block header store. Filter header files are checked against
+// known checkpoints, but aren't written because their contents can't be
+// authenticated without the corresponding compact filter hashes.
 type headersImport struct {
 	// blockHeadersImportSource provides access to block headers from import
 	// source.
@@ -144,7 +144,8 @@ type headersImport struct {
 	// blockHeadersValidator validates the imported block headers.
 	blockHeadersValidator HeadersValidator
 
-	// filterHeadersValidator validates the imported filter headers.
+	// filterHeadersValidator checks imported filter headers against known
+	// checkpoints.
 	filterHeadersValidator HeadersValidator
 
 	// options contains configuration parameters for the import process.
@@ -225,7 +226,8 @@ func (h *headersImport) Import(ctx context.Context) (*ImportResult, error) {
 			"headers: %w", err)
 	}
 
-	log.Debugf("Validating %d filter headers", metadata.headersCount)
+	log.Debugf("Checking %d filter headers against known checkpoints",
+		metadata.headersCount)
 	filterHeadersIterator := h.filterHeadersImportSource.Iterator(
 		0, metadata.headersCount-1,
 		uint32(h.options.WriteBatchSizePerRegion),
@@ -272,8 +274,8 @@ func (h *headersImport) Import(ctx context.Context) (*ImportResult, error) {
 	result.EndTime = time.Now()
 	result.Duration = result.EndTime.Sub(result.StartTime)
 
-	log.Infof("Headers import completed: processed %d headers "+
-		"(block and filter) (added: %d, skipped: %d) from height "+
+	log.Infof("Headers import completed: processed %d block headers "+
+		"(added: %d, skipped: %d) from height "+
 		"%d to %d in %s (%.2f headers/sec, %.2f%% new)",
 		result.ProcessedCount, result.AddedCount, result.SkippedCount,
 		result.StartHeight, result.EndHeight, result.Duration,
@@ -306,28 +308,18 @@ func (h *headersImport) validateChainContinuity() error {
 			"tip: %w", err)
 	}
 
-	// Take the minimum of the two heights as the effective chain tip height
-	// to handle the case where one store might be ahead in case of existent
-	// divergence region.
-	effectiveTipHeight := min(blockTipHeight, filterTipHeight)
-	if blockTipHeight != filterTipHeight {
-		log.Infof("Target header stores at different heights "+
-			"(block=%d, filter=%d), using effective tip height %d",
-			blockTipHeight, filterTipHeight, effectiveTipHeight)
-	}
-
 	importStartHeight := sourceMetadata.startHeight
 	importEndHeight := sourceMetadata.endHeight
 
 	switch {
-	case importStartHeight > effectiveTipHeight+1:
+	case importStartHeight > blockTipHeight+1:
 		// Import data doesn't start at the next height after the target
 		// tip height, there would be a gap in the chain.
 		return fmt.Errorf("import data starts at height %d but target "+
 			"tip is at %d, creating a gap", importStartHeight,
-			effectiveTipHeight)
+			blockTipHeight)
 
-	case importStartHeight > effectiveTipHeight:
+	case importStartHeight > blockTipHeight:
 		// Import data starts immediately after the target tip height.
 		// This is a forward extension.
 		if err := h.validateHeaderConnection(
@@ -346,11 +338,15 @@ func (h *headersImport) validateChainContinuity() error {
 
 		// First we need to determine the overlap range.
 		overlapStart := importStartHeight
-		overlapEnd := min(effectiveTipHeight, importEndHeight)
+		overlapEnd := min(blockTipHeight, importEndHeight)
 
 		// Now we can verify headers at the start of the overlap range.
+		verifyStart := verifyBlockOnly
+		if overlapStart <= filterTipHeight {
+			verifyStart = verifyBlockAndFilter
+		}
 		if err = h.verifyHeadersAtTargetHeight(
-			overlapStart, verifyBlockAndFilter,
+			overlapStart, verifyStart,
 		); err != nil {
 			return err
 		}
@@ -358,8 +354,12 @@ func (h *headersImport) validateChainContinuity() error {
 		// If overlap range is more than 1 header, we can also verify at
 		// the end.
 		if overlapEnd > overlapStart {
+			verifyEnd := verifyBlockOnly
+			if overlapEnd <= filterTipHeight {
+				verifyEnd = verifyBlockAndFilter
+			}
 			if err = h.verifyHeadersAtTargetHeight(
-				overlapEnd, verifyBlockAndFilter,
+				overlapEnd, verifyEnd,
 			); err != nil {
 				return err
 			}
@@ -565,36 +565,26 @@ func (h *headersImport) determineProcessingRegions() (*processingRegions, error)
 		effectiveTip:      effectiveTipHeight,
 	}
 
-	// 1. Divergence Headers region.
-	// This region contains headers where one store extends beyond the
-	// effective tip but still within the import range. It represents
-	// heights where targetblock and filter headers are out of sync and need
-	// reconciliation.
+	// A divergence region spans the heights held by only one target store.
+	// When the filter store leads, the imported block chain can fill the gap
+	// after its connection has been checked. When the block store leads, the
+	// missing filter headers remain the responsibility of peer sync because
+	// the import file can't derive them from compact filters.
 	divergeStart := effectiveTipHeight + 1
 	divergeEnd := min(max(bTipHeight, fTipHeight), importEndHeight)
 	divergeExists := bTipHeight != fTipHeight && divergeStart <= divergeEnd
-	divergenceSyncModes := h.determineDivergenceSyncModes(
-		bTipHeight, fTipHeight,
-	)
 	regions.divergence = headerRegion{
-		start:     divergeStart,
-		end:       divergeEnd,
-		exists:    divergeExists,
-		syncModes: divergenceSyncModes,
+		start:  divergeStart,
+		end:    divergeEnd,
+		exists: divergeExists,
+		syncModes: h.determineDivergenceSyncModes(
+			bTipHeight, fTipHeight,
+		),
 	}
 
-	// 2. New Headers region.
-	// This region contains headers that are in the import source but not
-	// yet in either target store. They start one height beyond the highest
-	// tip of either store (ensuring no overlap with divergence region) and
-	// extend to the end of the import data. These headers need to be added
-	// to both stores. It only exists if there are headers beyond both tips.
-	//
-	// Note: This region is supposed to be processed after handling the
-	// divergence region, ensuring that any potential inconsistencies in
-	// existing data are resolved before adding new headers. This sequential
-	// processing guarantees that new headers are only added on top of a
-	// verified and consistent chain state.
+	// A new region extends beyond both target stores. We only extend the block
+	// store here: the normal multi-peer synchronization path derives and
+	// verifies the missing filter headers from compact filter hashes.
 	newStart := max(bTipHeight, fTipHeight) + 1
 	newEnd := importEndHeight
 	regions.newHeaders = headerRegion{
@@ -602,7 +592,7 @@ func (h *headersImport) determineProcessingRegions() (*processingRegions, error)
 		end:    newEnd,
 		exists: newStart <= newEnd,
 		syncModes: syncModes{
-			append: appendBlockAndFilter,
+			append: appendBlockOnly,
 		},
 	}
 
@@ -648,6 +638,22 @@ func (h *headersImport) processDivergenceHeadersRegion(ctx context.Context,
 
 	log.Infof("Processing %d divergence headers from heights %d to %d",
 		region.end-region.start+1, region.start, region.end)
+
+	// A leading block store already contains the only values this format can
+	// validate fully. Verify that it agrees with the source, then leave the
+	// filter store untouched so peer sync can authenticate its continuation.
+	if region.syncModes.append == appendFilterOnly {
+		if err := h.verifyHeadersAtTargetHeight(
+			region.end, verifyBlockOnly,
+		); err != nil {
+			return fmt.Errorf("failed to verify leading block header: %w",
+				err)
+		}
+
+		log.Infof("Leaving filter headers at their current tip for " +
+			"peer-validated synchronization")
+		return nil
+	}
 
 	if err := h.validateLeadAndSyncLag(ctx, region); err != nil {
 		return fmt.Errorf("failed to validate lead and sync lag "+
@@ -696,7 +702,7 @@ func (h *headersImport) processNewHeadersRegion(ctx context.Context,
 		return nil
 	}
 
-	log.Infof("Adding %d new headers (block and filter) from heights "+
+	log.Infof("Adding %d new block headers from heights "+
 		"%d to %d", region.end-region.start+1, region.start, region.end)
 
 	if err := h.appendNewHeaders(
@@ -721,6 +727,13 @@ func (h *headersImport) appendNewHeaders(ctx context.Context, startHeight,
 			"metadata: %w", err)
 	}
 
+	// Filter headers need their compact filter hashes to establish each link
+	// in the chain. Since the current format doesn't carry those hashes, no
+	// caller may route imported filter headers into the persistence path.
+	if appendMode != appendBlockOnly {
+		return fmt.Errorf("importing filter headers is unsupported")
+	}
+
 	totalHeaders := endHeight - startHeight + 1
 	log.Infof("Appending %d new headers in batches of %d", totalHeaders,
 		h.options.WriteBatchSizePerRegion)
@@ -737,11 +750,6 @@ func (h *headersImport) appendNewHeaders(ctx context.Context, startHeight,
 		uint32(h.options.WriteBatchSizePerRegion),
 	)
 
-	filterIter := h.filterHeadersImportSource.Iterator(
-		sourceStartIdx, sourceEndIdx,
-		uint32(h.options.WriteBatchSizePerRegion),
-	)
-
 	batchStart := startHeight
 	for {
 		if err := ctxCancelled(ctx); err != nil {
@@ -749,7 +757,7 @@ func (h *headersImport) appendNewHeaders(ctx context.Context, startHeight,
 		}
 
 		batchEnd, err := h.processBatch(
-			blockIter, filterIter, batchStart, appendMode,
+			blockIter, nil, batchStart, appendMode,
 		)
 		if err == io.EOF {
 			break
@@ -974,9 +982,9 @@ func (h *headersImport) validateHeaderConnection(targetStartHeight,
 		return err
 	}
 
-	// Ensure the current header's previous block hash matches the
-	// hash of the previously fetched block header to maintain chain
-	// integrity.
+	// This inexpensive connection check runs before full source validation.
+	// The validator later reuses the same pair as contextual parent and
+	// child.
 	prevHash := prevBlkHdr.BlockHash()
 	if !currBlkHeader.PrevBlock.IsEqual(&prevHash) {
 		return fmt.Errorf("header chain broken: current "+

--- a/chainimport/headers_import.go
+++ b/chainimport/headers_import.go
@@ -128,10 +128,10 @@ type headerRegion struct {
 	syncModes syncModes
 }
 
-// headersImport validates block headers from external sources and writes them
-// to the local block header store. Filter header files are checked against
-// known checkpoints, but aren't written because their contents can't be
-// authenticated without the corresponding compact filter hashes.
+// headersImport validates headers from external sources and writes them to the
+// local header stores. Block headers receive full consensus validation. Filter
+// headers are checked against known checkpoints, while the configured import
+// source remains trusted for entries between those checkpoints.
 type headersImport struct {
 	// blockHeadersImportSource provides access to block headers from import
 	// source.
@@ -226,8 +226,7 @@ func (h *headersImport) Import(ctx context.Context) (*ImportResult, error) {
 			"headers: %w", err)
 	}
 
-	log.Debugf("Checking %d filter headers against known checkpoints",
-		metadata.headersCount)
+	log.Debugf("Validating %d filter headers", metadata.headersCount)
 	filterHeadersIterator := h.filterHeadersImportSource.Iterator(
 		0, metadata.headersCount-1,
 		uint32(h.options.WriteBatchSizePerRegion),
@@ -274,7 +273,7 @@ func (h *headersImport) Import(ctx context.Context) (*ImportResult, error) {
 	result.EndTime = time.Now()
 	result.Duration = result.EndTime.Sub(result.StartTime)
 
-	log.Infof("Headers import completed: processed %d block headers "+
+	log.Infof("Headers import completed: processed %d headers "+
 		"(added: %d, skipped: %d) from height "+
 		"%d to %d in %s (%.2f headers/sec, %.2f%% new)",
 		result.ProcessedCount, result.AddedCount, result.SkippedCount,
@@ -565,14 +564,15 @@ func (h *headersImport) determineProcessingRegions() (*processingRegions, error)
 		effectiveTip:      effectiveTipHeight,
 	}
 
-	// A divergence region spans the heights held by only one target store.
-	// When the filter store leads, the imported block chain can fill the gap
-	// after its connection has been checked. When the block store leads, the
-	// missing filter headers remain the responsibility of peer sync because
-	// the import file can't derive them from compact filters.
-	divergeStart := effectiveTipHeight + 1
+	// A divergence region can only be reconciled when the import source
+	// contains the first header missing from the lagging store. Clipping the
+	// region to the import range isn't sufficient because it would leave a gap
+	// before the first appended header.
+	divergeStart := max(effectiveTipHeight+1, importStartHeight)
 	divergeEnd := min(max(bTipHeight, fTipHeight), importEndHeight)
-	divergeExists := bTipHeight != fTipHeight && divergeStart <= divergeEnd
+	divergeExists := bTipHeight != fTipHeight &&
+		importStartHeight <= effectiveTipHeight+1 &&
+		divergeStart <= divergeEnd
 	regions.divergence = headerRegion{
 		start:  divergeStart,
 		end:    divergeEnd,
@@ -582,18 +582,22 @@ func (h *headersImport) determineProcessingRegions() (*processingRegions, error)
 		),
 	}
 
-	// A new region extends beyond both target stores. We only extend the block
-	// store here: the normal multi-peer synchronization path derives and
-	// verifies the missing filter headers from compact filter hashes.
-	newStart := max(bTipHeight, fTipHeight) + 1
+	newStart := max(max(bTipHeight, fTipHeight)+1, importStartHeight)
 	newEnd := importEndHeight
+	newAppendMode := appendBlockAndFilter
+	if bTipHeight > fTipHeight &&
+		importStartHeight > fTipHeight+1 {
+
+		// The import source doesn't contain the gap between the filter
+		// store and the block store. Keep importing block headers, but leave
+		// the filter gap and continuation for peer synchronization.
+		newAppendMode = appendBlockOnly
+	}
 	regions.newHeaders = headerRegion{
-		start:  newStart,
-		end:    newEnd,
-		exists: newStart <= newEnd,
-		syncModes: syncModes{
-			append: appendBlockOnly,
-		},
+		start:     newStart,
+		end:       newEnd,
+		exists:    newStart <= newEnd,
+		syncModes: syncModes{append: newAppendMode},
 	}
 
 	return regions, nil
@@ -638,22 +642,6 @@ func (h *headersImport) processDivergenceHeadersRegion(ctx context.Context,
 
 	log.Infof("Processing %d divergence headers from heights %d to %d",
 		region.end-region.start+1, region.start, region.end)
-
-	// A leading block store already contains the only values this format can
-	// validate fully. Verify that it agrees with the source, then leave the
-	// filter store untouched so peer sync can authenticate its continuation.
-	if region.syncModes.append == appendFilterOnly {
-		if err := h.verifyHeadersAtTargetHeight(
-			region.end, verifyBlockOnly,
-		); err != nil {
-			return fmt.Errorf("failed to verify leading block header: %w",
-				err)
-		}
-
-		log.Infof("Leaving filter headers at their current tip for " +
-			"peer-validated synchronization")
-		return nil
-	}
 
 	if err := h.validateLeadAndSyncLag(ctx, region); err != nil {
 		return fmt.Errorf("failed to validate lead and sync lag "+
@@ -702,7 +690,7 @@ func (h *headersImport) processNewHeadersRegion(ctx context.Context,
 		return nil
 	}
 
-	log.Infof("Adding %d new block headers from heights "+
+	log.Infof("Adding %d new headers from heights "+
 		"%d to %d", region.end-region.start+1, region.start, region.end)
 
 	if err := h.appendNewHeaders(
@@ -727,13 +715,6 @@ func (h *headersImport) appendNewHeaders(ctx context.Context, startHeight,
 			"metadata: %w", err)
 	}
 
-	// Filter headers need their compact filter hashes to establish each link
-	// in the chain. Since the current format doesn't carry those hashes, no
-	// caller may route imported filter headers into the persistence path.
-	if appendMode != appendBlockOnly {
-		return fmt.Errorf("importing filter headers is unsupported")
-	}
-
 	totalHeaders := endHeight - startHeight + 1
 	log.Infof("Appending %d new headers in batches of %d", totalHeaders,
 		h.options.WriteBatchSizePerRegion)
@@ -749,15 +730,21 @@ func (h *headersImport) appendNewHeaders(ctx context.Context, startHeight,
 		sourceStartIdx, sourceEndIdx,
 		uint32(h.options.WriteBatchSizePerRegion),
 	)
+	filterIter := h.filterHeadersImportSource.Iterator(
+		sourceStartIdx, sourceEndIdx,
+		uint32(h.options.WriteBatchSizePerRegion),
+	)
 
-	batchStart := startHeight
+	batchStartHeight := startHeight
+	batchStartIndex := sourceStartIdx
 	for {
 		if err := ctxCancelled(ctx); err != nil {
 			return err
 		}
 
-		batchEnd, err := h.processBatch(
-			blockIter, nil, batchStart, appendMode,
+		batchEndHeight, headersRead, err := h.processBatch(
+			blockIter, filterIter, batchStartIndex,
+			batchStartHeight, appendMode,
 		)
 		if err == io.EOF {
 			break
@@ -767,7 +754,8 @@ func (h *headersImport) appendNewHeaders(ctx context.Context, startHeight,
 		}
 
 		// Move to next batch.
-		batchStart = batchEnd + 1
+		batchStartHeight = batchEndHeight + 1
+		batchStartIndex += headersRead
 	}
 
 	log.Infof("Successfully added %d new headers from heights %d to %d",
@@ -780,55 +768,62 @@ func (h *headersImport) appendNewHeaders(ctx context.Context, startHeight,
 // returns the batch end height on success, or an error including io.EOF when no
 // more batches.
 func (h *headersImport) processBatch(blockIter, filterIter HeaderIterator,
-	batchStart uint32, appendMode appendMode) (uint32, error) {
+	batchStartIndex, batchStartHeight uint32,
+	appendMode appendMode) (uint32, uint32, error) {
 
 	var (
-		blockHeaders  []headerfs.BlockHeader
-		filterHeaders []headerfs.FilterHeader
-		batchEnd      uint32
+		blockHeaders   []headerfs.BlockHeader
+		filterHeaders  []headerfs.FilterHeader
+		batchEndHeight uint32
+		headersRead    uint32
 	)
 
 	if appendMode != appendFilterOnly {
 		blockBatch, blockErr := blockIter.ReadBatch(
-			batchStart, blockIter.GetEndIndex(),
+			batchStartIndex, blockIter.GetEndIndex(),
 			blockIter.GetBatchSize(),
 		)
 		if blockErr == io.EOF {
-			return 0, io.EOF
+			return 0, 0, io.EOF
 		}
 		if blockErr != nil {
-			return 0, fmt.Errorf("failed to read block headers "+
-				"batch at height %d: %w", batchStart, blockErr)
+			return 0, 0, fmt.Errorf("failed to read block headers "+
+				"batch at height %d: %w", batchStartHeight,
+				blockErr)
 		}
-
 		// Convert block header batches to target store format.
 		blockHeaders = make([]headerfs.BlockHeader, 0, len(blockBatch))
 		for _, header := range blockBatch {
 			blkHeader, err := assertBlockHeader(header)
 			if err != nil {
-				return 0, err
+				return 0, 0, err
 			}
 			blockHeaders = append(
 				blockHeaders, blkHeader.BlockHeader,
 			)
 		}
 
-		batchEnd = batchStart + uint32(len(blockBatch)) - 1
+		headersRead = uint32(len(blockBatch))
+		if headersRead > 0 {
+			batchEndHeight = batchStartHeight + headersRead - 1
+		}
 	}
 
 	if appendMode != appendBlockOnly {
 		filterBatch, filterErr := filterIter.ReadBatch(
-			batchStart, blockIter.GetEndIndex(),
-			blockIter.GetBatchSize(),
+			batchStartIndex, filterIter.GetEndIndex(),
+			filterIter.GetBatchSize(),
 		)
 		if filterErr == io.EOF {
-			return 0, io.EOF
+			return 0, 0, io.EOF
 		}
 		if filterErr != nil {
-			return 0, fmt.Errorf("failed to read filter headers "+
-				"batch at height %d: %w", batchStart, filterErr)
+			return 0, 0, fmt.Errorf(
+				"failed to read filter headers batch at "+
+					"height %d: %w", batchStartHeight,
+				filterErr,
+			)
 		}
-
 		// Convert filter header batches to target store format.
 		filterHeaders = make(
 			[]headerfs.FilterHeader, 0, len(filterBatch),
@@ -836,31 +831,34 @@ func (h *headersImport) processBatch(blockIter, filterIter HeaderIterator,
 		for _, header := range filterBatch {
 			fHeader, err := assertFilterHeader(header)
 			if err != nil {
-				return 0, err
+				return 0, 0, err
 			}
 			filterHeaders = append(
 				filterHeaders, fHeader.FilterHeader,
 			)
 		}
 
-		batchEnd = batchStart + uint32(len(filterBatch)) - 1
+		filterHeadersRead := uint32(len(filterBatch))
+		if headersRead != 0 && headersRead != filterHeadersRead {
+			return 0, 0, fmt.Errorf("mismatch between block "+
+				"headers (%d) and filter headers (%d)",
+				headersRead, filterHeadersRead)
+		}
+		headersRead = filterHeadersRead
+		if headersRead > 0 {
+			batchEndHeight = batchStartHeight + headersRead - 1
+		}
 
-		isLastBatch := batchEnd >= filterIter.GetEndIndex()
-		if appendMode == appendFilterOnly && isLastBatch {
-			// Get the chain tip from both target stores.
-			tBHS := h.options.TargetBlockHeaderStore
-			lastH, height, err := tBHS.ChainTip()
+		if appendMode == appendFilterOnly {
+			// Each filter-store write takes its tip from the last
+			// filter header's block hash. Fetch that block header;
+			// the batch may stop before the block-store tip.
+			lastH, err := h.options.TargetBlockHeaderStore.
+				FetchHeaderByHeight(batchEndHeight)
 			if err != nil {
-				return 0, fmt.Errorf("failed to get target "+
-					"block header chain tip: %w", err)
-			}
-
-			i := len(filterHeaders) - 1
-			if height != filterHeaders[i].Height {
-				return 0, fmt.Errorf("mismatch between target "+
-					"block header chain tip height and "+
-					"filter headers height: %d != %d",
-					height, filterHeaders[i].Height)
+				return 0, 0, fmt.Errorf("failed to get target "+
+					"block header at height %d: %w",
+					batchEndHeight, err)
 			}
 
 			chainTipBlockHeader := headerfs.BlockHeader{
@@ -872,33 +870,35 @@ func (h *headersImport) processBatch(blockIter, filterIter HeaderIterator,
 		}
 	}
 
+	if headersRead == 0 {
+		return 0, 0, io.ErrUnexpectedEOF
+	}
+
 	if appendMode == appendBlockAndFilter {
 		// The length check condition should never be triggered during
 		// normal import operations as validation occurs earlier. They
 		// serve as sanity checks to catch unexpected inconsistencies.
 		if len(blockHeaders) != len(filterHeaders) {
-			return 0, fmt.Errorf("mismatch between block headers "+
-				"(%d) and filter headers (%d)",
+			return 0, 0, fmt.Errorf("mismatch between block "+
+				"headers (%d) and filter headers (%d)",
 				len(blockHeaders), len(filterHeaders))
 		}
 
 		chainTipBlockHeader := blockHeaders[len(blockHeaders)-1]
 		setLastFilterHeaderHash(filterHeaders, chainTipBlockHeader)
 	}
-
 	err := h.writeHeadersToTargetStores(
-		blockHeaders, filterHeaders, batchStart, batchEnd,
+		blockHeaders, filterHeaders, batchStartHeight, batchEndHeight,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("failed to write headers to target "+
+		return 0, 0, fmt.Errorf("failed to write headers to target "+
 			"stores: %v", err)
 	}
 
 	log.Debugf("Wrote headers batch from height %d to %d "+
-		"(%d headers)", batchStart, batchEnd,
-		batchEnd-batchStart+1)
+		"(%d headers)", batchStartHeight, batchEndHeight, headersRead)
 
-	return batchEnd, nil
+	return batchEndHeight, headersRead, nil
 }
 
 // Write block and filter headers to the target stores in a specific order to

--- a/chainimport/headers_import_test.go
+++ b/chainimport/headers_import_test.go
@@ -4674,6 +4674,108 @@ func TestHeaderValidationOnBlockHeadersPair(t *testing.T) {
 	}
 }
 
+// TestBlockHeaderImportBoundaryValidation verifies that the first header in an
+// import range is subject to the same proof-of-work, difficulty, and checkpoint
+// rules as every subsequent header.
+func TestBlockHeaderImportBoundaryValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("first batch header proof of work", func(t *testing.T) {
+		first, err := constructBlkHdr(blockHdrs[0], 0)
+		require.NoError(t, err)
+		second, err := constructBlkHdr(blockHdrs[1], 1)
+		require.NoError(t, err)
+
+		first.Bits = 0x03000001
+		firstHash := first.BlockHash()
+		second.PrevBlock = firstHash
+
+		validator := &blockHeadersImportSourceValidator{
+			targetChainParams: chaincfg.SimNetParams,
+			flags:             blockchain.BFFastAdd,
+		}
+		err = validator.ValidateBatch([]Header{first, second})
+		require.ErrorContains(t, err, "validation failed at batch "+
+			"position 0: block hash")
+	})
+
+	t.Run("first source header difficulty", func(t *testing.T) {
+		genesis, err := constructBlkHdr(blockHdrs[0], 0)
+		require.NoError(t, err)
+		first, err := constructBlkHdr(blockHdrs[1], 1)
+		require.NoError(t, err)
+		first.Bits = 0x1f00ffff
+
+		validator := boundaryTestValidator(
+			t, chaincfg.SimNetParams, blockchain.BFNone, genesis,
+			first,
+		)
+		err = validator.Validate(t.Context(),
+			validator.blockHeadersImportSource.Iterator(0, 0, 1))
+		require.ErrorContains(t, err, "block difficulty")
+	})
+
+	t.Run("first source header checkpoint", func(t *testing.T) {
+		genesis, err := constructBlkHdr(blockHdrs[0], 0)
+		require.NoError(t, err)
+		first, err := constructBlkHdr(blockHdrs[1], 1)
+		require.NoError(t, err)
+
+		params := chaincfg.SimNetParams
+		wrongHash := chainhash.Hash{1}
+		params.Checkpoints = []chaincfg.Checkpoint{{
+			Height: 1,
+			Hash:   &wrongHash,
+		}}
+
+		validator := boundaryTestValidator(
+			t, params, blockchain.BFFastAdd, genesis, first,
+		)
+		err = validator.Validate(t.Context(),
+			validator.blockHeadersImportSource.Iterator(0, 0, 1))
+		require.ErrorContains(t, err, "does not match checkpoint hash")
+	})
+}
+
+// boundaryTestValidator constructs a validator whose source begins at height
+// one and whose target store contains the source header's parent.
+func boundaryTestValidator(t *testing.T, params chaincfg.Params,
+	flags blockchain.BehaviorFlags, parent,
+	first *blockHeader) *blockHeadersImportSourceValidator {
+
+	t.Helper()
+
+	source := &mockHeaderImportSource{}
+	source.On("GetHeaderMetadata").Return(&headerMetadata{
+		importMetadata: &importMetadata{
+			startHeight: first.Height,
+		},
+		endHeight:    first.Height,
+		headersCount: 1,
+	}, nil)
+	source.On("GetHeader", uint32(0)).Return(first, nil)
+	source.On("Iterator", uint32(0), uint32(0), uint32(1)).Return(
+		&importSourceHeaderIterator{
+			source:     source,
+			startIndex: 0,
+			endIndex:   0,
+			batchSize:  1,
+		},
+	)
+
+	store := &headerfs.MockBlockHeaderStore{}
+	store.On("FetchHeaderByHeight", parent.Height).Return(
+		parent.BlockHeader.BlockHeader, nil,
+	)
+
+	return &blockHeadersImportSourceValidator{
+		targetChainParams:        params,
+		targetBlockHeaderStore:   store,
+		flags:                    flags,
+		blockHeadersImportSource: source,
+	}
+}
+
 // TestLightHeaderCtxParent tests that lightHeaderCtx.Parent() correctly
 // delegates to RelativeAncestorCtx(1) instead of returning nil. This is
 // critical for CalcPastMedianTime to compute the median of the last 11 blocks
@@ -5653,7 +5755,7 @@ func TestHeaderProcessing(t *testing.T) {
 					end:    90,
 					exists: true,
 					syncModes: syncModes{
-						append: appendBlockAndFilter,
+						append: appendBlockOnly,
 					},
 				}
 				require.Equal(v.tc, nHRE, nHR)
@@ -5841,7 +5943,7 @@ func TestHeaderProcessing(t *testing.T) {
 					end:    90,
 					exists: true,
 					syncModes: syncModes{
-						append: appendBlockAndFilter,
+						append: appendBlockOnly,
 					},
 				}
 				require.Equal(v.tc, nHRE, nHR)
@@ -6605,7 +6707,7 @@ func TestHeaderStorageOnDivergenceHeadersRegion(t *testing.T) {
 			expectErrMsg: "block header mismatch at height 4",
 		},
 		{
-			name: "ErrorOnSyncingFilterStoreWhenBlockStoreLeading",
+			name: "FilterStoreCatchUpDeferredToPeers",
 			region: headerRegion{
 				start:  1,
 				end:    4,
@@ -6690,15 +6792,13 @@ func TestHeaderStorageOnDivergenceHeadersRegion(t *testing.T) {
 					cleanup: func() {},
 				}
 			},
-			verify:    func(verify) {},
-			expectErr: true,
-			expectErrMsg: "failed to validate lead and sync " +
-				"lag headers: failed to sync target header " +
-				"store: failed to read filter headers batch " +
-				"at height 1: I/O read error",
+			verify: func(v verify) {
+				require.Zero(v.tc, v.importResult.AddedCount)
+				require.Zero(v.tc, v.importResult.ProcessedCount)
+			},
 		},
 		{
-			name: "ValidateLeadBlockStoreAndSyncLagFilterStore",
+			name: "ValidateLeadBlockStoreAndDeferLagFilterStore",
 			region: headerRegion{
 				start:  1,
 				end:    4,
@@ -6869,42 +6969,21 @@ func TestHeaderStorageOnDivergenceHeadersRegion(t *testing.T) {
 				}
 			},
 			verify: func(v verify) {
-				// Ensure divergence headers are processed and
-				// added.
-				nH := len(filterHdrs)
-				require.Equal(
-					v.tc, nH-1, v.importResult.AddedCount,
-				)
-				require.Equal(
-					v.tc, nH-1,
-					v.importResult.ProcessedCount,
-				)
+				require.Zero(v.tc, v.importResult.AddedCount)
+				require.Zero(v.tc, v.importResult.ProcessedCount)
 
 				// Verify no headers in the overlap region.
 				require.Equal(
 					v.tc, 0, v.importResult.SkippedCount,
 				)
 
-				// Verify that we can retrieve the chain tip of
-				// the target filter header store. It helps in
-				// signaling a correct write op.
+				// The filter store remains at genesis until peer
+				// synchronization derives its continuation.
 				options := v.importOptions
 				tFS := options.TargetFilterHeaderStore
-				chainTipF, height, err := tFS.ChainTip()
+				_, height, err := tFS.ChainTip()
 				require.NoError(v.tc, err)
-
-				// Verify that the target filter header store
-				// synced with filter header import store.
-				require.Equal(v.tc, uint32(nH-1), height)
-
-				// Assert that the known filter header at this
-				// index matches the retrieved one.
-				chainTipFEx, err := constructFilterHdr(
-					filterHdrs[nH-1], uint32(nH-1),
-				)
-				require.NoError(v.tc, err)
-				b := &chainTipFEx.FilterHash
-				require.Equal(v.tc, b, chainTipF)
+				require.Zero(v.tc, height)
 			},
 		},
 		{
@@ -7339,9 +7418,8 @@ func TestHeaderStorageOnDivergenceHeadersRegion(t *testing.T) {
 	}
 }
 
-// TestHeaderStorageOnNewHeadersRegion tests the header storage on the new
-// headers region. It checks that the headers are written correctly to the
-// target header stores.
+// TestHeaderStorageOnNewHeadersRegion tests block header storage in the new
+// headers region. Imported filter-header writes are rejected.
 func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -7416,7 +7494,7 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 				end:    100,
 				exists: true,
 				syncModes: syncModes{
-					append: appendBlockAndFilter,
+					append: appendBlockOnly,
 				},
 			},
 			importResult: &ImportResult{},
@@ -7474,7 +7552,7 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 				end:    100,
 				exists: true,
 				syncModes: syncModes{
-					append: appendBlockAndFilter,
+					append: appendBlockOnly,
 				},
 			},
 			importResult: &ImportResult{},
@@ -7528,7 +7606,7 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 				"*chainimport.filterHeader",
 		},
 		{
-			name: "ErrorOnGetFilterHeader",
+			name: "RejectFilterHeaderRead",
 			region: headerRegion{
 				start:  1,
 				end:    100,
@@ -7583,13 +7661,12 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 					cleanup: func() {},
 				}
 			},
-			verify:    func(verify) {},
-			expectErr: true,
-			expectErrMsg: "failed to read filter headers batch " +
-				"at height 1: I/O read error",
+			verify:       func(verify) {},
+			expectErr:    true,
+			expectErrMsg: "importing filter headers is unsupported",
 		},
 		{
-			name: "ErrorOnTypeAssertingFilterHeader",
+			name: "RejectFilterHeaderTypeAssertion",
 			region: headerRegion{
 				start:  1,
 				end:    100,
@@ -7645,13 +7722,12 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 					cleanup: func() {},
 				}
 			},
-			verify:    func(verify) {},
-			expectErr: true,
-			expectErrMsg: "expected filterHeader type, got " +
-				"*chainimport.blockHeader",
+			verify:       func(verify) {},
+			expectErr:    true,
+			expectErrMsg: "importing filter headers is unsupported",
 		},
 		{
-			name: "ErrorOnHeadersLengthMismatch",
+			name: "RejectCombinedHeaderWrite",
 			region: headerRegion{
 				start:  1,
 				end:    100,
@@ -7707,10 +7783,9 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 					cleanup: func() {},
 				}
 			},
-			verify:    func(verify) {},
-			expectErr: true,
-			expectErrMsg: "mismatch between block headers (0) " +
-				"and filter headers (1)",
+			verify:       func(verify) {},
+			expectErr:    true,
+			expectErrMsg: "importing filter headers is unsupported",
 		},
 		{
 			name: "ErrorOnWriteHeadersToTargetStores",
@@ -7719,7 +7794,7 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 				end:    100,
 				exists: true,
 				syncModes: syncModes{
-					append: appendBlockAndFilter,
+					append: appendBlockOnly,
 				},
 			},
 			importResult: &ImportResult{},
@@ -7791,7 +7866,7 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 				end:    4,
 				exists: true,
 				syncModes: syncModes{
-					append: appendBlockAndFilter,
+					append: appendBlockOnly,
 				},
 			},
 			importResult: &ImportResult{},

--- a/chainimport/headers_import_test.go
+++ b/chainimport/headers_import_test.go
@@ -106,9 +106,9 @@ func TestHeadersConjunctionProperty(t *testing.T) {
 	}
 }
 
-// TestImportOperationOnFileHeaderSource tests the import operation on a file
-// header source. It checks that the import is successful and that the headers
-// are written to the target header stores.
+// TestImportOperationOnFileHeaderSource tests the import operation on file
+// header sources. It checks that the block and filter headers are written to
+// their target stores.
 func TestImportOperationOnFileHeaderSource(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -253,6 +253,22 @@ func TestImportOperationOnFileHeaderSource(t *testing.T) {
 				require.Equal(
 					v.tc, 0, v.importResult.SkippedCount,
 				)
+
+				blockStore := ops.TargetBlockHeaderStore
+				_, blockHeight, err := blockStore.ChainTip()
+				require.NoError(v.tc, err)
+				require.Equal(
+					v.tc, uint32(len(blockHdrs)-1),
+					blockHeight,
+				)
+
+				_, filterHeight, err :=
+					ops.TargetFilterHeaderStore.ChainTip()
+				require.NoError(v.tc, err)
+				require.Equal(
+					v.tc, uint32(len(filterHdrs)-1),
+					filterHeight,
+				)
 			},
 		},
 	}
@@ -279,6 +295,157 @@ func TestImportOperationOnFileHeaderSource(t *testing.T) {
 			require.NoError(t, err)
 			tc.verify(verify)
 		})
+	}
+}
+
+// TestImportOperationFromNonZeroHeight verifies that absolute target heights
+// are translated to zero-based import-source indices while both header stores
+// are extended.
+func TestImportOperationFromNonZeroHeight(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "test.db")
+	db, err := walletdb.Create(
+		"bdb", dbPath, true, time.Second*10, false,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	blockStore, err := headerfs.NewBlockHeaderStore(
+		tempDir, db, &chaincfg.SimNetParams,
+	)
+	require.NoError(t, err)
+	filterStore, err := headerfs.NewFilterHeaderStore(
+		tempDir, db, headerfs.RegularFilter,
+		&chaincfg.SimNetParams, nil,
+	)
+	require.NoError(t, err)
+
+	const startHeight = uint32(1)
+	blockFile, cleanupBlockFile, err := setupFileWithHdrsAtHeight(
+		headerfs.Block, startHeight,
+	)
+	require.NoError(t, err)
+	t.Cleanup(cleanupBlockFile)
+	blockPath := blockFile.Name()
+	require.NoError(t, blockFile.Close())
+
+	filterFile, cleanupFilterFile, err := setupFileWithHdrsAtHeight(
+		headerfs.RegularFilter, startHeight,
+	)
+	require.NoError(t, err)
+	t.Cleanup(cleanupFilterFile)
+	filterPath := filterFile.Name()
+	require.NoError(t, filterFile.Close())
+
+	importer, err := NewHeadersImport(&ImportOptions{
+		TargetChainParams:       chaincfg.SimNetParams,
+		TargetBlockHeaderStore:  blockStore,
+		TargetFilterHeaderStore: filterStore,
+		BlockHeadersSource:      blockPath,
+		FilterHeadersSource:     filterPath,
+		WriteBatchSizePerRegion: 2,
+		ValidationFlags:         blockchain.BFFastAdd,
+	})
+	require.NoError(t, err)
+
+	result, err := importer.Import(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, len(blockHdrs)-1, result.AddedCount)
+	require.Equal(t, len(blockHdrs)-1, result.ProcessedCount)
+
+	_, blockTip, err := blockStore.ChainTip()
+	require.NoError(t, err)
+	require.Equal(t, uint32(len(blockHdrs)-1), blockTip)
+
+	_, filterTip, err := filterStore.ChainTip()
+	require.NoError(t, err)
+	require.Equal(t, uint32(len(filterHdrs)-1), filterTip)
+}
+
+// TestFilterOnlyImportStopsBeforeBlockTip verifies that a partial filter-only
+// import uses the block hash at the end of each write batch for the filter
+// store tip.
+func TestFilterOnlyImportStopsBeforeBlockTip(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "test.db")
+	db, err := walletdb.Create(
+		"bdb", dbPath, true, time.Second*10, false,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	blockStore, err := headerfs.NewBlockHeaderStore(
+		tempDir, db, &chaincfg.SimNetParams,
+	)
+	require.NoError(t, err)
+	filterStore, err := headerfs.NewFilterHeaderStore(
+		tempDir, db, headerfs.RegularFilter,
+		&chaincfg.SimNetParams, nil,
+	)
+	require.NoError(t, err)
+
+	blockHeaders := make([]headerfs.BlockHeader, 0, len(blockHdrs)-1)
+	for height := uint32(1); height < uint32(len(blockHdrs)); height++ {
+		header, err := constructBlkHdr(blockHdrs[height], height)
+		require.NoError(t, err)
+		blockHeaders = append(blockHeaders, header.BlockHeader)
+	}
+	require.NoError(t, blockStore.WriteHeaders(blockHeaders...))
+
+	const (
+		startHeight = uint32(1)
+		endHeight   = uint32(3)
+	)
+	blockFile, cleanupBlockFile, err := setupFileWithHdrsRange(
+		headerfs.Block, startHeight, endHeight,
+	)
+	require.NoError(t, err)
+	t.Cleanup(cleanupBlockFile)
+	blockPath := blockFile.Name()
+	require.NoError(t, blockFile.Close())
+
+	filterFile, cleanupFilterFile, err := setupFileWithHdrsRange(
+		headerfs.RegularFilter, startHeight, endHeight,
+	)
+	require.NoError(t, err)
+	t.Cleanup(cleanupFilterFile)
+	filterPath := filterFile.Name()
+	require.NoError(t, filterFile.Close())
+
+	importer, err := NewHeadersImport(&ImportOptions{
+		TargetChainParams:       chaincfg.SimNetParams,
+		TargetBlockHeaderStore:  blockStore,
+		TargetFilterHeaderStore: filterStore,
+		BlockHeadersSource:      blockPath,
+		FilterHeadersSource:     filterPath,
+		WriteBatchSizePerRegion: 2,
+		ValidationFlags:         blockchain.BFFastAdd,
+	})
+	require.NoError(t, err)
+
+	result, err := importer.Import(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, int(endHeight), result.AddedCount)
+	require.Equal(t, int(endHeight), result.ProcessedCount)
+
+	_, filterTip, err := filterStore.ChainTip()
+	require.NoError(t, err)
+	require.Equal(t, endHeight, filterTip)
+
+	for height := startHeight; height <= endHeight; height++ {
+		expected, err := constructFilterHdr(filterHdrs[height], height)
+		require.NoError(t, err)
+		actual, err := filterStore.FetchHeaderByHeight(height)
+		require.NoError(t, err)
+		require.Equal(t, expected.FilterHash, *actual)
 	}
 }
 
@@ -5632,6 +5799,51 @@ func TestHeaderProcessing(t *testing.T) {
 				"chain tip",
 		},
 
+		{
+			name: "BlockExtensionStartsAfterLaggingFilterGap",
+			prep: func() prep {
+				hM := &headerMetadata{
+					importMetadata: &importMetadata{
+						startHeight: 161,
+					},
+					endHeight: 170,
+				}
+
+				hIS := &mockHeaderImportSource{}
+				hIS.On("GetHeaderMetadata").Return(hM, nil)
+
+				bHS := &headerfs.MockBlockHeaderStore{}
+				bHS.On("ChainTip").Return(
+					&wire.BlockHeader{}, uint32(160), nil,
+				)
+
+				fHS := &headerfs.MockFilterHeaderStore{}
+				fHS.On("ChainTip").Return(
+					&chainhash.Hash{}, uint32(150), nil,
+				)
+
+				return prep{hImport: &headersImport{
+					blockHeadersImportSource: hIS,
+					options: &ImportOptions{
+						TargetBlockHeaderStore:  bHS,
+						TargetFilterHeaderStore: fHS,
+					},
+				}}
+			},
+			verify: func(v verify) {
+				divergence := v.processingRegions.divergence
+				require.False(v.tc, divergence.exists)
+				require.Equal(v.tc, headerRegion{
+					start:  161,
+					end:    170,
+					exists: true,
+					syncModes: syncModes{
+						append: appendBlockOnly,
+					},
+				}, v.processingRegions.newHeaders)
+			},
+		},
+
 		// ⚠️ Divergent cases (B ≠ F), B & F start at same pos.
 
 		/*
@@ -5755,7 +5967,7 @@ func TestHeaderProcessing(t *testing.T) {
 					end:    90,
 					exists: true,
 					syncModes: syncModes{
-						append: appendBlockOnly,
+						append: appendBlockAndFilter,
 					},
 				}
 				require.Equal(v.tc, nHRE, nHR)
@@ -5943,7 +6155,7 @@ func TestHeaderProcessing(t *testing.T) {
 					end:    90,
 					exists: true,
 					syncModes: syncModes{
-						append: appendBlockOnly,
+						append: appendBlockAndFilter,
 					},
 				}
 				require.Equal(v.tc, nHRE, nHR)
@@ -6707,7 +6919,7 @@ func TestHeaderStorageOnDivergenceHeadersRegion(t *testing.T) {
 			expectErrMsg: "block header mismatch at height 4",
 		},
 		{
-			name: "FilterStoreCatchUpDeferredToPeers",
+			name: "ErrorOnSyncingFilterStoreWhenBlockStoreLeading",
 			region: headerRegion{
 				start:  1,
 				end:    4,
@@ -6772,6 +6984,8 @@ func TestHeaderStorageOnDivergenceHeadersRegion(t *testing.T) {
 				fIt.On("ReadBatch", in, in, in).Return(
 					nil, errors.New("I/O read error"),
 				)
+				fIt.On("GetEndIndex").Return(uint32(100))
+				fIt.On("GetBatchSize").Return(uint32(10))
 
 				fIS := &mockHeaderImportSource{}
 				fIS.On("Iterator", in, in, in).Return(fIt)
@@ -6792,13 +7006,15 @@ func TestHeaderStorageOnDivergenceHeadersRegion(t *testing.T) {
 					cleanup: func() {},
 				}
 			},
-			verify: func(v verify) {
-				require.Zero(v.tc, v.importResult.AddedCount)
-				require.Zero(v.tc, v.importResult.ProcessedCount)
-			},
+			verify:    func(verify) {},
+			expectErr: true,
+			expectErrMsg: "failed to validate lead and sync " +
+				"lag headers: failed to sync target header " +
+				"store: failed to read filter headers batch " +
+				"at height 1: I/O read error",
 		},
 		{
-			name: "ValidateLeadBlockStoreAndDeferLagFilterStore",
+			name: "ValidateLeadBlockStoreAndSyncLagFilterStore",
 			region: headerRegion{
 				start:  1,
 				end:    4,
@@ -6969,21 +7185,41 @@ func TestHeaderStorageOnDivergenceHeadersRegion(t *testing.T) {
 				}
 			},
 			verify: func(v verify) {
-				require.Zero(v.tc, v.importResult.AddedCount)
-				require.Zero(v.tc, v.importResult.ProcessedCount)
+				// Ensure divergence headers are processed and
+				// added.
+				nH := len(filterHdrs)
+				require.Equal(
+					v.tc, nH-1, v.importResult.AddedCount,
+				)
+				require.Equal(
+					v.tc, nH-1,
+					v.importResult.ProcessedCount,
+				)
 
 				// Verify no headers in the overlap region.
 				require.Equal(
 					v.tc, 0, v.importResult.SkippedCount,
 				)
 
-				// The filter store remains at genesis until peer
-				// synchronization derives its continuation.
+				// Verify the filter store caught up through the
+				// imported range.
 				options := v.importOptions
 				tFS := options.TargetFilterHeaderStore
-				_, height, err := tFS.ChainTip()
+				chainTipF, height, err := tFS.ChainTip()
 				require.NoError(v.tc, err)
-				require.Zero(v.tc, height)
+
+				// Verify that the target filter header store
+				// synced with filter header import store.
+				require.Equal(v.tc, uint32(nH-1), height)
+
+				// Assert that the known filter header at this
+				// index matches the retrieved one.
+				chainTipFEx, err := constructFilterHdr(
+					filterHdrs[nH-1], uint32(nH-1),
+				)
+				require.NoError(v.tc, err)
+				b := &chainTipFEx.FilterHash
+				require.Equal(v.tc, b, chainTipF)
 			},
 		},
 		{
@@ -7418,8 +7654,8 @@ func TestHeaderStorageOnDivergenceHeadersRegion(t *testing.T) {
 	}
 }
 
-// TestHeaderStorageOnNewHeadersRegion tests block header storage in the new
-// headers region. Imported filter-header writes are rejected.
+// TestHeaderStorageOnNewHeadersRegion tests the header storage on the new
+// headers region. It checks that headers are written to both target stores.
 func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -7494,7 +7730,7 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 				end:    100,
 				exists: true,
 				syncModes: syncModes{
-					append: appendBlockOnly,
+					append: appendBlockAndFilter,
 				},
 			},
 			importResult: &ImportResult{},
@@ -7552,7 +7788,7 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 				end:    100,
 				exists: true,
 				syncModes: syncModes{
-					append: appendBlockOnly,
+					append: appendBlockAndFilter,
 				},
 			},
 			importResult: &ImportResult{},
@@ -7606,7 +7842,7 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 				"*chainimport.filterHeader",
 		},
 		{
-			name: "RejectFilterHeaderRead",
+			name: "ErrorOnGetFilterHeader",
 			region: headerRegion{
 				start:  1,
 				end:    100,
@@ -7661,12 +7897,13 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 					cleanup: func() {},
 				}
 			},
-			verify:       func(verify) {},
-			expectErr:    true,
-			expectErrMsg: "importing filter headers is unsupported",
+			verify:    func(verify) {},
+			expectErr: true,
+			expectErrMsg: "failed to read filter headers batch " +
+				"at height 1: I/O read error",
 		},
 		{
-			name: "RejectFilterHeaderTypeAssertion",
+			name: "ErrorOnTypeAssertingFilterHeader",
 			region: headerRegion{
 				start:  1,
 				end:    100,
@@ -7722,12 +7959,13 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 					cleanup: func() {},
 				}
 			},
-			verify:       func(verify) {},
-			expectErr:    true,
-			expectErrMsg: "importing filter headers is unsupported",
+			verify:    func(verify) {},
+			expectErr: true,
+			expectErrMsg: "expected filterHeader type, got " +
+				"*chainimport.blockHeader",
 		},
 		{
-			name: "RejectCombinedHeaderWrite",
+			name: "ErrorOnHeadersLengthMismatch",
 			region: headerRegion{
 				start:  1,
 				end:    100,
@@ -7783,9 +8021,10 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 					cleanup: func() {},
 				}
 			},
-			verify:       func(verify) {},
-			expectErr:    true,
-			expectErrMsg: "importing filter headers is unsupported",
+			verify:    func(verify) {},
+			expectErr: true,
+			expectErrMsg: "mismatch between block headers (0) " +
+				"and filter headers (1)",
 		},
 		{
 			name: "ErrorOnWriteHeadersToTargetStores",
@@ -7794,7 +8033,7 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 				end:    100,
 				exists: true,
 				syncModes: syncModes{
-					append: appendBlockOnly,
+					append: appendBlockAndFilter,
 				},
 			},
 			importResult: &ImportResult{},
@@ -7866,7 +8105,7 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 				end:    4,
 				exists: true,
 				syncModes: syncModes{
-					append: appendBlockOnly,
+					append: appendBlockAndFilter,
 				},
 			},
 			importResult: &ImportResult{},
@@ -8078,6 +8317,44 @@ func TestHeaderStorageOnNewHeadersRegion(t *testing.T) {
 func setupFileWithHdrs(hT headerfs.HeaderType,
 	includeMetadata bool) (headerfs.File, func(), error) {
 
+	if !includeMetadata {
+		return setupFileWithHdrsFromHeight(hT, false, 0)
+	}
+
+	return setupFileWithHdrsAtHeight(hT, 0)
+}
+
+// setupFileWithHdrsAtHeight creates a temporary import file whose first header
+// has the specified absolute height.
+func setupFileWithHdrsAtHeight(hT headerfs.HeaderType,
+	startHeight uint32) (headerfs.File, func(), error) {
+
+	return setupFileWithHdrsFromHeight(hT, true, startHeight)
+}
+
+// setupFileWithHdrsRange creates a temporary import file containing the
+// inclusive header range.
+func setupFileWithHdrsRange(hT headerfs.HeaderType, startHeight,
+	endHeight uint32) (headerfs.File, func(), error) {
+
+	return setupFileWithHdrsFromRange(
+		hT, true, startHeight, endHeight,
+	)
+}
+
+func setupFileWithHdrsFromHeight(hT headerfs.HeaderType,
+	includeMetadata bool, startHeight uint32) (
+	headerfs.File, func(), error) {
+
+	return setupFileWithHdrsFromRange(
+		hT, includeMetadata, startHeight, uint32(len(blockHdrs)-1),
+	)
+}
+
+func setupFileWithHdrsFromRange(hT headerfs.HeaderType,
+	includeMetadata bool, startHeight, endHeight uint32) (
+	headerfs.File, func(), error) {
+
 	fileName := fmt.Sprintf("test-%s-*", hT)
 	tempFile, err := os.CreateTemp("", fileName)
 	cleanup := func() {
@@ -8099,9 +8376,18 @@ func setupFileWithHdrs(hT headerfs.HeaderType,
 		return nil, cleanup, fmt.Errorf("%s", hT)
 	}
 
+	if startHeight >= uint32(len(hdrsData)) {
+		return nil, cleanup, fmt.Errorf("start height %d exceeds %s "+
+			"test headers", startHeight, hT)
+	}
+	if endHeight < startHeight || endHeight >= uint32(len(hdrsData)) {
+		return nil, cleanup, fmt.Errorf("invalid end height %d for %s "+
+			"test headers", endHeight, hT)
+	}
+
 	if includeMetadata {
 		err = AddHeadersImportMetadata(
-			tempFile.Name(), wire.SimNet, 0, hT, 0,
+			tempFile.Name(), wire.SimNet, 0, hT, startHeight,
 		)
 		if err != nil {
 			return nil, cleanup, err
@@ -8118,7 +8404,7 @@ func setupFileWithHdrs(hT headerfs.HeaderType,
 		}
 	}
 
-	for _, hdrHex := range hdrsData {
+	for _, hdrHex := range hdrsData[startHeight : endHeight+1] {
 		hdrBytes, err := hex.DecodeString(hdrHex)
 		if err != nil {
 			return nil, cleanup, fmt.Errorf("failed to decode "+

--- a/neutrino.go
+++ b/neutrino.go
@@ -604,10 +604,8 @@ type Config struct {
 	// they're doing something like a key import.
 	PersistToDisk bool
 
-	// HeadersImport contains configuration options for importing block
-	// headers from external sources. Filter headers are synchronized over
-	// P2P because the import format doesn't contain the compact filter hashes
-	// needed to authenticate them.
+	// HeadersImport contains configuration options for importing block and
+	// filter headers from external sources.
 	HeadersImport *HeadersImportConfig
 
 	// AssertFilterHeader is an optional field that allows the creator of
@@ -635,10 +633,10 @@ type HeadersImportConfig struct {
 	// This could be a file path, URL, or other source identifier.
 	BlockHeadersSource string
 
-	// FilterHeadersSource specifies a filter header file used for metadata
-	// compatibility and known-checkpoint checks. Imported filter headers are
-	// not written to the filter header store because the format doesn't
-	// contain the compact filter hashes needed to authenticate the chain.
+	// FilterHeadersSource specifies the filter-header source. The import
+	// format doesn't contain compact filter hashes, so entries between
+	// hardcoded checkpoints trust the configured source. Compact filters
+	// fetched later are checked against these imported commitments.
 	FilterHeadersSource string
 
 	// WriteBatchSizePerRegion defines the number of headers to write in a
@@ -651,9 +649,8 @@ type HeadersImportConfig struct {
 	// usage.
 	//
 	// Default value: 16,384 (2^14) entries.
-	// This results in 16,384 block headers and 16,384 filter headers checked
-	// per batch. Only the block headers are written during import. The total
-	// upper bound size per batch is:
+	// This results in 16,384 block headers and 16,384 filter headers per
+	// batch. The total upper bound size per batch is:
 	//   - Block headers: (16,384 * 80 bytes) / (2^10) = 1.28 MB
 	//   - Filter headers: (16,384 * 32 bytes) / (2^10) = 0.5 MB
 	// Peak memory usage observed during benchmarking was ≈ 66 MB.

--- a/neutrino.go
+++ b/neutrino.go
@@ -604,10 +604,10 @@ type Config struct {
 	// they're doing something like a key import.
 	PersistToDisk bool
 
-	// HeadersImport contains configuration options for importing headers
-	// from external sources. When these options are set, neutrino will
-	// attempt to import headers from file before falling back to P2P
-	// synchronization.
+	// HeadersImport contains configuration options for importing block
+	// headers from external sources. Filter headers are synchronized over
+	// P2P because the import format doesn't contain the compact filter hashes
+	// needed to authenticate them.
 	HeadersImport *HeadersImportConfig
 
 	// AssertFilterHeader is an optional field that allows the creator of
@@ -635,8 +635,10 @@ type HeadersImportConfig struct {
 	// This could be a file path, URL, or other source identifier.
 	BlockHeadersSource string
 
-	// FilterHeadersSource specifies where to obtain filter headers from.
-	// This could be a file path, URL, or other source identifier.
+	// FilterHeadersSource specifies a filter header file used for metadata
+	// compatibility and known-checkpoint checks. Imported filter headers are
+	// not written to the filter header store because the format doesn't
+	// contain the compact filter hashes needed to authenticate the chain.
 	FilterHeadersSource string
 
 	// WriteBatchSizePerRegion defines the number of headers to write in a
@@ -649,8 +651,9 @@ type HeadersImportConfig struct {
 	// usage.
 	//
 	// Default value: 16,384 (2^14) entries.
-	// This results in 16,384 block headers and 16,384 filter headers per
-	// batch. The total upper bound size per batch is:
+	// This results in 16,384 block headers and 16,384 filter headers checked
+	// per batch. Only the block headers are written during import. The total
+	// upper bound size per batch is:
 	//   - Block headers: (16,384 * 80 bytes) / (2^10) = 1.28 MB
 	//   - Filter headers: (16,384 * 32 bytes) / (2^10) = 0.5 MB
 	// Peak memory usage observed during benchmarking was ≈ 66 MB.

--- a/sync_test.go
+++ b/sync_test.go
@@ -1063,10 +1063,9 @@ func testRandomBlocks(harness *neutrinoHarness, t *testing.T) {
 // headers. It then prepares header files for import by copying them and adding
 // the necessary metadata.
 //
-// The first part of the test creates a new Neutrino instance that imports block
-// headers from files without connecting to any peers. Filter headers remain at
-// genesis because the import format doesn't include the compact filter hashes
-// needed to authenticate them.
+// The first part of the test creates a new Neutrino instance that imports these
+// headers from files without connecting to any peers. It verifies that both
+// header stores reach the imported chain tip without network assistance.
 //
 // The second part generates additional blocks and creates another Neutrino
 // instance with the same import configuration but with network connectivity.
@@ -1204,15 +1203,14 @@ func TestNeutrinoSyncWithHeadersImport(t *testing.T) {
 	require.NoError(t, err)
 	defer importSvc.Stop()
 
-	_, blockHeight, err := importSvc.BlockHeaders.ChainTip()
-	require.NoError(t, err)
-	require.Equal(t, uint32(800), blockHeight)
-
-	_, filterHeight, err := importSvc.RegFilterHeaders.ChainTip()
-	require.NoError(t, err)
-	require.Zero(t, filterHeight)
-
-	require.NoError(t, importSvc.Stop())
+	// Ensure that Neutrino initially synced using the imported headers.
+	testHarness = &neutrinoHarness{
+		h1:  h1,
+		h2:  nil,
+		h3:  nil,
+		svc: importSvc,
+	}
+	testInitialSync(testHarness, t)
 
 	// Generate an additional 300 blocks on h1. This ensures that when we
 	// sync again, the client will need to fetch these new blocks from the
@@ -1245,8 +1243,8 @@ func TestNeutrinoSyncWithHeadersImport(t *testing.T) {
 	importSvcToBeSynced.Start(rootCtx)
 	defer importSvcToBeSynced.Stop()
 
-	// This test demonstrates that the service can authenticate the filter
-	// headers and continue the block-header chain once peers are available.
+	// This test demonstrates that the service can continue both imported
+	// header chains once peers are available.
 	testHarness = &neutrinoHarness{
 		h1:  h1,
 		h2:  nil,

--- a/sync_test.go
+++ b/sync_test.go
@@ -1063,10 +1063,10 @@ func testRandomBlocks(harness *neutrinoHarness, t *testing.T) {
 // headers. It then prepares header files for import by copying them and adding
 // the necessary metadata.
 //
-// The first part of the test creates a new Neutrino instance that imports these
-// headers from files without connecting to any peers. It verifies that headers
-// are correctly imported and the chain is properly synchronized without network
-// assistance.
+// The first part of the test creates a new Neutrino instance that imports block
+// headers from files without connecting to any peers. Filter headers remain at
+// genesis because the import format doesn't include the compact filter hashes
+// needed to authenticate them.
 //
 // The second part generates additional blocks and creates another Neutrino
 // instance with the same import configuration but with network connectivity.
@@ -1200,17 +1200,19 @@ func TestNeutrinoSyncWithHeadersImport(t *testing.T) {
 	importSvc, err := neutrino.NewChainService(importConfig)
 	require.NoError(t, err)
 
-	importSvc.Start(rootCtx)
+	err = importSvc.Start(rootCtx)
+	require.NoError(t, err)
 	defer importSvc.Stop()
 
-	// Ensure that neutrino initial synced using the imported headers.
-	testHarness = &neutrinoHarness{
-		h1:  h1,
-		h2:  nil,
-		h3:  nil,
-		svc: importSvc,
-	}
-	testInitialSync(testHarness, t)
+	_, blockHeight, err := importSvc.BlockHeaders.ChainTip()
+	require.NoError(t, err)
+	require.Equal(t, uint32(800), blockHeight)
+
+	_, filterHeight, err := importSvc.RegFilterHeaders.ChainTip()
+	require.NoError(t, err)
+	require.Zero(t, filterHeight)
+
+	require.NoError(t, importSvc.Stop())
 
 	// Generate an additional 300 blocks on h1. This ensures that when we
 	// sync again, the client will need to fetch these new blocks from the
@@ -1243,8 +1245,8 @@ func TestNeutrinoSyncWithHeadersImport(t *testing.T) {
 	importSvcToBeSynced.Start(rootCtx)
 	defer importSvcToBeSynced.Stop()
 
-	// This test demonstrates that the service can successfully sync to the
-	// chain tip after the database has already been populated with headers.
+	// This test demonstrates that the service can authenticate the filter
+	// headers and continue the block-header chain once peers are available.
 	testHarness = &neutrinoHarness{
 		h1:  h1,
 		h2:  nil,


### PR DESCRIPTION
In this PR, we align header import with the normal synchronization path by applying the same sanity, contextual difficulty, and checkpoint validation to every imported block header, including the first header in a range.

The existing filter-header format doesn't include the compact filters needed to derive each filter-header link, so imported block headers are persisted first and filter headers continue through normal peer validation. The import file format is unchanged.

## Testing

- `go test ./chainimport`
- `go test -race ./chainimport`
- `go test ./... -run '^$'`
- `go test . -run 'TestNeutrino(SyncWithHeadersImport|ImportThenP2PSync)$' -count=1`
